### PR TITLE
Fix QR manager actions by loading scanner library via CDN

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -1,5 +1,10 @@
 function initKerbcycleScanner() {
-    const scanner = new Html5Qrcode("reader", true);
+    let scanner = null;
+    if (typeof Html5Qrcode !== 'undefined') {
+        scanner = new Html5Qrcode("reader", true);
+    } else {
+        console.warn('Html5Qrcode library not loaded; scanner disabled.');
+    }
     const scanResult = document.getElementById("scan-result");
     const qrSelect = document.getElementById("qr-code-select");
     const sendEmailCheckbox = document.getElementById("send-email");
@@ -102,7 +107,9 @@ function initKerbcycleScanner() {
     }
 
     function onScanSuccess(decodedText) {
-        scanner.pause(); // Stop scanning after success
+        if (scanner) {
+            scanner.pause(); // Stop scanning after success
+        }
         scannedCode = decodedText;
         scanResult.style.display = 'block'; // Make the result visible
         scanResult.classList.add('updated'); // Use WordPress success styles
@@ -116,7 +123,9 @@ function initKerbcycleScanner() {
         }
     }
 
-    scanner.start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, onScanSuccess);
+    if (scanner) {
+        scanner.start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, onScanSuccess);
+    }
 
     const bulkForm = document.getElementById('qr-code-bulk-form');
     if (bulkForm) {

--- a/includes/Admin/Assets/AdminAssets.php
+++ b/includes/Admin/Assets/AdminAssets.php
@@ -68,7 +68,7 @@ class AdminAssets
 
         wp_register_script(
             'html5-qrcode',
-            KERBCYCLE_QR_URL . 'assets/js/vendor/html5-qrcode.min.js',
+            'https://unpkg.com/html5-qrcode@2.3.8/minified/html5-qrcode.min.js',
             [],
             null,
             true


### PR DESCRIPTION
## Summary
- Load html5-qrcode from CDN instead of missing placeholder
- Guard scanner setup so admin actions work even if library isn't available

## Testing
- `php -l includes/Admin/Assets/AdminAssets.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_68b200c1c810832d9867a3849aa305f1