### PR TITLE
Add dashboard QR scanner toggle

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -1,5 +1,5 @@
 function initKerbcycleScanner() {
-    const scanner = new Html5Qrcode("reader", true);
+    const scannerAllowed = typeof kerbcycle_ajax.scanner_enabled === 'undefined' || kerbcycle_ajax.scanner_enabled;
     const scanResult = document.getElementById("scan-result");
     const qrSelect = document.getElementById("qr-code-select");
     const sendEmailCheckbox = document.getElementById("send-email");
@@ -101,18 +101,22 @@ function initKerbcycleScanner() {
         });
     }
 
-    function onScanSuccess(decodedText) {
-        scanner.pause(); // Stop scanning after success
-        scannedCode = decodedText;
-        scanResult.style.display = 'block'; // Make the result visible
-        scanResult.classList.add('updated'); // Use WordPress success styles
-        scanResult.innerHTML = `<strong>✅ QR Code Scanned Successfully!</strong><br>Content: <code>${decodedText}</code>`;
-        if (qrSelect) {
-            qrSelect.value = decodedText;
-        }
-    }
+    if (scannerAllowed && typeof Html5Qrcode !== 'undefined') {
+        const scanner = new Html5Qrcode("reader", true);
 
-    scanner.start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, onScanSuccess);
+        function onScanSuccess(decodedText) {
+            scanner.pause(); // Stop scanning after success
+            scannedCode = decodedText;
+            scanResult.style.display = 'block'; // Make the result visible
+            scanResult.classList.add('updated'); // Use WordPress success styles
+            scanResult.innerHTML = `<strong>✅ QR Code Scanned Successfully!</strong><br>Content: <code>${decodedText}</code>`;
+            if (qrSelect) {
+                qrSelect.value = decodedText;
+            }
+        }
+
+        scanner.start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, onScanSuccess);
+    }
 
     const bulkForm = document.getElementById('qr-code-bulk-form');
     if (bulkForm) {

--- a/includes/Admin/Assets/AdminAssets.php
+++ b/includes/Admin/Assets/AdminAssets.php
@@ -59,18 +59,26 @@ class AdminAssets
             return;
         }
 
-        wp_enqueue_script('html5-qrcode', 'https://unpkg.com/html5-qrcode', [], null, true);
+        $scanner_enabled = (bool) get_option('kerbcycle_qr_enable_scanner', 1);
+
+        $deps = ['jquery-ui-sortable'];
+        if ($scanner_enabled) {
+            wp_enqueue_script('html5-qrcode', 'https://unpkg.com/html5-qrcode', [], null, true);
+            $deps[] = 'html5-qrcode';
+        }
+
         wp_enqueue_script(
             'kerbcycle-qr-js',
             KERBCYCLE_QR_URL . 'assets/js/qr-scanner.js',
-            ['html5-qrcode', 'jquery-ui-sortable'],
+            $deps,
             '1.0',
             true
         );
 
         wp_localize_script('kerbcycle-qr-js', 'kerbcycle_ajax', [
             'ajax_url' => admin_url('admin-ajax.php'),
-            'nonce' => wp_create_nonce('kerbcycle_qr_nonce')
+            'nonce' => wp_create_nonce('kerbcycle_qr_nonce'),
+            'scanner_enabled' => $scanner_enabled
         ]);
     }
 }

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -90,6 +90,7 @@ class DashboardPage
                 $email_enabled    = (bool) get_option('kerbcycle_qr_enable_email', 1);
                 $sms_enabled      = (bool) get_option('kerbcycle_qr_enable_sms', 0);
                 $reminder_enabled = (bool) get_option('kerbcycle_qr_enable_reminders', 0);
+                $scanner_enabled  = (bool) get_option('kerbcycle_qr_enable_scanner', 1);
                 ?>
                 <label><input type="checkbox" id="send-email" <?php checked($email_enabled); ?> <?php disabled(!$email_enabled); ?>> <?php esc_html_e('Send notification email', 'kerbcycle'); ?></label>
                 <label><input type="checkbox" id="send-sms" <?php checked($sms_enabled); ?> <?php disabled(!$sms_enabled); ?>> <?php esc_html_e('Send SMS', 'kerbcycle'); ?></label>
@@ -98,7 +99,13 @@ class DashboardPage
                     <button id="assign-qr-btn" class="button button-primary"><?php esc_html_e('Assign QR Code', 'kerbcycle'); ?></button>
                     <button id="release-qr-btn" class="button"><?php esc_html_e('Release QR Code', 'kerbcycle'); ?></button>
                 </p>
-                <div id="reader" style="width: 100%; max-width: 400px; margin-top: 20px;"></div>
+                <?php if ($scanner_enabled) : ?>
+                    <div id="reader" style="width: 100%; max-width: 400px; margin-top: 20px;"></div>
+                <?php else : ?>
+                    <div class="notice notice-warning" style="margin-top: 20px;">
+                        <p><?php esc_html_e('QR code scanner camera is disabled in settings.', 'kerbcycle'); ?></p>
+                    </div>
+                <?php endif; ?>
                 <div id="scan-result" class="updated" style="display: none;"></div>
             </div>
 

--- a/includes/Admin/Pages/SettingsPage.php
+++ b/includes/Admin/Pages/SettingsPage.php
@@ -56,6 +56,7 @@ class SettingsPage
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_email');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_sms');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_reminders');
+        register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_scanner');
 
         add_settings_section(
             'kerbcycle_qr_main',
@@ -87,6 +88,14 @@ class SettingsPage
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
+
+        add_settings_field(
+            'kerbcycle_qr_enable_scanner',
+            __('Enable Dashboard QR Scanner Camera', 'kerbcycle'),
+            [$this, 'render_enable_scanner_field'],
+            'kerbcycle_qr_settings',
+            'kerbcycle_qr_main'
+        );
     }
 
     public function render_enable_email_field()
@@ -113,6 +122,15 @@ class SettingsPage
         ?>
         <input type="checkbox" name="kerbcycle_qr_enable_reminders" value="1" <?php checked(1, $value); ?> />
         <span class="description"><?php esc_html_e('Schedule automated reminders after assignment', 'kerbcycle'); ?></span>
+        <?php
+    }
+
+    public function render_enable_scanner_field()
+    {
+        $value = get_option('kerbcycle_qr_enable_scanner', 1);
+        ?>
+        <input type="checkbox" name="kerbcycle_qr_enable_scanner" value="1" <?php checked(1, $value); ?> />
+        <span class="description"><?php esc_html_e('Allow camera use on the dashboard scanner', 'kerbcycle'); ?></span>
         <?php
     }
 }


### PR DESCRIPTION
## Summary
- add settings option to toggle dashboard QR scanner camera
- pass scanner enabled state to admin scripts
- conditionally initialize scanner based on setting and show notice when disabled
- keep assignment and release actions working without the QR library by loading it only when needed

## Testing
- `php -l includes/Admin/Pages/SettingsPage.php`
- `php -l includes/Admin/Assets/AdminAssets.php`
- `php -l includes/Admin/Pages/DashboardPage.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_68b32b888d38832d9266a07b8421bcb5