### PR TITLE
Fix QR code scanning issues and REST route

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -1,10 +1,11 @@
 document.addEventListener('DOMContentLoaded', function () {
     const scanner = new Html5Qrcode("reader", true);
     const scanResult = document.getElementById("scan-result");
+    let scannedCode = '';
 
     document.getElementById("assign-qr-btn").addEventListener("click", function () {
         const userId = document.getElementById("customer-id").value;
-        const qrCode = scanResult.innerText;
+        const qrCode = scannedCode;
 
         if (!userId || !qrCode) {
             alert("Please enter user ID and scan a QR code.");
@@ -33,11 +34,12 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     function onScanSuccess(decodedText) {
-    scanner.pause(); // Stop scanning after success
-    scanResult.style.display = 'block'; // Make the result visible
-    scanResult.classList.add('updated'); // Use WordPress success styles
-    scanResult.innerHTML = `<strong>✅ QR Code Scanned Successfully!</strong><br>Content: <code>${decodedText}</code>`;
-}
+        scanner.pause(); // Stop scanning after success
+        scannedCode = decodedText;
+        scanResult.style.display = 'block'; // Make the result visible
+        scanResult.classList.add('updated'); // Use WordPress success styles
+        scanResult.innerHTML = `<strong>✅ QR Code Scanned Successfully!</strong><br>Content: <code>${decodedText}</code>`;
+    }
 
     scanner.start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, onScanSuccess);
 });

--- a/includes/class-kerbcycle-qr-manager.php
+++ b/includes/class-kerbcycle-qr-manager.php
@@ -216,7 +216,7 @@ class KerbCycle_QR_Manager {
     }
 
     public function register_rest_endpoints() {
-        register_rest_route('qrmgmt2/v1', '/qr-code/scanned', array(
+        register_rest_route('kerbcycle/v1', '/qr-code/scanned', array(
             'methods' => 'POST',
             'callback' => array($this, 'handle_qr_code_scan'),
             'permission_callback' => '__return_true',

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -263,7 +263,7 @@ class KerbCycle_QR_Manager {
 
     // REST API: Handle QR code scan
     public function register_rest_endpoints() {
-        register_rest_route('qrmgmt2/v1', '/qr-code/scanned', array(
+        register_rest_route('kerbcycle/v1', '/qr-code/scanned', array(
             'methods' => 'POST',
             'callback' => array($this, 'handle_qr_code_scan'),
             'permission_callback' => '__return_true'


### PR DESCRIPTION
## Summary
- capture QR code value correctly during scanning instead of using DOM text
- standardize REST endpoint namespace to `kerbcycle/v1`

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `php -l includes/class-kerbcycle-qr-manager.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_688e817bb4ec832d9235cfc3b3ae253d