### PR TITLE
Add Chart.js reports for QR code analytics

### DIFF
--- a/assets/js/qr-reports.js
+++ b/assets/js/qr-reports.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', function () {
+    if (typeof Chart === 'undefined' || typeof kerbcycleReportData === 'undefined') {
+        return;
+    }
+
+    const ctx = document.getElementById('qr-report-chart');
+    if (!ctx) {
+        return;
+    }
+
+    new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: kerbcycleReportData.labels,
+            datasets: [{
+                label: 'QR Codes Assigned',
+                data: kerbcycleReportData.counts,
+                backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                borderColor: 'rgba(54, 162, 235, 1)',
+                borderWidth: 1
+            }]
+        },
+        options: {
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    precision: 0
+                }
+            }
+        }
+    });
+});
+

--- a/assets/js/qr-reports.js
+++ b/assets/js/qr-reports.js
@@ -3,30 +3,87 @@ document.addEventListener('DOMContentLoaded', function () {
         return;
     }
 
-    const ctx = document.getElementById('qr-report-chart');
-    if (!ctx) {
-        return;
+    const weeklyCtx = document.getElementById('qr-report-chart');
+    const dailyCtx = document.getElementById('qr-daily-chart');
+    let weeklyChart;
+    let dailyChart;
+
+    function renderCharts(data) {
+        if (weeklyCtx) {
+            if (!weeklyChart) {
+                weeklyChart = new Chart(weeklyCtx, {
+                    type: 'bar',
+                    data: {
+                        labels: data.labels,
+                        datasets: [{
+                            label: 'QR Codes Assigned',
+                            data: data.counts,
+                            backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                            borderColor: 'rgba(54, 162, 235, 1)',
+                            borderWidth: 1
+                        }]
+                    },
+                    options: {
+                        scales: {
+                            y: { beginAtZero: true, precision: 0 }
+                        }
+                    }
+                });
+            } else {
+                weeklyChart.data.labels = data.labels;
+                weeklyChart.data.datasets[0].data = data.counts;
+                weeklyChart.update();
+            }
+        }
+
+        if (dailyCtx) {
+            if (!dailyChart) {
+                dailyChart = new Chart(dailyCtx, {
+                    type: 'line',
+                    data: {
+                        labels: data.daily_labels,
+                        datasets: [{
+                            label: 'Assignments Today',
+                            data: data.daily_counts,
+                            backgroundColor: 'rgba(255, 99, 132, 0.5)',
+                            borderColor: 'rgba(255, 99, 132, 1)',
+                            borderWidth: 1,
+                            fill: true
+                        }]
+                    },
+                    options: {
+                        scales: {
+                            y: { beginAtZero: true, precision: 0 }
+                        }
+                    }
+                });
+            } else {
+                dailyChart.data.labels = data.daily_labels;
+                dailyChart.data.datasets[0].data = data.daily_counts;
+                dailyChart.update();
+            }
+        }
     }
 
-    new Chart(ctx, {
-        type: 'bar',
-        data: {
-            labels: kerbcycleReportData.labels,
-            datasets: [{
-                label: 'QR Codes Assigned',
-                data: kerbcycleReportData.counts,
-                backgroundColor: 'rgba(54, 162, 235, 0.5)',
-                borderColor: 'rgba(54, 162, 235, 1)',
-                borderWidth: 1
-            }]
-        },
-        options: {
-            scales: {
-                y: {
-                    beginAtZero: true,
-                    precision: 0
-                }
-            }
+    function refreshCharts() {
+        fetch(kerbcycleReportData.ajax_url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+            body: 'action=kerbcycle_qr_report_data'
+        })
+            .then(res => res.json())
+            .then(data => {
+                renderCharts(data);
+            })
+            .catch(err => console.error('Failed to load report data', err));
+    }
+
+    renderCharts(kerbcycleReportData);
+    window.kerbcycleRefreshReports = refreshCharts;
+
+    window.addEventListener('storage', function (e) {
+        if (e.key === 'kerbcycleAssignment') {
+            refreshCharts();
         }
     });
 });

--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -42,6 +42,11 @@ function initKerbcycleScanner() {
                         }
                     }
                     alert(msg);
+                    try {
+                        localStorage.setItem('kerbcycleAssignment', Date.now().toString());
+                    } catch (e) {
+                        console.warn('LocalStorage unavailable', e);
+                    }
                 } else {
                     const err = data.data && data.data.message ? data.data.message : "Failed to assign QR code.";
                     alert(err);


### PR DESCRIPTION
## Summary
- add Reports admin page with Chart.js visualizations of QR code assignments
- integrate Chart.js and data localization for recent assignment counts
- include front-end script for rendering analytics charts

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68967ebd8510832d9083257409698886