### PR TITLE
Ensure QR scans create database records

### DIFF
--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -210,17 +210,32 @@ class KerbCycle_QR_Manager {
         $user_id = intval($_POST['customer_id']);
         $table = $wpdb->prefix . 'kerbcycle_qr_codes';
 
-        $result = $wpdb->update(
-            $table,
-            array(
-                'user_id' => $user_id,
-                'status' => 'assigned',
-                'assigned_at' => current_time('mysql')
-            ),
-            array('qr_code' => $qr_code),
-            array('%d', '%s', '%s'),
-            array('%s')
-        );
+        $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM $table WHERE qr_code = %s", $qr_code));
+
+        if ($exists) {
+            $result = $wpdb->update(
+                $table,
+                array(
+                    'user_id' => $user_id,
+                    'status' => 'assigned',
+                    'assigned_at' => current_time('mysql')
+                ),
+                array('qr_code' => $qr_code),
+                array('%d', '%s', '%s'),
+                array('%s')
+            );
+        } else {
+            $result = $wpdb->insert(
+                $table,
+                array(
+                    'qr_code' => $qr_code,
+                    'user_id' => $user_id,
+                    'status' => 'assigned',
+                    'assigned_at' => current_time('mysql')
+                ),
+                array('%s', '%d', '%s', '%s')
+            );
+        }
 
         if ($result !== false) {
             $this->send_notification_email($user_id, $qr_code);
@@ -277,17 +292,39 @@ class KerbCycle_QR_Manager {
         global $wpdb;
         $table = $wpdb->prefix . 'kerbcycle_qr_codes';
 
-        $wpdb->update(
-            $table,
-            array(
-                'user_id' => $user_id,
-                'status' => 'assigned',
-                'assigned_at' => current_time('mysql')
-            ),
-            array('qr_code' => $qr_code),
-            array('%d', '%s', '%s'),
-            array('%s')
-        );
+        $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM $table WHERE qr_code = %s", $qr_code));
+
+        if ($exists) {
+            $result = $wpdb->update(
+                $table,
+                array(
+                    'user_id' => $user_id,
+                    'status' => 'assigned',
+                    'assigned_at' => current_time('mysql')
+                ),
+                array('qr_code' => $qr_code),
+                array('%d', '%s', '%s'),
+                array('%s')
+            );
+        } else {
+            $result = $wpdb->insert(
+                $table,
+                array(
+                    'qr_code' => $qr_code,
+                    'user_id' => $user_id,
+                    'status' => 'assigned',
+                    'assigned_at' => current_time('mysql')
+                ),
+                array('%s', '%d', '%s', '%s')
+            );
+        }
+
+        if ($result === false) {
+            return new WP_REST_Response(array(
+                'success' => false,
+                'message' => 'Failed to process QR code'
+            ), 500);
+        }
 
         return new WP_REST_Response(array(
             'success' => true,


### PR DESCRIPTION
## Summary
- create QR code record if none exists when assigning via AJAX
- persist scans through REST endpoint with fallback insert and error handling

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `php -l includes/class-kerbcycle-qr-manager.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68911f1eacb4832d84b38267cd4c1af6