### PR TITLE
Fix test SMS sending on Messages page

### DIFF
--- a/includes/Services/MessagesService.php
+++ b/includes/Services/MessagesService.php
@@ -111,7 +111,7 @@ class MessagesService {
             $test_preview_email = $rendered['email'];
 
             // SMS send (optional)
-            if ($do_send_sms && $t_to_sms && function_exists('kerbcycle_sms_send')) {
+            if ($do_send_sms && $t_to_sms && function_exists(__NAMESPACE__ . '\kerbcycle_sms_send')) {
                 $r = kerbcycle_sms_send($t_to_sms, $test_preview_sms);
                 if (is_wp_error($r)) {
                     $d = $r->get_error_data();


### PR DESCRIPTION
## Summary
- ensure Messages page locates namespaced `kerbcycle_sms_send` before attempting a test SMS

## Testing
- `php -l includes/Services/MessagesService.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1f436c800832dad36b59af5b848b5