### PR TITLE
feat: allow manual QR code entry

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -7,7 +7,38 @@ function initKerbcycleScanner() {
     const sendReminderCheckbox = document.getElementById("send-reminder");
     const assignBtn = document.getElementById("assign-qr-btn");
     const releaseBtn = document.getElementById("release-qr-btn");
+    const manualQrInput = document.getElementById("manual-qr-code");
+    const addQrBtn = document.getElementById("add-qr-btn");
     let scannedCode = '';
+
+    if (addQrBtn) {
+        addQrBtn.addEventListener("click", function () {
+            const qrCode = manualQrInput ? manualQrInput.value.trim() : '';
+            if (!qrCode) {
+                alert("Please enter a QR code.");
+                return;
+            }
+
+            fetch(kerbcycle_ajax.ajax_url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                },
+                body: `action=add_qr_code&qr_code=${encodeURIComponent(qrCode)}&security=${kerbcycle_ajax.nonce}`
+            })
+            .then(res => res.json())
+            .then(data => {
+                const msg = data.data && data.data.message ? data.data.message : (data.success ? "QR code added successfully." : "Failed to add QR code.");
+                alert(msg);
+                location.reload();
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('An error occurred while adding the QR code.');
+                location.reload();
+            });
+        });
+    }
 
     if (assignBtn) {
         assignBtn.addEventListener("click", function () {

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -35,6 +35,7 @@ class AdminAjax
         add_action('wp_ajax_release_qr_code', [$this, 'release_qr_code']);
         add_action('wp_ajax_bulk_release_qr_codes', [$this, 'bulk_release_qr_codes']);
         add_action('wp_ajax_update_qr_code', [$this, 'update_qr_code']);
+        add_action('wp_ajax_add_qr_code', [$this, 'add_qr_code']);
         add_action('wp_ajax_kerbcycle_qr_report_data', [$this, 'ajax_report_data']);
         add_action('wp_ajax_kerbcycle_delete_logs', [$this, 'delete_logs']);
     }
@@ -69,6 +70,28 @@ class AdminAjax
                 }
             }
             wp_send_json_success($response);
+        }
+    }
+
+    public function add_qr_code()
+    {
+        Nonces::verify('kerbcycle_qr_nonce', 'security');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => 'Unauthorized'], 403);
+        }
+
+        $qr_code = sanitize_text_field($_POST['qr_code'] ?? '');
+
+        if (empty($qr_code)) {
+            wp_send_json_error(['message' => 'Invalid QR code']);
+        }
+
+        $result = $this->qr_service->create($qr_code);
+
+        if (is_wp_error($result)) {
+            wp_send_json_error(['message' => $result->get_error_message()]);
+        } else {
+            wp_send_json_success(['message' => 'QR code added successfully']);
         }
     }
 

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -86,6 +86,10 @@ class DashboardPage
                         <option value="<?= esc_attr($code->qr_code); ?>"><?= esc_html($code->qr_code); ?></option>
                     <?php endforeach; ?>
                 </select>
+                <p>
+                    <input type="text" id="manual-qr-code" placeholder="<?php esc_attr_e('Enter QR Code', 'kerbcycle'); ?>" />
+                    <button id="add-qr-btn" class="button"><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></button>
+                </p>
                 <?php
                 $email_enabled    = (bool) get_option('kerbcycle_qr_enable_email', 1);
                 $sms_enabled      = (bool) get_option('kerbcycle_qr_enable_sms', 0);

--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -23,6 +23,19 @@ class QrCodeRepository
         $this->table = $wpdb->prefix . 'kerbcycle_qr_codes';
     }
 
+    public function insert_available($qr_code)
+    {
+        global $wpdb;
+        return $wpdb->insert(
+            $this->table,
+            [
+                'qr_code' => $qr_code,
+                'status'  => 'available',
+            ],
+            ['%s', '%s']
+        );
+    }
+
     public function insert_assigned($qr_code, $user_id)
     {
         global $wpdb;

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -26,6 +26,15 @@ class QrService
         $this->repository = new QrCodeRepository();
     }
 
+    public function create($qr_code)
+    {
+        $result = $this->repository->insert_available($qr_code);
+        if ($result === false) {
+            return new \WP_Error('db_error', 'Failed to add QR code in database.');
+        }
+        return true;
+    }
+
     public function assign($qr_code, $user_id, $send_email, $send_sms, $send_reminder)
     {
         $result = $this->repository->insert_assigned($qr_code, $user_id);


### PR DESCRIPTION
## Summary
- allow manually entering QR codes on dashboard
- add server endpoint to store manual codes
- support adding codes even when scanner disabled

## Testing
- `php -l includes/Data/Repositories/QrCodeRepository.php && php -l includes/Services/QrService.php && php -l includes/Admin/Ajax/AdminAjax.php && php -l includes/Admin/Pages/DashboardPage.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_68b32d55a9f4832daf789ca9fb3a5da3