### PR TITLE
Fix SMS settings page registration

### DIFF
--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -23,6 +23,7 @@ class Admin
     public function __construct()
     {
         add_action('admin_menu', [$this, 'register_admin_menu']);
+        add_action('admin_init', ['\\Kerbcycle\\QrCode\\Services\\SmsService', 'register_settings']);
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure SMS settings fields are registered by hooking SmsService register_settings on admin_init

## Testing
- `php -l includes/Admin/Admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1edb015c4832d8dd918c4e63f8faf