### PR TITLE
Allow multiple QR scans

### DIFF
--- a/includes/class-kerbcycle-qr-manager.php
+++ b/includes/class-kerbcycle-qr-manager.php
@@ -34,7 +34,7 @@ class KerbCycle_QR_Manager {
         
         $sql = "CREATE TABLE $table (
             id mediumint(9) NOT NULL AUTO_INCREMENT,
-            qr_code varchar(255) NOT NULL UNIQUE,
+            qr_code varchar(255) NOT NULL,
             user_id mediumint(9),
             status varchar(20) DEFAULT 'available',
             assigned_at datetime DEFAULT NULL,
@@ -163,33 +163,17 @@ class KerbCycle_QR_Manager {
         $qr_code = sanitize_text_field($_POST['qr_code']);
         $user_id = intval($_POST['customer_id']);
         $table = $wpdb->prefix . 'kerbcycle_qr_codes';
-        
-        $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM $table WHERE qr_code = %s", $qr_code));
 
-        if ($exists) {
-            $result = $wpdb->update(
-                $table,
-                array(
-                    'user_id' => $user_id,
-                    'status' => 'assigned',
-                    'assigned_at' => current_time('mysql')
-                ),
-                array('qr_code' => $qr_code),
-                array('%d', '%s', '%s'),
-                array('%s')
-            );
-        } else {
-            $result = $wpdb->insert(
-                $table,
-                array(
-                    'qr_code' => $qr_code,
-                    'user_id' => $user_id,
-                    'status' => 'assigned',
-                    'assigned_at' => current_time('mysql')
-                ),
-                array('%s', '%d', '%s', '%s')
-            );
-        }
+        $result = $wpdb->insert(
+            $table,
+            array(
+                'qr_code' => $qr_code,
+                'user_id' => $user_id,
+                'status' => 'assigned',
+                'assigned_at' => current_time('mysql')
+            ),
+            array('%s', '%d', '%s', '%s')
+        );
 
         if ($result !== false) {
             $this->send_notification_email($user_id, $qr_code);
@@ -209,18 +193,25 @@ class KerbCycle_QR_Manager {
         global $wpdb;
         $qr_code = sanitize_text_field($_POST['qr_code']);
         $table = $wpdb->prefix . 'kerbcycle_qr_codes';
-        
-        $result = $wpdb->update(
-            $table,
-            array(
-                'user_id' => null,
-                'status' => 'available',
-                'assigned_at' => null
-            ),
-            array('qr_code' => $qr_code),
-            array('%d', '%s', '%s'),
-            array('%s')
+
+        $latest_id = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT id FROM $table WHERE qr_code = %s ORDER BY id DESC LIMIT 1",
+                $qr_code
+            )
         );
+
+        if ($latest_id) {
+            $result = $wpdb->query(
+                $wpdb->prepare(
+                    "UPDATE $table SET user_id = NULL, status = %s, assigned_at = NULL WHERE id = %d",
+                    'available',
+                    $latest_id
+                )
+            );
+        } else {
+            $result = false;
+        }
         
         if ($result !== false) {
             wp_send_json_success(array('message' => 'QR code released successfully'));
@@ -251,32 +242,16 @@ class KerbCycle_QR_Manager {
         global $wpdb;
         $table = $wpdb->prefix . 'kerbcycle_qr_codes';
 
-        $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM $table WHERE qr_code = %s", $qr_code));
-
-        if ($exists) {
-            $result = $wpdb->update(
-                $table,
-                array(
-                    'user_id' => $user_id,
-                    'status' => 'assigned',
-                    'assigned_at' => current_time('mysql')
-                ),
-                array('qr_code' => $qr_code),
-                array('%d', '%s', '%s'),
-                array('%s')
-            );
-        } else {
-            $result = $wpdb->insert(
-                $table,
-                array(
-                    'qr_code' => $qr_code,
-                    'user_id' => $user_id,
-                    'status' => 'assigned',
-                    'assigned_at' => current_time('mysql')
-                ),
-                array('%s', '%d', '%s', '%s')
-            );
-        }
+        $result = $wpdb->insert(
+            $table,
+            array(
+                'qr_code' => $qr_code,
+                'user_id' => $user_id,
+                'status' => 'assigned',
+                'assigned_at' => current_time('mysql')
+            ),
+            array('%s', '%d', '%s', '%s')
+        );
 
         if ($result === false) {
             return new WP_REST_Response(array(


### PR DESCRIPTION
## Summary
- remove unique constraint on `qr_code` column so multiple scans can be stored
- always insert a new row when assigning or scanning a QR code
- release routine now clears only the most recent record for a QR code

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `php -l includes/class-kerbcycle-qr-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_68912cc689a4832db700790a932c568e