### PR TITLE
Fix bulk QR code release

### DIFF
--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -490,7 +490,9 @@ class KerbCycle_QR_Manager {
     public function bulk_release_qr_codes() {
         check_ajax_referer('kerbcycle_qr_nonce', 'security');
 
-        $codes = isset($_POST['qr_codes']) ? explode(',', sanitize_text_field($_POST['qr_codes'])) : array();
+        $codes = isset($_POST['qr_codes'])
+            ? array_filter(array_map('sanitize_text_field', array_map('trim', explode(',', $_POST['qr_codes']))))
+            : array();
         if (empty($codes)) {
             wp_send_json_error(array('message' => 'No QR codes provided'));
         }


### PR DESCRIPTION
## Summary
- sanitize each QR code individually in bulk release handler
- trim and filter empty entries before processing

## Testing
- `php -l kerbcycle-qr-code-manager.php`

------
https://chatgpt.com/codex/tasks/task_e_68964902f228832dbc9d99f881fd5e06