### PR TITLE
fix: handle failed QR code releases

### DIFF
--- a/includes/class-kerbcycle-qr-manager.php
+++ b/includes/class-kerbcycle-qr-manager.php
@@ -213,10 +213,12 @@ class KerbCycle_QR_Manager {
             $result = false;
         }
         
-        if ($result !== false) {
-            wp_send_json_success(array('message' => 'QR code released successfully'));
-        } else {
+        if ($result === false) {
             wp_send_json_error(array('message' => 'Failed to release QR code'));
+        } elseif ($result === 0) {
+            wp_send_json_error(array('message' => 'QR code not found or already released'));
+        } else {
+            wp_send_json_success(array('message' => 'QR code released successfully'));
         }
     }
 


### PR DESCRIPTION
## Summary
- improve QR code release handling by checking affected rows and returning appropriate errors

## Testing
- `php -l includes/class-kerbcycle-qr-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_6893dfb07544832d8220d8033da01e3c