### PR TITLE
Show full details in QR management list

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -90,7 +90,7 @@ function initKerbcycleScanner() {
 
     const bulkForm = document.getElementById('qr-code-bulk-form');
     if (bulkForm) {
-        jQuery('#qr-code-list').sortable();
+        jQuery('#qr-code-list').sortable({ items: 'li.qr-item' });
 
         document.getElementById('apply-bulk').addEventListener('click', function(e) {
             e.preventDefault();
@@ -115,7 +115,7 @@ function initKerbcycleScanner() {
             }
         });
 
-        document.querySelectorAll('#qr-code-list .qr-text').forEach(span => {
+        document.querySelectorAll('#qr-code-list .qr-item .qr-text').forEach(span => {
             span.addEventListener('blur', function() {
                 const li = span.closest('li');
                 const oldCode = li.dataset.code;

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -228,6 +228,7 @@ class KerbCycle_QR_Manager {
             <form id="qr-code-bulk-form">
                 <ul id="qr-code-list">
                     <li class="qr-header">
+                        <input type="checkbox" class="qr-select" disabled style="visibility:hidden" aria-hidden="true" />
                         <span class="qr-id"><?php esc_html_e('ID', 'kerbcycle'); ?></span>
                         <span class="qr-text"><?php esc_html_e('QR Code', 'kerbcycle'); ?></span>
                         <span class="qr-user"><?php esc_html_e('User ID', 'kerbcycle'); ?></span>

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -186,7 +186,7 @@ class KerbCycle_QR_Manager {
         global $wpdb;
         $table = $wpdb->prefix . 'kerbcycle_qr_codes';
         $available_codes = $wpdb->get_results("SELECT qr_code FROM $table WHERE status = 'available' ORDER BY id DESC");
-        $all_codes = $wpdb->get_results("SELECT qr_code, user_id, status FROM $table ORDER BY id DESC");
+        $all_codes = $wpdb->get_results("SELECT id, qr_code, user_id, status, assigned_at FROM $table ORDER BY id DESC");
         ?>
         <div class="wrap">
             <h1>KerbCycle QR Code Manager</h1>
@@ -227,10 +227,21 @@ class KerbCycle_QR_Manager {
             <p class="description"><?php esc_html_e('Drag and drop to reorder, select multiple codes for bulk actions, or click a code to edit.', 'kerbcycle'); ?></p>
             <form id="qr-code-bulk-form">
                 <ul id="qr-code-list">
+                    <li class="qr-header">
+                        <span class="qr-id"><?php esc_html_e('ID', 'kerbcycle'); ?></span>
+                        <span class="qr-text"><?php esc_html_e('QR Code', 'kerbcycle'); ?></span>
+                        <span class="qr-user"><?php esc_html_e('User ID', 'kerbcycle'); ?></span>
+                        <span class="qr-status"><?php esc_html_e('Status', 'kerbcycle'); ?></span>
+                        <span class="qr-assigned"><?php esc_html_e('Assigned At', 'kerbcycle'); ?></span>
+                    </li>
                     <?php foreach ($all_codes as $code) : ?>
-                        <li class="qr-item" data-code="<?= esc_attr($code->qr_code); ?>">
+                        <li class="qr-item" data-code="<?= esc_attr($code->qr_code); ?>" data-id="<?= esc_attr($code->id); ?>">
                             <input type="checkbox" class="qr-select" />
+                            <span class="qr-id"><?= esc_html($code->id); ?></span>
                             <span class="qr-text" contenteditable="true"><?= esc_html($code->qr_code); ?></span>
+                            <span class="qr-user"><?= $code->user_id ? esc_html($code->user_id) : '—'; ?></span>
+                            <span class="qr-status"><?= esc_html(ucfirst($code->status)); ?></span>
+                            <span class="qr-assigned"><?= $code->assigned_at ? esc_html($code->assigned_at) : '—'; ?></span>
                         </li>
                     <?php endforeach; ?>
                 </ul>


### PR DESCRIPTION
## Summary
- Fetch and display extra QR code fields (ID, user, status, assigned time) in the management list
- Add header row and expose details for each code to match history view
- Ensure sortable and inline editing only affect QR items, ignoring header row

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_6892902eba88832d8212c11668ada5f9