### PR TITLE
feat: display email send status after assigning QR

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -34,11 +34,20 @@ function initKerbcycleScanner() {
             .then(data => {
                 if (data.success) {
                     let msg = "QR code assigned successfully.";
-                    if (data.data && typeof data.data.sms_sent !== 'undefined') {
-                        if (data.data.sms_sent) {
-                            msg += " SMS notification sent.";
-                        } else {
-                            msg += " SMS failed: " + (data.data.sms_error || "Unknown error") + ".";
+                    if (data.data) {
+                        if (typeof data.data.email_sent !== 'undefined') {
+                            if (data.data.email_sent) {
+                                msg += " Email notification sent.";
+                            } else {
+                                msg += " Email failed: " + (data.data.email_error || "Unknown error") + ".";
+                            }
+                        }
+                        if (typeof data.data.sms_sent !== 'undefined') {
+                            if (data.data.sms_sent) {
+                                msg += " SMS notification sent.";
+                            } else {
+                                msg += " SMS failed: " + (data.data.sms_error || "Unknown error") + ".";
+                            }
                         }
                     }
                     alert(msg);

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -613,8 +613,9 @@ class KerbCycle_QR_Manager {
         );
 
         if ($result !== false) {
+            $email_result = null;
             if ($send_email) {
-                $this->send_notification_email($user_id, $qr_code, 'assigned');
+                $email_result = $this->send_notification_email($user_id, $qr_code, 'assigned');
             }
             $sms_result = null;
             if ($send_sms) {
@@ -629,6 +630,12 @@ class KerbCycle_QR_Manager {
                 'qr_code' => $qr_code,
                 'user_id' => $user_id,
             );
+            if ($send_email) {
+                $response['email_sent'] = ($email_result === true);
+                if ($email_result !== true) {
+                    $response['email_error'] = is_wp_error($email_result) ? $email_result->get_error_message() : __('Unknown error', 'kerbcycle');
+                }
+            }
             if ($send_sms) {
                 $response['sms_sent'] = ($sms_result === true);
                 if ($sms_result !== true) {


### PR DESCRIPTION
## Summary
- include email send result in QR assignment AJAX response
- show email success or failure in QR assignment alert

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0af48acc832da7758aa4e03a0c8a