### PR TITLE
Add configurable SMS settings and remove Twilio options

### DIFF
--- a/includes/class-kerbcycle-sms.php
+++ b/includes/class-kerbcycle-sms.php
@@ -1,0 +1,350 @@
+<?php
+/**
+ * KerbCycle SMS Settings and Sender
+ *
+ * Provides a configurable SMS gateway interface with a settings page
+ * located under the WordPress “Settings” menu. Supports multiple
+ * providers through a generic HTTP request builder.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class KerbCycle_SMS {
+
+    const OPT = 'kerbcycle_sms_options';
+
+    public static function boot() {
+        add_action('admin_menu', [__CLASS__, 'admin_menu'], 20);
+        add_action('admin_init', [__CLASS__, 'register_settings']);
+    }
+
+    /* ---------------- Admin ---------------- */
+
+    public static function admin_menu() {
+        add_submenu_page(
+            'kerbcycle-qr-manager',
+            'SMS Settings',
+            'SMS Settings',
+            'manage_options',
+            'kerbcycle-sms',
+            [__CLASS__, 'render_settings_page']
+        );
+    }
+
+    public static function defaults() {
+        return [
+            'provider'       => 'webex', // webex|twilio|textbelt|messagebird|webhook|email2sms
+            'api_key'        => '',
+            'api_secret'     => '',
+            'auth_method'    => 'key_header', // none|basic|bearer|key_header|custom
+            'from_number'    => '',
+            'country_code'   => '+1',
+            'gateway_url'    => 'https://api.us.webexconnect.io/v1/sms/messages',
+            'method'         => 'POST', // POST|GET
+            // JSON with placeholders {to},{from},{message},{api_key},{api_secret}
+            'body_template'  => "{\n  \"from\": \"{from}\",\n  \"to\": \"{to}\",\n  \"content\": \"{message}\",\n  \"contentType\": \"text\"\n}",
+            // One per line: Header-Name: value (placeholders allowed)
+            'headers'        => "Content-Type: application/json\nkey: {api_key}",
+            'email_gateway'  => '', // for email-to-sms (e.g., vtext.com)
+            'debug'          => '0',
+        ];
+    }
+
+    public static function get_opts() {
+        $opts = get_option(self::OPT, []);
+        return wp_parse_args(is_array($opts) ? $opts : [], self::defaults());
+    }
+
+    public static function register_settings() {
+        register_setting(self::OPT, self::OPT, [__CLASS__, 'sanitize']);
+
+        add_settings_section('kc_sms_main', 'Provider & Authentication', function () {
+            echo '<p>Configure a generic SMS gateway. Works with Webex Connect, Twilio-compatible, Textbelt, MessageBird, or any custom webhook.</p>';
+        }, self::OPT);
+
+        self::add_field('provider', 'Provider', function ($o) {
+            $map = [
+                'webex'       => 'Webex Connect (Sandbox/Prod)',
+                'twilio'      => 'Twilio-compatible',
+                'messagebird' => 'MessageBird',
+                'textbelt'    => 'Textbelt / Self-hosted',
+                'webhook'     => 'Generic Webhook',
+                'email2sms'   => 'Email-to-SMS (via wp_mail)',
+            ];
+            echo '<select name="' . esc_attr(self::OPT) . '[provider]">';
+            foreach ($map as $k => $v) {
+                printf('<option value="%s"%s>%s</option>', esc_attr($k), selected($o['provider'], $k, false), esc_html($v));
+            }
+            echo '</select>';
+        });
+
+        self::add_field('api_key', 'API Key / Service Key', function ($o) {
+            printf('<input type="text" name="%s[api_key]" value="%s" style="width:380px" />',
+                esc_attr(self::OPT), esc_attr($o['api_key']));
+        });
+
+        self::add_field('api_secret', 'API Secret / Token (if needed)', function ($o) {
+            printf('<input type="password" name="%s[api_secret]" value="%s" style="width:380px" />',
+                esc_attr(self::OPT), esc_attr($o['api_secret']));
+        });
+
+        self::add_field('auth_method', 'Auth Method', function ($o) {
+            $methods = [
+                'none'       => 'None',
+                'basic'      => 'HTTP Basic (user=API Key, pass=Secret)',
+                'bearer'     => 'Bearer <API Key>',
+                'key_header' => 'Header: key: {api_key}',
+                'custom'     => 'Custom (use headers box)',
+            ];
+            echo '<select name="' . esc_attr(self::OPT) . '[auth_method]">';
+            foreach ($methods as $k => $v) {
+                printf('<option value="%s"%s>%s</option>', esc_attr($k), selected($o['auth_method'], $k, false), esc_html($v));
+            }
+            echo '</select>';
+        });
+
+        add_settings_section('kc_sms_routing', 'Routing & Templates', '__return_null', self::OPT);
+
+        self::add_field('from_number', 'Default From (Sender ID/Number)', function ($o) {
+            printf('<input type="text" name="%s[from_number]" value="%s" placeholder="+15551234567 or ALPHASENDER" style="width:280px" />',
+                esc_attr(self::OPT), esc_attr($o['from_number']));
+            echo '<p class="description">Webex sandbox often uses a pre-provisioned number; Twilio requires a purchased number; MessageBird can accept up to 11-char alphanumeric.</p>';
+        });
+
+        self::add_field('country_code', 'Default Country Code', function ($o) {
+            printf('<input type="text" name="%s[country_code]" value="%s" placeholder="+1" style="width:120px" />',
+                esc_attr(self::OPT), esc_attr($o['country_code']));
+        });
+
+        self::add_field('gateway_url', 'Gateway URL', function ($o) {
+            printf('<input type="url" name="%s[gateway_url]" value="%s" style="width:520px" />',
+                esc_attr(self::OPT), esc_attr($o['gateway_url']));
+        });
+
+        self::add_field('method', 'HTTP Method', function ($o) {
+            echo '<select name="' . esc_attr(self::OPT) . '[method]">';
+            foreach (['POST', 'GET'] as $m) {
+                printf('<option %s>%s</option>', selected($o['method'], $m, false), $m);
+            }
+            echo '</select>';
+        });
+
+        self::add_field('body_template', 'Request Body Template (JSON or form-encoded)', function ($o) {
+            printf('<textarea name="%s[body_template]" rows="8" style="width:520px">%s</textarea>',
+                esc_attr(self::OPT), esc_textarea($o['body_template']));
+            echo '<p class="description">Placeholders: {to} {from} {message} {api_key} {api_secret}</p>';
+        });
+
+        self::add_field('headers', 'Custom Headers (one per line)', function ($o) {
+            printf('<textarea name="%s[headers]" rows="5" style="width:520px">%s</textarea>',
+                esc_attr(self::OPT), esc_textarea($o['headers']));
+            echo '<p class="description">Example:<br>Content-Type: application/json<br>key: {api_key}<br>Authorization: Bearer {api_key}</p>';
+        });
+
+        self::add_field('email_gateway', 'Email-to-SMS Gateway (if used)', function ($o) {
+            printf('<input type="text" name="%s[email_gateway]" value="%s" placeholder="vtext.com" style="width:240px" />',
+                esc_attr(self::OPT), esc_attr($o['email_gateway']));
+        });
+
+        self::add_field('debug', 'Debug Logging', function ($o) {
+            printf('<label><input type="checkbox" name="%s[debug]" value="1" %s /> Log requests/responses to error_log</label>',
+                esc_attr(self::OPT), checked('1', $o['debug'], false));
+        });
+
+        // Quick test sender (same screen)
+        add_settings_section('kc_sms_test', 'Send Test', '__return_null', self::OPT);
+        add_settings_field('kc_sms_test_btn', '', function () {
+            wp_nonce_field('kc_sms_test', 'kc_sms_test_nonce');
+            echo '<input type="text" name="kc_sms_test_to" placeholder="+15551234567" style="width:220px" /> ';
+            echo '<input type="text" name="kc_sms_test_msg" placeholder="Hello from KerbCycle" style="width:320px" /> ';
+            submit_button('Send Test SMS', 'secondary', 'kc_sms_do_test', false);
+        }, self::OPT, 'kc_sms_test');
+    }
+
+    private static function add_field($key, $label, $cb) {
+        add_settings_field($key, $label, function () use ($cb) {
+            $cb(self::get_opts());
+        }, self::OPT, 'kc_sms_main' === $key || 'kc_sms_routing' === $key ? $key : (strpos($key, 'kc_sms_') === 0 ? 'kc_sms_test' : 'kc_sms_routing'));
+    }
+
+    public static function sanitize($in) {
+        $out = self::defaults();
+        foreach ($out as $k => $v) {
+            if (!isset($in[$k])) {
+                continue;
+            }
+            $val = is_string($in[$k]) ? trim($in[$k]) : $in[$k];
+            $out[$k] = is_string($val) ? wp_kses_post($val) : $val;
+        }
+        // Handle in-page test send
+        if (!empty($_POST['kc_sms_do_test']) && check_admin_referer('kc_sms_test', 'kc_sms_test_nonce')) {
+            $to  = isset($_POST['kc_sms_test_to']) ? sanitize_text_field($_POST['kc_sms_test_to']) : '';
+            $msg = isset($_POST['kc_sms_test_msg']) ? sanitize_text_field($_POST['kc_sms_test_msg']) : '';
+            if ($to && $msg) {
+                $res = kerbcycle_sms_send($to, $msg);
+                if (is_wp_error($res)) {
+                    add_settings_error(self::OPT, 'kc_sms_test_fail', 'Test failed: ' . $res->get_error_message(), 'error');
+                } else {
+                    add_settings_error(self::OPT, 'kc_sms_test_ok', 'Test sent: ' . esc_html(json_encode($res)), 'updated');
+                }
+            }
+        }
+        return $out;
+    }
+
+    public static function render_settings_page() {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+        echo '<div class="wrap"><h1>KerbCycle SMS Settings</h1>';
+        echo '<form method="post" action="options.php">';
+        settings_fields(self::OPT);
+        do_settings_sections(self::OPT);
+        submit_button('Save Settings');
+        echo '</form></div>';
+    }
+
+    /* ---------------- Sender ---------------- */
+
+    public static function normalize_phone($to, $opts) {
+        $to = trim($to);
+        if (strpos($to, '+') !== 0 && !empty($opts['country_code'])) {
+            $cc = preg_replace('/\s+/', '', $opts['country_code']);
+            if ($cc && $cc[0] !== '+') {
+                $cc = '+' . $cc;
+            }
+            $to = $cc . preg_replace('/\D+/', '', $to);
+        }
+        return $to;
+    }
+
+    // Build headers array from textarea lines + auth_method
+    private static function build_headers($opts, $map) {
+        $headers = [];
+        // 1) Auth method helpers
+        switch ($opts['auth_method']) {
+            case 'basic':
+                $headers['Authorization'] = 'Basic ' . base64_encode($opts['api_key'] . ':' . $opts['api_secret']);
+                break;
+            case 'bearer':
+                $headers['Authorization'] = 'Bearer ' . $opts['api_key'];
+                break;
+            case 'key_header':
+                $headers['key'] = $opts['api_key'];
+                break;
+            case 'custom':
+            case 'none':
+            default:
+                // use custom headers box only
+                break;
+        }
+        // 2) Custom headers textarea (supports placeholders)
+        $lines = preg_split('/\r\n|\n|\r/', (string) $opts['headers']);
+        foreach ($lines as $line) {
+            if (!trim($line) || strpos($line, ':') === false) {
+                continue;
+            }
+            list($k, $v) = array_map('trim', explode(':', $line, 2));
+            $v = strtr($v, $map);
+            $headers[$k] = $v;
+        }
+        return $headers;
+    }
+
+    public static function send($to, $message, $args = []) {
+        $opts = self::get_opts();
+
+        // Email-to-SMS pathway (optional)
+        if ($opts['provider'] === 'email2sms') {
+            if (empty($opts['email_gateway'])) {
+                return new WP_Error('kc_sms_email_gateway', 'Email-to-SMS gateway domain is missing.');
+            }
+            $digits = preg_replace('/\D+/', '', $to);
+            $addr   = $digits . '@' . $opts['email_gateway'];
+            $sent = wp_mail($addr, '', wp_strip_all_tags($message));
+            return $sent ? ['ok' => true, 'to' => $addr] : new WP_Error('kc_sms_email_fail', 'wp_mail failed.');
+        }
+
+        $to_norm = self::normalize_phone($to, $opts);
+        $from    = isset($args['from']) && $args['from'] !== '' ? $args['from'] : $opts['from_number'];
+
+        $map = [
+            '{to}'         => $to_norm,
+            '{from}'       => $from,
+            '{message}'    => wp_strip_all_tags($message),
+            '{api_key}'    => $opts['api_key'],
+            '{api_secret}' => $opts['api_secret'],
+        ];
+
+        $url     = trim($opts['gateway_url']);
+        $method  = strtoupper($opts['method']);
+        $bodyTpl = (string) $opts['body_template'];
+        $body    = strtr($bodyTpl, $map);
+
+        $headers = self::build_headers($opts, $map);
+        if (empty($headers['Content-Type'])) {
+            // Default to JSON
+            $headers['Content-Type'] = 'application/json';
+        }
+
+        $args_http = [
+            'timeout' => 20,
+            'headers' => $headers,
+        ];
+
+        if ($method === 'GET') {
+            // Append query
+            $query = [];
+            // Try to interpret JSON; if fails, treat as URL-encoded template “key=value&…”
+            $decoded = json_decode($body, true);
+            if (is_array($decoded)) {
+                $query = $decoded;
+            } else {
+                wp_parse_str($body, $query);
+            }
+            $url = add_query_arg($query, $url);
+            $response = wp_remote_get($url, $args_http);
+        } else {
+            // POST
+            // If JSON header, send JSON; else send as form data
+            if (stripos($headers['Content-Type'], 'json') !== false) {
+                $args_http['body'] = $body;
+            } else {
+                $decoded = json_decode($body, true);
+                $args_http['body'] = is_array($decoded) ? $decoded : $body;
+            }
+            $response = wp_remote_post($url, $args_http);
+        }
+
+        if (is_wp_error($response)) {
+            if ($opts['debug'] === '1') {
+                error_log('KerbCycle SMS WP_Error: ' . $response->get_error_message());
+            }
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+        $resp_body = wp_remote_retrieve_body($response);
+
+        if ($opts['debug'] === '1') {
+            error_log('KerbCycle SMS Response: HTTP ' . $code . ' Body: ' . $resp_body);
+        }
+
+        if ($code >= 200 && $code < 300) {
+            return ['ok' => true, 'http' => $code, 'body' => $resp_body];
+        }
+        return new WP_Error('kc_sms_http', 'SMS gateway error', ['http' => $code, 'body' => $resp_body]);
+    }
+}
+
+KerbCycle_SMS::boot();
+
+/**
+ * Public helper your plugin can call anywhere.
+ */
+function kerbcycle_sms_send($to, $message, $args = []) {
+    return KerbCycle_SMS::send($to, $message, $args);
+}
+

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -19,6 +19,9 @@ if (!defined('KERBCYCLE_QR_URL')) {
 // Load integrations helper
 require_once plugin_dir_path(__FILE__) . 'includes/class-kerbcycle-plugin-integrations.php';
 
+// Load SMS settings and sender
+require_once plugin_dir_path(__FILE__) . 'includes/class-kerbcycle-sms.php';
+
 // Main plugin class
 class KerbCycle_QR_Manager {
 
@@ -193,9 +196,6 @@ class KerbCycle_QR_Manager {
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_email');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_sms');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_reminders');
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_twilio_api_key');
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_twilio_api_secret');
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_twilio_from');
 
         add_settings_section(
             'kerbcycle_qr_main',
@@ -228,29 +228,6 @@ class KerbCycle_QR_Manager {
             'kerbcycle_qr_main'
         );
 
-        add_settings_field(
-            'kerbcycle_twilio_api_key',
-            __('Twilio API Key', 'kerbcycle'),
-            array($this, 'render_twilio_api_key_field'),
-            'kerbcycle_qr_settings',
-            'kerbcycle_qr_main'
-        );
-
-        add_settings_field(
-            'kerbcycle_twilio_api_secret',
-            __('Twilio API Secret', 'kerbcycle'),
-            array($this, 'render_twilio_api_secret_field'),
-            'kerbcycle_qr_settings',
-            'kerbcycle_qr_main'
-        );
-
-        add_settings_field(
-            'kerbcycle_twilio_from',
-            __('Twilio From Number', 'kerbcycle'),
-            array($this, 'render_twilio_from_field'),
-            'kerbcycle_qr_settings',
-            'kerbcycle_qr_main'
-        );
     }
 
     public function render_enable_email_field() {
@@ -274,28 +251,6 @@ class KerbCycle_QR_Manager {
         ?>
         <input type="checkbox" name="kerbcycle_qr_enable_reminders" value="1" <?php checked(1, $value); ?> />
         <span class="description"><?php esc_html_e('Schedule automated reminders after assignment', 'kerbcycle'); ?></span>
-        <?php
-    }
-
-    public function render_twilio_api_key_field() {
-        $value = get_option('kerbcycle_twilio_api_key', '');
-        ?>
-        <input type="text" name="kerbcycle_twilio_api_key" value="<?php echo esc_attr($value); ?>" class="regular-text" />
-        <?php
-    }
-
-    public function render_twilio_api_secret_field() {
-        $value = get_option('kerbcycle_twilio_api_secret', '');
-        ?>
-        <input type="password" name="kerbcycle_twilio_api_secret" value="<?php echo esc_attr($value); ?>" class="regular-text" />
-        <?php
-    }
-
-    public function render_twilio_from_field() {
-        $value = get_option('kerbcycle_twilio_from', '');
-        ?>
-        <input type="text" name="kerbcycle_twilio_from" value="<?php echo esc_attr($value); ?>" class="regular-text" />
-        <span class="description"><?php esc_html_e('Twilio phone number including country code', 'kerbcycle'); ?></span>
         <?php
     }
 
@@ -870,46 +825,24 @@ class KerbCycle_QR_Manager {
     }
 
     private function send_notification_sms($user_id, $qr_code) {
-        $api_key    = get_option('kerbcycle_twilio_api_key');
-        $api_secret = get_option('kerbcycle_twilio_api_secret');
-        $from       = get_option('kerbcycle_twilio_from');
-
         $to = get_user_meta($user_id, 'phone_number', true);
         if (empty($to)) {
             $to = get_user_meta($user_id, 'billing_phone', true);
         }
 
-        if (empty($api_key) || empty($api_secret) || empty($from) || empty($to)) {
-            return new WP_Error('sms_config', __('Missing SMS configuration or phone number', 'kerbcycle'));
+        if (empty($to)) {
+            return new WP_Error('sms_config', __('Missing phone number', 'kerbcycle'));
         }
 
         $body = sprintf(__('You have been assigned QR code %s', 'kerbcycle'), $qr_code);
 
-        $response = wp_remote_post("https://api.twilio.com/2010-04-01/Accounts/{$api_key}/Messages.json", array(
-            'body'    => array(
-                'From' => $from,
-                'To'   => $to,
-                'Body' => $body,
-            ),
-            'headers' => array(
-                'Authorization' => 'Basic ' . base64_encode($api_key . ':' . $api_secret),
-            ),
-        ));
+        $result = kerbcycle_sms_send($to, $body);
 
-        if (is_wp_error($response)) {
-            return $response;
+        if (is_wp_error($result)) {
+            return $result;
         }
 
-        $status_code = wp_remote_retrieve_response_code($response);
-        if ($status_code >= 200 && $status_code < 300) {
-            return true;
-        }
-
-        $resp_body = wp_remote_retrieve_body($response);
-        $decoded   = json_decode($resp_body, true);
-        $error     = is_array($decoded) && isset($decoded['message']) ? $decoded['message'] : __('Unknown error', 'kerbcycle');
-
-        return new WP_Error('sms_failed', $error);
+        return true;
     }
 
     private function schedule_reminder($user_id, $qr_code) {


### PR DESCRIPTION
## Summary
- add `KerbCycle_SMS` class providing a generic SMS gateway and settings page
- remove Twilio-specific settings and switch SMS sending to the new helper
- expose SMS settings as submenu under QR Codes

## Testing
- `php -l includes/class-kerbcycle-sms.php`
- `php -l kerbcycle-qr-code-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa0cdc0420832da78b2dfdd4a8e505