### PR TITLE
feat: display email send status after assigning QR

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -23,22 +23,41 @@ function initKerbcycleScanner() {
                 return;
             }
 
+            const params = new URLSearchParams({
+                action: 'assign_qr_code',
+                qr_code: qrCode,
+                customer_id: userId,
+                send_email: sendEmail ? 1 : 0,
+                send_sms: sendSms ? 1 : 0,
+                send_reminder: sendReminder ? 1 : 0,
+                security: kerbcycle_ajax.nonce
+            });
+
             fetch(kerbcycle_ajax.ajax_url, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
                 },
-                body: `action=assign_qr_code&qr_code=${encodeURIComponent(qrCode)}&customer_id=${encodeURIComponent(userId)}&send_email=${sendEmail ? 1 : 0}&send_sms=${sendSms ? 1 : 0}&send_reminder=${sendReminder ? 1 : 0}&security=${kerbcycle_ajax.nonce}`
+                body: params.toString()
             })
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
                     let msg = "QR code assigned successfully.";
-                    if (data.data && typeof data.data.sms_sent !== 'undefined') {
-                        if (data.data.sms_sent) {
-                            msg += " SMS notification sent.";
-                        } else {
-                            msg += " SMS failed: " + (data.data.sms_error || "Unknown error") + ".";
+                    if (data.data) {
+                        if (typeof data.data.email_sent !== 'undefined') {
+                            if (data.data.email_sent) {
+                                msg += " Email notification sent.";
+                            } else {
+                                msg += " Email failed: " + (data.data.email_error || "Unknown error") + ".";
+                            }
+                        }
+                        if (typeof data.data.sms_sent !== 'undefined') {
+                            if (data.data.sms_sent) {
+                                msg += " SMS notification sent.";
+                            } else {
+                                msg += " SMS failed: " + (data.data.sms_error || "Unknown error") + ".";
+                            }
                         }
                     }
                     alert(msg);
@@ -70,12 +89,20 @@ function initKerbcycleScanner() {
                 return;
             }
 
+            const releaseParams = new URLSearchParams({
+                action: 'release_qr_code',
+                qr_code: qrCode,
+                send_email: sendEmail ? 1 : 0,
+                send_sms: sendSms ? 1 : 0,
+                security: kerbcycle_ajax.nonce
+            });
+
             fetch(kerbcycle_ajax.ajax_url, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
                 },
-                body: `action=release_qr_code&qr_code=${encodeURIComponent(qrCode)}&send_email=${sendEmail ? 1 : 0}&send_sms=${sendSms ? 1 : 0}&security=${kerbcycle_ajax.nonce}`
+                body: releaseParams.toString()
             })
             .then(response => response.json())
             .then(data => {

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -613,8 +613,9 @@ class KerbCycle_QR_Manager {
         );
 
         if ($result !== false) {
+            $email_result = null;
             if ($send_email) {
-                $this->send_notification_email($user_id, $qr_code, 'assigned');
+                $email_result = $this->send_notification_email($user_id, $qr_code, 'assigned');
             }
             $sms_result = null;
             if ($send_sms) {
@@ -629,10 +630,20 @@ class KerbCycle_QR_Manager {
                 'qr_code' => $qr_code,
                 'user_id' => $user_id,
             );
+            if ($send_email) {
+                $response['email_sent'] = ($email_result === true);
+                if ($email_result !== true) {
+                    $response['email_error'] = is_wp_error($email_result)
+                        ? $email_result->get_error_message()
+                        : __('Unknown error', 'kerbcycle');
+                }
+            }
             if ($send_sms) {
                 $response['sms_sent'] = ($sms_result === true);
                 if ($sms_result !== true) {
-                    $response['sms_error'] = is_wp_error($sms_result) ? $sms_result->get_error_message() : __('Unknown error', 'kerbcycle');
+                    $response['sms_error'] = is_wp_error($sms_result)
+                        ? $sms_result->get_error_message()
+                        : __('Unknown error', 'kerbcycle');
                 }
             }
             wp_send_json_success($response);
@@ -684,7 +695,9 @@ class KerbCycle_QR_Manager {
             if ($send_sms) {
                 $response['sms_sent'] = ($sms_result === true);
                 if ($sms_result !== true) {
-                    $response['sms_error'] = is_wp_error($sms_result) ? $sms_result->get_error_message() : __('Unknown error', 'kerbcycle');
+                    $response['sms_error'] = is_wp_error($sms_result)
+                        ? $sms_result->get_error_message()
+                        : __('Unknown error', 'kerbcycle');
                 }
             }
             wp_send_json_success($response);


### PR DESCRIPTION
## Summary
- encode QR assignment and release requests with URLSearchParams to include email and SMS flags
- clean up backend responses to return email and SMS delivery results

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0af48acc832da7758aa4e03a0c8a