### PR TITLE
Fix release success check

### DIFF
--- a/includes/class-kerbcycle-qr-manager.php
+++ b/includes/class-kerbcycle-qr-manager.php
@@ -196,8 +196,9 @@ class KerbCycle_QR_Manager {
 
         $latest_id = $wpdb->get_var(
             $wpdb->prepare(
-                "SELECT id FROM $table WHERE qr_code = %s ORDER BY id DESC LIMIT 1",
-                $qr_code
+                "SELECT id FROM $table WHERE qr_code = %s AND status = %s ORDER BY id DESC LIMIT 1",
+                $qr_code,
+                'assigned'
             )
         );
 
@@ -210,10 +211,10 @@ class KerbCycle_QR_Manager {
                 )
             );
         } else {
-            $result = false;
+            $result = 0;
         }
-        
-        if ($result !== false) {
+
+        if ($result > 0) {
             wp_send_json_success(array('message' => 'QR code released successfully'));
         } else {
             wp_send_json_error(array('message' => 'Failed to release QR code'));

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -462,8 +462,9 @@ class KerbCycle_QR_Manager {
 
         $latest_id = $wpdb->get_var(
             $wpdb->prepare(
-                "SELECT id FROM $table WHERE qr_code = %s ORDER BY id DESC LIMIT 1",
-                $qr_code
+                "SELECT id FROM $table WHERE qr_code = %s AND status = %s ORDER BY id DESC LIMIT 1",
+                $qr_code,
+                'assigned'
             )
         );
 
@@ -476,10 +477,10 @@ class KerbCycle_QR_Manager {
                 )
             );
         } else {
-            $result = false;
+            $result = 0;
         }
 
-        if ($result !== false) {
+        if ($result > 0) {
             wp_send_json_success(array('message' => 'QR code released successfully'));
         } else {
             wp_send_json_error(array('message' => 'Failed to release QR code'));
@@ -500,8 +501,9 @@ class KerbCycle_QR_Manager {
         foreach ($codes as $code) {
             $latest_id = $wpdb->get_var(
                 $wpdb->prepare(
-                    "SELECT id FROM $table WHERE qr_code = %s ORDER BY id DESC LIMIT 1",
-                    $code
+                    "SELECT id FROM $table WHERE qr_code = %s AND status = %s ORDER BY id DESC LIMIT 1",
+                    $code,
+                    'assigned'
                 )
             );
             if ($latest_id) {


### PR DESCRIPTION
## Summary
- ensure QR code release only reports success when a row is updated
- restrict release queries to entries marked as assigned

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `php -l includes/class-kerbcycle-qr-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_6893dfb07544832d8220d8033da01e3c