### PR TITLE
Ensure QR code release verifies database update

### DIFF
--- a/includes/class-kerbcycle-qr-manager.php
+++ b/includes/class-kerbcycle-qr-manager.php
@@ -209,15 +209,14 @@ class KerbCycle_QR_Manager {
                     $latest_id
                 )
             );
-        } else {
-            $result = false;
+
+            if ($result !== false && $wpdb->rows_affected > 0) {
+                wp_send_json_success(array('message' => 'QR code released successfully'));
+                return;
+            }
         }
-        
-        if ($result !== false) {
-            wp_send_json_success(array('message' => 'QR code released successfully'));
-        } else {
-            wp_send_json_error(array('message' => 'Failed to release QR code'));
-        }
+
+        wp_send_json_error(array('message' => 'Failed to release QR code'));
     }
 
     public function register_rest_endpoints() {

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -475,15 +475,14 @@ class KerbCycle_QR_Manager {
                     $latest_id
                 )
             );
-        } else {
-            $result = false;
+
+            if ($result !== false && $wpdb->rows_affected > 0) {
+                wp_send_json_success(array('message' => 'QR code released successfully'));
+                return;
+            }
         }
 
-        if ($result !== false) {
-            wp_send_json_success(array('message' => 'QR code released successfully'));
-        } else {
-            wp_send_json_error(array('message' => 'Failed to release QR code'));
-        }
+        wp_send_json_error(array('message' => 'Failed to release QR code'));
     }
 
     // AJAX: Bulk release QR codes


### PR DESCRIPTION
## Summary
- ensure `release_qr_code` checks that the database update modified a row before reporting success
- return an error when no rows are affected

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `php -l includes/class-kerbcycle-qr-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_6893db4f5298832d9e133f687280d581