### PR TITLE
Implement Twilio SMS notifications

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -33,9 +33,18 @@ function initKerbcycleScanner() {
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    alert("QR code assigned successfully.");
+                    let msg = "QR code assigned successfully.";
+                    if (data.data && typeof data.data.sms_sent !== 'undefined') {
+                        if (data.data.sms_sent) {
+                            msg += " SMS notification sent.";
+                        } else {
+                            msg += " SMS failed: " + (data.data.sms_error || "Unknown error") + ".";
+                        }
+                    }
+                    alert(msg);
                 } else {
-                    alert("Failed to assign QR code.");
+                    const err = data.data && data.data.message ? data.data.message : "Failed to assign QR code.";
+                    alert(err);
                 }
             })
             .catch(error => {


### PR DESCRIPTION
## Summary
- add Twilio configuration options for SID, token, and sender number
- implement Twilio-based SMS delivery with user phone lookup and error handling
- include SMS result in AJAX response and surface in admin UI

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_6893d46dc5ac832dae2a6ec7cda90f9b