### PR TITLE
Reload page after QR code assignment or release

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -42,6 +42,7 @@ function initKerbcycleScanner() {
                         }
                     }
                     alert(msg);
+                    window.location.reload();
                 } else {
                     const err = data.data && data.data.message ? data.data.message : "Failed to assign QR code.";
                     alert(err);
@@ -73,6 +74,7 @@ function initKerbcycleScanner() {
             .then(data => {
                 if (data.success) {
                     alert("QR code released successfully.");
+                    window.location.reload();
                 } else {
                     alert("Failed to release QR code.");
                 }
@@ -120,6 +122,9 @@ function initKerbcycleScanner() {
                 .then(res => res.json())
                 .then(data => {
                     alert(data.success ? 'QR codes released' : 'Failed to release codes');
+                    if (data.success) {
+                        window.location.reload();
+                    }
                 });
             }
         });


### PR DESCRIPTION
## Summary
- Automatically refresh the admin page after assigning or releasing QR codes so the latest status is displayed immediately.
- Refresh the page after bulk QR code releases to keep the list in sync.

## Testing
- `node --check assets/js/qr-scanner.js`
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6893e5da39cc832d950dff779ccfa4c4