### PR TITLE
Fix QR manager assets loading and scanner initialization

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -10,6 +10,10 @@ function initKerbcycleScanner() {
     const releaseBtn = document.getElementById("release-qr-btn");
     let scannedCode = '';
 
+    if (typeof window.kerbcycle_i18n === 'undefined') {
+        window.kerbcycle_i18n = {};
+    }
+
     if (typeof Html5Qrcode !== 'undefined' && reader) {
         try {
             scanner = new Html5Qrcode("reader", true);

--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -1,5 +1,6 @@
 function initKerbcycleScanner() {
-    const scanner = new Html5Qrcode("reader", true);
+    let scanner = null;
+    const reader = document.getElementById("reader");
     const scanResult = document.getElementById("scan-result");
     const qrSelect = document.getElementById("qr-code-select");
     const sendEmailCheckbox = document.getElementById("send-email");
@@ -8,6 +9,16 @@ function initKerbcycleScanner() {
     const assignBtn = document.getElementById("assign-qr-btn");
     const releaseBtn = document.getElementById("release-qr-btn");
     let scannedCode = '';
+
+    if (typeof Html5Qrcode !== 'undefined' && reader) {
+        try {
+            scanner = new Html5Qrcode("reader", true);
+        } catch (e) {
+            console.error('Failed to initialize QR code scanner', e);
+        }
+    } else {
+        console.warn('Html5Qrcode library not loaded. Scanner functionality disabled.');
+    }
 
     if (assignBtn) {
         assignBtn.addEventListener("click", function () {
@@ -102,7 +113,9 @@ function initKerbcycleScanner() {
     }
 
     function onScanSuccess(decodedText) {
-        scanner.pause(); // Stop scanning after success
+        if (scanner && scanner.pause) {
+            scanner.pause(); // Stop scanning after success
+        }
         scannedCode = decodedText;
         scanResult.style.display = 'block'; // Make the result visible
         scanResult.classList.add('updated'); // Use WordPress success styles
@@ -116,7 +129,13 @@ function initKerbcycleScanner() {
         }
     }
 
-    scanner.start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, onScanSuccess);
+    if (scanner && typeof scanner.start === 'function') {
+        try {
+            scanner.start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, onScanSuccess);
+        } catch (e) {
+            console.error('Failed to start QR code scanner', e);
+        }
+    }
 
     const bulkForm = document.getElementById('qr-code-bulk-form');
     if (bulkForm) {

--- a/includes/Admin/Assets/AdminAssets.php
+++ b/includes/Admin/Assets/AdminAssets.php
@@ -62,7 +62,7 @@ class AdminAssets
             return;
         }
 
-        if (!in_array($hook, ['toplevel_page_kerbcycle-qr-manager', 'kerbcycle-qr-manager_page_kerbcycle-qr-history'])) {
+        if (strpos($hook, 'kerbcycle-qr-manager') === false && strpos($hook, 'kerbcycle-qr-history') === false) {
             return;
         }
 
@@ -77,7 +77,7 @@ class AdminAssets
         wp_enqueue_script(
             'kerbcycle-qr-js',
             KERBCYCLE_QR_URL . 'assets/js/qr-scanner.js',
-            ['html5-qrcode', 'jquery-ui-sortable'],
+            ['html5-qrcode', 'jquery', 'jquery-ui-sortable'],
             '1.0',
             true
         );

--- a/includes/Admin/Assets/AdminAssets.php
+++ b/includes/Admin/Assets/AdminAssets.php
@@ -68,7 +68,7 @@ class AdminAssets
 
         wp_register_script(
             'html5-qrcode',
-            KERBCYCLE_QR_URL . 'assets/js/vendor/html5-qrcode.min.js',
+            'https://unpkg.com/html5-qrcode@2.3.8/dist/html5-qrcode.min.js',
             [],
             null,
             true


### PR DESCRIPTION
## Summary
- Load html5-qrcode library from CDN instead of placeholder
- Guard scanner setup so other actions still work if library fails to load

## Testing
- `php -l includes/Admin/Assets/AdminAssets.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1f8d5da08832da178ff3a5f28a540