### PR TITLE
Add manual QR code entry with settings toggle

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -7,6 +7,7 @@ function initKerbcycleScanner() {
     const sendReminderCheckbox = document.getElementById("send-reminder");
     const assignBtn = document.getElementById("assign-qr-btn");
     const releaseBtn = document.getElementById("release-qr-btn");
+    const addBtn = document.getElementById("add-qr-btn");
     let scannedCode = '';
 
     if (assignBtn) {
@@ -56,6 +57,38 @@ function initKerbcycleScanner() {
             .catch(error => {
                 console.error('Error:', error);
                 alert("An error occurred while assigning the QR code.");
+            });
+        });
+    }
+
+    if (addBtn) {
+        addBtn.addEventListener("click", function () {
+            const input = document.getElementById("manual-qr-input");
+            const qrCode = input ? input.value.trim() : '';
+            if (!qrCode) {
+                alert("Please enter a QR code.");
+                return;
+            }
+            fetch(kerbcycle_ajax.ajax_url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                },
+                body: `action=add_qr_code&qr_code=${encodeURIComponent(qrCode)}&security=${kerbcycle_ajax.nonce}`
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    alert('QR code added successfully.');
+                    location.reload();
+                } else {
+                    const err = data.data && data.data.message ? data.data.message : 'Failed to add QR code.';
+                    alert(err);
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('An error occurred while adding the QR code.');
             });
         });
     }

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -35,6 +35,7 @@ class AdminAjax
         add_action('wp_ajax_release_qr_code', [$this, 'release_qr_code']);
         add_action('wp_ajax_bulk_release_qr_codes', [$this, 'bulk_release_qr_codes']);
         add_action('wp_ajax_update_qr_code', [$this, 'update_qr_code']);
+        add_action('wp_ajax_add_qr_code', [$this, 'add_qr_code']);
         add_action('wp_ajax_kerbcycle_qr_report_data', [$this, 'ajax_report_data']);
         add_action('wp_ajax_kerbcycle_delete_logs', [$this, 'delete_logs']);
     }
@@ -153,6 +154,31 @@ class AdminAjax
             wp_send_json_success(['message' => 'QR code updated']);
         } else {
             wp_send_json_error(['message' => 'Failed to update QR code']);
+        }
+    }
+
+    public function add_qr_code()
+    {
+        Nonces::verify('kerbcycle_qr_nonce', 'security');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => 'Unauthorized'], 403);
+        }
+
+        if (!get_option('kerbcycle_qr_enable_manual_entry', 0)) {
+            wp_send_json_error(['message' => 'Manual entry disabled'], 403);
+        }
+
+        $qr_code = sanitize_text_field($_POST['qr_code'] ?? '');
+        if (empty($qr_code)) {
+            wp_send_json_error(['message' => 'Invalid QR code']);
+        }
+
+        $result = $this->qr_service->add($qr_code);
+
+        if ($result !== false) {
+            wp_send_json_success(['message' => 'QR code added']);
+        } else {
+            wp_send_json_error(['message' => 'Failed to add QR code']);
         }
     }
 

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -102,6 +102,14 @@ class DashboardPage
                 <div id="scan-result" class="updated" style="display: none;"></div>
             </div>
 
+            <?php if (get_option('kerbcycle_qr_enable_manual_entry', 0)) : ?>
+            <h2><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></h2>
+            <div id="qr-manual-entry">
+                <input type="text" id="manual-qr-input" placeholder="<?php esc_attr_e('Enter QR Code', 'kerbcycle'); ?>" />
+                <button id="add-qr-btn" class="button"><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></button>
+            </div>
+            <?php endif; ?>
+
             <h2><?php esc_html_e('Manage QR Codes', 'kerbcycle'); ?></h2>
             <p class="description"><?php esc_html_e('Drag and drop to reorder, select multiple codes for bulk actions, or click a code to edit.', 'kerbcycle'); ?></p>
             <form id="qr-code-bulk-form">

--- a/includes/Admin/Pages/SettingsPage.php
+++ b/includes/Admin/Pages/SettingsPage.php
@@ -56,6 +56,7 @@ class SettingsPage
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_email');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_sms');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_reminders');
+        register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_manual_entry');
 
         add_settings_section(
             'kerbcycle_qr_main',
@@ -87,6 +88,14 @@ class SettingsPage
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
+
+        add_settings_field(
+            'kerbcycle_qr_enable_manual_entry',
+            __('Enable Manual QR Entry', 'kerbcycle'),
+            [$this, 'render_enable_manual_entry_field'],
+            'kerbcycle_qr_settings',
+            'kerbcycle_qr_main'
+        );
     }
 
     public function render_enable_email_field()
@@ -113,6 +122,15 @@ class SettingsPage
         ?>
         <input type="checkbox" name="kerbcycle_qr_enable_reminders" value="1" <?php checked(1, $value); ?> />
         <span class="description"><?php esc_html_e('Schedule automated reminders after assignment', 'kerbcycle'); ?></span>
+        <?php
+    }
+
+    public function render_enable_manual_entry_field()
+    {
+        $value = get_option('kerbcycle_qr_enable_manual_entry', 0);
+        ?>
+        <input type="checkbox" name="kerbcycle_qr_enable_manual_entry" value="1" <?php checked(1, $value); ?> />
+        <span class="description"><?php esc_html_e('Allow adding QR codes manually from the dashboard', 'kerbcycle'); ?></span>
         <?php
     }
 }

--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -38,6 +38,19 @@ class QrCodeRepository
         );
     }
 
+    public function insert_available($qr_code)
+    {
+        global $wpdb;
+        return $wpdb->insert(
+            $this->table,
+            [
+                'qr_code' => $qr_code,
+                'status'  => 'available',
+            ],
+            ['%s', '%s']
+        );
+    }
+
     public function release_latest_assigned($qr_code)
     {
         global $wpdb;

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -47,6 +47,11 @@ class QrService
         return ['sms_result' => $sms_result];
     }
 
+    public function add($qr_code)
+    {
+        return $this->repository->insert_available($qr_code);
+    }
+
     public function release($qr_code, $send_email, $send_sms)
     {
         $row = $this->repository->find_by_qr_code($qr_code);


### PR DESCRIPTION
## Summary
- allow optional manual QR code entry from dashboard and persist via AJAX
- add setting to enable or disable manual entry feature

## Testing
- `php -l includes/Data/Repositories/QrCodeRepository.php`
- `php -l includes/Services/QrService.php`
- `php -l includes/Admin/Ajax/AdminAjax.php`
- `php -l includes/Admin/Pages/SettingsPage.php`
- `php -l includes/Admin/Pages/DashboardPage.php`
- `node --check assets/js/qr-scanner.js && echo "JS syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b317eb069c832d8b27fcd44bdb3cc2