### PR TITLE
Fix release success check

### DIFF
--- a/includes/class-kerbcycle-qr-manager.php
+++ b/includes/class-kerbcycle-qr-manager.php
@@ -210,10 +210,10 @@ class KerbCycle_QR_Manager {
                 )
             );
         } else {
-            $result = false;
+            $result = 0;
         }
-        
-        if ($result !== false) {
+
+        if ($result > 0) {
             wp_send_json_success(array('message' => 'QR code released successfully'));
         } else {
             wp_send_json_error(array('message' => 'Failed to release QR code'));

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -476,10 +476,10 @@ class KerbCycle_QR_Manager {
                 )
             );
         } else {
-            $result = false;
+            $result = 0;
         }
 
-        if ($result !== false) {
+        if ($result > 0) {
             wp_send_json_success(array('message' => 'QR code released successfully'));
         } else {
             wp_send_json_error(array('message' => 'Failed to release QR code'));


### PR DESCRIPTION
## Summary
- ensure QR code release only reports success when a row is updated

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `php -l includes/class-kerbcycle-qr-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_6893dfb07544832d8220d8033da01e3c