### PR TITLE
Add manual QR code entry with settings toggle

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -35,6 +35,7 @@ class AdminAjax
         add_action('wp_ajax_release_qr_code', [$this, 'release_qr_code']);
         add_action('wp_ajax_bulk_release_qr_codes', [$this, 'bulk_release_qr_codes']);
         add_action('wp_ajax_update_qr_code', [$this, 'update_qr_code']);
+        add_action('wp_ajax_add_qr_code', [$this, 'add_qr_code']);
         add_action('wp_ajax_kerbcycle_qr_report_data', [$this, 'ajax_report_data']);
         add_action('wp_ajax_kerbcycle_delete_logs', [$this, 'delete_logs']);
     }
@@ -153,6 +154,31 @@ class AdminAjax
             wp_send_json_success(['message' => 'QR code updated']);
         } else {
             wp_send_json_error(['message' => 'Failed to update QR code']);
+        }
+    }
+
+    public function add_qr_code()
+    {
+        Nonces::verify('kerbcycle_qr_nonce', 'security');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => 'Unauthorized'], 403);
+        }
+
+        if (!get_option('kerbcycle_qr_enable_manual_entry', 0)) {
+            wp_send_json_error(['message' => 'Manual entry disabled'], 403);
+        }
+
+        $qr_code = sanitize_text_field($_POST['qr_code'] ?? '');
+        if (empty($qr_code)) {
+            wp_send_json_error(['message' => 'Invalid QR code']);
+        }
+
+        $result = $this->qr_service->add($qr_code);
+
+        if ($result !== false) {
+            wp_send_json_success(['message' => 'QR code added']);
+        } else {
+            wp_send_json_error(['message' => 'Failed to add QR code']);
         }
     }
 

--- a/includes/Admin/Assets/AdminAssets.php
+++ b/includes/Admin/Assets/AdminAssets.php
@@ -59,7 +59,13 @@ class AdminAssets
             return;
         }
 
-        wp_enqueue_script('html5-qrcode', 'https://unpkg.com/html5-qrcode', [], null, true);
+        wp_enqueue_script(
+            'html5-qrcode',
+            'https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js',
+            [],
+            '2.3.8',
+            true
+        );
         wp_enqueue_script(
             'kerbcycle-qr-js',
             KERBCYCLE_QR_URL . 'assets/js/qr-scanner.js',

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -102,6 +102,14 @@ class DashboardPage
                 <div id="scan-result" class="updated" style="display: none;"></div>
             </div>
 
+            <?php if (get_option('kerbcycle_qr_enable_manual_entry', 0)) : ?>
+            <h2><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></h2>
+            <div id="qr-manual-entry">
+                <input type="text" id="manual-qr-input" placeholder="<?php esc_attr_e('Enter QR Code', 'kerbcycle'); ?>" />
+                <button id="add-qr-btn" type="button" class="button"><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></button>
+            </div>
+            <?php endif; ?>
+
             <h2><?php esc_html_e('Manage QR Codes', 'kerbcycle'); ?></h2>
             <p class="description"><?php esc_html_e('Drag and drop to reorder, select multiple codes for bulk actions, or click a code to edit.', 'kerbcycle'); ?></p>
             <form id="qr-code-bulk-form">

--- a/includes/Admin/Pages/SettingsPage.php
+++ b/includes/Admin/Pages/SettingsPage.php
@@ -56,6 +56,7 @@ class SettingsPage
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_email');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_sms');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_reminders');
+        register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_manual_entry');
 
         add_settings_section(
             'kerbcycle_qr_main',
@@ -87,6 +88,14 @@ class SettingsPage
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
+
+        add_settings_field(
+            'kerbcycle_qr_enable_manual_entry',
+            __('Enable Manual QR Entry', 'kerbcycle'),
+            [$this, 'render_enable_manual_entry_field'],
+            'kerbcycle_qr_settings',
+            'kerbcycle_qr_main'
+        );
     }
 
     public function render_enable_email_field()
@@ -113,6 +122,15 @@ class SettingsPage
         ?>
         <input type="checkbox" name="kerbcycle_qr_enable_reminders" value="1" <?php checked(1, $value); ?> />
         <span class="description"><?php esc_html_e('Schedule automated reminders after assignment', 'kerbcycle'); ?></span>
+        <?php
+    }
+
+    public function render_enable_manual_entry_field()
+    {
+        $value = get_option('kerbcycle_qr_enable_manual_entry', 0);
+        ?>
+        <input type="checkbox" name="kerbcycle_qr_enable_manual_entry" value="1" <?php checked(1, $value); ?> />
+        <span class="description"><?php esc_html_e('Allow adding QR codes manually from the dashboard', 'kerbcycle'); ?></span>
         <?php
     }
 }

--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -38,6 +38,19 @@ class QrCodeRepository
         );
     }
 
+    public function insert_available($qr_code)
+    {
+        global $wpdb;
+        return $wpdb->insert(
+            $this->table,
+            [
+                'qr_code' => $qr_code,
+                'status'  => 'available',
+            ],
+            ['%s', '%s']
+        );
+    }
+
     public function release_latest_assigned($qr_code)
     {
         global $wpdb;

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -47,6 +47,11 @@ class QrService
         return ['sms_result' => $sms_result];
     }
 
+    public function add($qr_code)
+    {
+        return $this->repository->insert_available($qr_code);
+    }
+
     public function release($qr_code, $send_email, $send_sms)
     {
         $row = $this->repository->find_by_qr_code($qr_code);


### PR DESCRIPTION
## Summary
- allow optional manual QR code entry from dashboard and persist via AJAX
- add setting to enable or disable manual entry feature
- prevent default form submission on manual entry button to trigger AJAX correctly
- pin html5-qrcode script and guard scanner initialization so manual entry works without camera

## Testing
- `php -l includes/Admin/Pages/DashboardPage.php`
- `php -l includes/Admin/Assets/AdminAssets.php`
- `node --check assets/js/qr-scanner.js && echo "JS syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b317eb069c832d8b27fcd44bdb3cc2