### PR TITLE
feat: add settings page and quick assignment ui

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -1,37 +1,75 @@
-document.addEventListener('DOMContentLoaded', function () {
+function initKerbcycleScanner() {
     const scanner = new Html5Qrcode("reader", true);
     const scanResult = document.getElementById("scan-result");
+    const qrSelect = document.getElementById("qr-code-select");
+    const sendEmailCheckbox = document.getElementById("send-email");
+    const assignBtn = document.getElementById("assign-qr-btn");
+    const releaseBtn = document.getElementById("release-qr-btn");
     let scannedCode = '';
 
-    document.getElementById("assign-qr-btn").addEventListener("click", function () {
-        const userId = document.getElementById("customer-id").value;
-        const qrCode = scannedCode;
+    if (assignBtn) {
+        assignBtn.addEventListener("click", function () {
+            const userField = document.getElementById("customer-id");
+            const userId = userField ? userField.value : '';
+            const qrCode = scannedCode || (qrSelect ? qrSelect.value : '');
+            const sendEmail = sendEmailCheckbox ? sendEmailCheckbox.checked : false;
 
-        if (!userId || !qrCode) {
-            alert("Please enter user ID and scan a QR code.");
-            return;
-        }
-
-        fetch(kerbcycle_ajax.ajax_url, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
-            },
-            body: `action=assign_qr_code&qr_code=${encodeURIComponent(qrCode)}&customer_id=${encodeURIComponent(userId)}&security=${kerbcycle_ajax.nonce}`
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                alert("QR code assigned successfully.");
-            } else {
-                alert("Failed to assign QR code.");
+            if (!userId || !qrCode) {
+                alert("Please select a user and scan or choose a QR code.");
+                return;
             }
-        })
-        .catch(error => {
-            console.error('Error:', error);
-            alert("An error occurred while assigning the QR code.");
+
+            fetch(kerbcycle_ajax.ajax_url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                },
+                body: `action=assign_qr_code&qr_code=${encodeURIComponent(qrCode)}&customer_id=${encodeURIComponent(userId)}&send_email=${sendEmail ? 1 : 0}&security=${kerbcycle_ajax.nonce}`
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    alert("QR code assigned successfully.");
+                } else {
+                    alert("Failed to assign QR code.");
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert("An error occurred while assigning the QR code.");
+            });
         });
-    });
+    }
+
+    if (releaseBtn) {
+        releaseBtn.addEventListener("click", function () {
+            const qrCode = scannedCode || (qrSelect ? qrSelect.value : '');
+            if (!qrCode) {
+                alert("Please scan or select a QR code to release.");
+                return;
+            }
+
+            fetch(kerbcycle_ajax.ajax_url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                },
+                body: `action=release_qr_code&qr_code=${encodeURIComponent(qrCode)}&security=${kerbcycle_ajax.nonce}`
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    alert("QR code released successfully.");
+                } else {
+                    alert("Failed to release QR code.");
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert("An error occurred while releasing the QR code.");
+            });
+        });
+    }
 
     function onScanSuccess(decodedText) {
         scanner.pause(); // Stop scanning after success
@@ -39,7 +77,16 @@ document.addEventListener('DOMContentLoaded', function () {
         scanResult.style.display = 'block'; // Make the result visible
         scanResult.classList.add('updated'); // Use WordPress success styles
         scanResult.innerHTML = `<strong>✅ QR Code Scanned Successfully!</strong><br>Content: <code>${decodedText}</code>`;
+        if (qrSelect) {
+            qrSelect.value = decodedText;
+        }
     }
 
     scanner.start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, onScanSuccess);
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initKerbcycleScanner);
+} else {
+    initKerbcycleScanner();
+}


### PR DESCRIPTION
## Summary
- modernize plugin with WordPress Settings API and dedicated settings page
- streamline admin UI with user/code dropdowns, email toggle, and release support
- restore QR scanner by initializing immediately when DOM is ready

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_68926e9ef74c832d850e6efa5f27f3b4