### PR TITLE
Add plugin integrations summary page

### DIFF
--- a/includes/class-kerbcycle-plugin-integrations.php
+++ b/includes/class-kerbcycle-plugin-integrations.php
@@ -1,0 +1,71 @@
+<?php
+// Handle third-party plugin integrations and summaries
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class KerbCycle_Plugin_Integrations {
+    public static function get_summaries() {
+        $user_id   = get_current_user_id();
+        $summaries = array();
+
+        // Bookly - scheduling pickups
+        $bookly_active  = class_exists('Bookly\\Lib\\Plugin') || defined('BOOKLY_VERSION');
+        $bookly_summary = $bookly_active ? __('Bookly active. Schedule pickups through Bookly.', 'kerbcycle') : __('Bookly inactive.', 'kerbcycle');
+        $summaries[]    = array(
+            'name'    => 'Bookly',
+            'active'  => $bookly_active,
+            'summary' => $bookly_summary,
+        );
+
+        // Ultimate Member - customer portal
+        $um_active  = function_exists('um_user') || class_exists('UM');
+        $um_summary = $um_active ? __('Ultimate Member active. Customer portal available.', 'kerbcycle') : __('Ultimate Member inactive.', 'kerbcycle');
+        $summaries[] = array(
+            'name'    => 'Ultimate Member',
+            'active'  => $um_active,
+            'summary' => $um_summary,
+        );
+
+        // WooCommerce - payments
+        $wc_active  = class_exists('WooCommerce');
+        $wc_summary = $wc_active ? __('WooCommerce active. Payments enabled.', 'kerbcycle') : __('WooCommerce inactive.', 'kerbcycle');
+        $summaries[] = array(
+            'name'    => 'WooCommerce',
+            'active'  => $wc_active,
+            'summary' => $wc_summary,
+        );
+
+        // TeraWallet - customer balance
+        $wallet_active = function_exists('woo_wallet') || class_exists('Woo_Wallet');
+        $balance       = '';
+        if ($wallet_active && $wc_active && function_exists('woo_wallet')) {
+            $wallet = woo_wallet();
+            if (isset($wallet->wallet) && method_exists($wallet->wallet, 'get_wallet_balance')) {
+                $balance_raw = $wallet->wallet->get_wallet_balance($user_id, 'edit');
+                if (function_exists('wc_price')) {
+                    $balance = wc_price($balance_raw);
+                } else {
+                    $balance = $balance_raw;
+                }
+            }
+        }
+        $wallet_summary = $wallet_active ? sprintf(__('Wallet balance: %s', 'kerbcycle'), $balance !== '' ? $balance : __('N/A', 'kerbcycle')) : __('TeraWallet inactive.', 'kerbcycle');
+        $summaries[]    = array(
+            'name'    => 'TeraWallet',
+            'active'  => $wallet_active,
+            'summary' => $wallet_summary,
+        );
+
+        // WP SMS - messaging
+        $sms_active  = class_exists('WP_SMS') || defined('WP_SMS_VERSION');
+        $sms_summary = $sms_active ? __('WP SMS active. SMS notifications available.', 'kerbcycle') : __('WP SMS inactive.', 'kerbcycle');
+        $summaries[] = array(
+            'name'    => 'WP SMS',
+            'active'  => $sms_active,
+            'summary' => $sms_summary,
+        );
+
+        return $summaries;
+    }
+}

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -504,9 +504,9 @@ class KerbCycle_QR_Manager {
         exit;
     }
 
-    // Redirect to TeraWallet user wallets page
+    // Redirect to TeraWallet wallet page
     public function terawallet_page() {
-        wp_redirect(admin_url('admin.php?page=woo-wallet-users'));
+        wp_redirect(admin_url('admin.php?page=woo-wallet'));
         exit;
     }
 

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -101,6 +101,32 @@ class KerbCycle_QR_Manager {
             array($this, 'reports_page')
         );
 
+        // Shortcut to Bookly appointments if Bookly is active
+        $bookly_active = class_exists('Bookly\\Lib\\Plugin') || defined('BOOKLY_VERSION');
+        if ($bookly_active) {
+            add_submenu_page(
+                'kerbcycle-qr-manager',
+                'Bookly Appointments',
+                'Appointments',
+                'manage_options',
+                'kerbcycle-bookly-appointments',
+                array($this, 'bookly_appointments_page')
+            );
+        }
+
+        // Shortcut to TeraWallet user wallets if TeraWallet is active
+        $wallet_active = function_exists('woo_wallet') || class_exists('Woo_Wallet');
+        if ($wallet_active) {
+            add_submenu_page(
+                'kerbcycle-qr-manager',
+                'TeraWallet',
+                'TeraWallet',
+                'manage_options',
+                'kerbcycle-terawallet',
+                array($this, 'terawallet_page')
+            );
+        }
+
         add_submenu_page(
             'kerbcycle-qr-manager',
             'Settings',
@@ -470,6 +496,18 @@ class KerbCycle_QR_Manager {
             'daily_labels' => $daily_labels,
             'daily_counts' => $daily_counts,
         ));
+    }
+
+    // Redirect to Bookly appointments page
+    public function bookly_appointments_page() {
+        wp_redirect(admin_url('admin.php?page=bookly-appointments'));
+        exit;
+    }
+
+    // Redirect to TeraWallet user wallets page
+    public function terawallet_page() {
+        wp_redirect(admin_url('admin.php?page=woo-wallet-users'));
+        exit;
     }
 
     // Plugin settings page

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -16,6 +16,9 @@ if (!defined('KERBCYCLE_QR_URL')) {
     define('KERBCYCLE_QR_URL', plugin_dir_url(__FILE__));
 }
 
+// Load integrations helper
+require_once plugin_dir_path(__FILE__) . 'includes/class-kerbcycle-plugin-integrations.php';
+
 // Main plugin class
 class KerbCycle_QR_Manager {
 
@@ -105,6 +108,15 @@ class KerbCycle_QR_Manager {
             'manage_options',
             'kerbcycle-qr-settings',
             array($this, 'settings_page')
+        );
+
+        add_submenu_page(
+            'kerbcycle-qr-manager',
+            'Plugin Integrations',
+            'Integrations',
+            'manage_options',
+            'kerbcycle-plugin-integrations',
+            array($this, 'integrations_page')
         );
     }
 
@@ -472,6 +484,34 @@ class KerbCycle_QR_Manager {
                 submit_button();
                 ?>
             </form>
+        </div>
+        <?php
+    }
+
+    // Display summaries of third-party plugin integrations
+    public function integrations_page() {
+        $summaries = KerbCycle_Plugin_Integrations::get_summaries();
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Plugin Integrations', 'kerbcycle'); ?></h1>
+            <table class="wp-list-table widefat fixed striped">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e('Plugin', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Summary', 'kerbcycle'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($summaries as $summary) : ?>
+                        <tr>
+                            <td><?php echo esc_html($summary['name']); ?></td>
+                            <td><?php echo $summary['active'] ? esc_html__('Active', 'kerbcycle') : esc_html__('Inactive', 'kerbcycle'); ?></td>
+                            <td><?php echo esc_html($summary['summary']); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
         </div>
         <?php
     }


### PR DESCRIPTION
## Summary
- add helper to gather Bookly, Ultimate Member, WooCommerce, TeraWallet and WP SMS statuses
- show plugin integration summaries via new admin submenu

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `php -l includes/class-kerbcycle-plugin-integrations.php`


------
https://chatgpt.com/codex/tasks/task_e_689bb42b9e10832d98cbbc4f2487a210