### PR TITLE
Use configured message templates for QR code notifications

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -34,11 +34,20 @@ function initKerbcycleScanner() {
             .then(data => {
                 if (data.success) {
                     let msg = "QR code assigned successfully.";
-                    if (data.data && typeof data.data.sms_sent !== 'undefined') {
-                        if (data.data.sms_sent) {
-                            msg += " SMS notification sent.";
-                        } else {
-                            msg += " SMS failed: " + (data.data.sms_error || "Unknown error") + ".";
+                    if (data.data) {
+                        if (typeof data.data.email_sent !== 'undefined') {
+                            if (data.data.email_sent) {
+                                msg += " Email notification sent.";
+                            } else {
+                                msg += " Email failed: " + (data.data.email_error || "Unknown error") + ".";
+                            }
+                        }
+                        if (typeof data.data.sms_sent !== 'undefined') {
+                            if (data.data.sms_sent) {
+                                msg += " SMS notification sent.";
+                            } else {
+                                msg += " SMS failed: " + (data.data.sms_error || "Unknown error") + ".";
+                            }
                         }
                     }
                     alert(msg);
@@ -63,6 +72,8 @@ function initKerbcycleScanner() {
     if (releaseBtn) {
         releaseBtn.addEventListener("click", function () {
             const qrCode = scannedCode || (qrSelect ? qrSelect.value : '');
+            const sendEmail = sendEmailCheckbox ? sendEmailCheckbox.checked : false;
+            const sendSms = sendSmsCheckbox ? sendSmsCheckbox.checked : false;
             if (!qrCode) {
                 alert("Please scan or select a QR code to release.");
                 return;
@@ -73,12 +84,20 @@ function initKerbcycleScanner() {
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
                 },
-                body: `action=release_qr_code&qr_code=${encodeURIComponent(qrCode)}&security=${kerbcycle_ajax.nonce}`
+                body: `action=release_qr_code&qr_code=${encodeURIComponent(qrCode)}&send_email=${sendEmail ? 1 : 0}&send_sms=${sendSms ? 1 : 0}&security=${kerbcycle_ajax.nonce}`
             })
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    alert("QR code released successfully.");
+                    let msg = "QR code released successfully.";
+                    if (data.data && typeof data.data.sms_sent !== 'undefined') {
+                        if (data.data.sms_sent) {
+                            msg += " SMS notification sent.";
+                        } else {
+                            msg += " SMS failed: " + (data.data.sms_error || "Unknown error") + ".";
+                        }
+                    }
+                    alert(msg);
                     location.reload();
                 } else {
                     alert("Failed to release QR code.");


### PR DESCRIPTION
## Summary
- Use saved message templates when sending assignment and release emails/SMS.
- Allow release actions to optionally send messages and report SMS result.
- Include email send status in QR code assignment alerts.

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae014a3264832da59884c638a86735