### PR TITLE
Add drag-and-drop QR management with inline editing and notification toggles

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -3,6 +3,8 @@ function initKerbcycleScanner() {
     const scanResult = document.getElementById("scan-result");
     const qrSelect = document.getElementById("qr-code-select");
     const sendEmailCheckbox = document.getElementById("send-email");
+    const sendSmsCheckbox = document.getElementById("send-sms");
+    const sendReminderCheckbox = document.getElementById("send-reminder");
     const assignBtn = document.getElementById("assign-qr-btn");
     const releaseBtn = document.getElementById("release-qr-btn");
     let scannedCode = '';
@@ -13,6 +15,8 @@ function initKerbcycleScanner() {
             const userId = userField ? userField.value : '';
             const qrCode = scannedCode || (qrSelect ? qrSelect.value : '');
             const sendEmail = sendEmailCheckbox ? sendEmailCheckbox.checked : false;
+            const sendSms = sendSmsCheckbox ? sendSmsCheckbox.checked : false;
+            const sendReminder = sendReminderCheckbox ? sendReminderCheckbox.checked : false;
 
             if (!userId || !qrCode) {
                 alert("Please select a user and scan or choose a QR code.");
@@ -24,7 +28,7 @@ function initKerbcycleScanner() {
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
                 },
-                body: `action=assign_qr_code&qr_code=${encodeURIComponent(qrCode)}&customer_id=${encodeURIComponent(userId)}&send_email=${sendEmail ? 1 : 0}&security=${kerbcycle_ajax.nonce}`
+                body: `action=assign_qr_code&qr_code=${encodeURIComponent(qrCode)}&customer_id=${encodeURIComponent(userId)}&send_email=${sendEmail ? 1 : 0}&send_sms=${sendSms ? 1 : 0}&send_reminder=${sendReminder ? 1 : 0}&security=${kerbcycle_ajax.nonce}`
             })
             .then(response => response.json())
             .then(data => {
@@ -83,6 +87,61 @@ function initKerbcycleScanner() {
     }
 
     scanner.start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, onScanSuccess);
+
+    const bulkForm = document.getElementById('qr-code-bulk-form');
+    if (bulkForm) {
+        jQuery('#qr-code-list').sortable();
+
+        document.getElementById('apply-bulk').addEventListener('click', function(e) {
+            e.preventDefault();
+            const action = document.getElementById('bulk-action').value;
+            if (action === 'release') {
+                const codes = Array.from(document.querySelectorAll('#qr-code-list .qr-select:checked')).map(cb => cb.closest('li').dataset.code);
+                if (!codes.length) {
+                    alert('Select codes first');
+                    return;
+                }
+                fetch(kerbcycle_ajax.ajax_url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                    },
+                    body: `action=bulk_release_qr_codes&qr_codes=${encodeURIComponent(codes.join(','))}&security=${kerbcycle_ajax.nonce}`
+                })
+                .then(res => res.json())
+                .then(data => {
+                    alert(data.success ? 'QR codes released' : 'Failed to release codes');
+                });
+            }
+        });
+
+        document.querySelectorAll('#qr-code-list .qr-text').forEach(span => {
+            span.addEventListener('blur', function() {
+                const li = span.closest('li');
+                const oldCode = li.dataset.code;
+                const newCode = span.textContent.trim();
+                if (oldCode === newCode) {
+                    return;
+                }
+                fetch(kerbcycle_ajax.ajax_url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                    },
+                    body: `action=update_qr_code&old_code=${encodeURIComponent(oldCode)}&new_code=${encodeURIComponent(newCode)}&security=${kerbcycle_ajax.nonce}`
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if (data.success) {
+                        li.dataset.code = newCode;
+                    } else {
+                        alert('Failed to update QR code');
+                        span.textContent = oldCode;
+                    }
+                });
+            });
+        });
+    }
 }
 
 if (document.readyState === 'loading') {
@@ -90,3 +149,4 @@ if (document.readyState === 'loading') {
 } else {
     initKerbcycleScanner();
 }
+


### PR DESCRIPTION
## Summary
- add settings for optional SMS and reminder notifications
- enable drag-and-drop QR list with bulk release and inline editing
- wire up admin interface and AJAX handlers for new actions

## Testing
- `php -l kerbcycle-qr-code-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_689275e0fbe0832da63d07af4ef9411e