### PR TITLE
Add QR code table shortcode for frontend display

### DIFF
--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -23,6 +23,7 @@ class Shortcodes
     public function __construct()
     {
         add_shortcode('kerbcycle_scanner', [$this, 'generate_frontend_scanner']);
+        add_shortcode('kerbcycle_qr_table', [$this, 'generate_qr_table']);
     }
 
     /**
@@ -42,6 +43,68 @@ class Shortcodes
             <div id="reader" style="width: 100%; max-width: 400px; margin-top: 20px;"></div>
             <div id="scan-result" class="updated" style="display: none;"></div>
         </div>
+        <?php
+        return ob_get_clean();
+    }
+
+    /**
+     * Generate a table of QR codes for the frontend.
+     *
+     * @since    1.0.0
+     */
+    public function generate_qr_table()
+    {
+        global $wpdb;
+        $table = $wpdb->prefix . 'kerbcycle_qr_codes';
+        $codes = $wpdb->get_results("SELECT id, qr_code, user_id, status, assigned_at FROM $table ORDER BY id DESC");
+
+        ob_start();
+        ?>
+        <style>
+            .kerbcycle-qr-table {
+                width: 100%;
+                border-collapse: collapse;
+                margin-bottom: 1em;
+            }
+            .kerbcycle-qr-table th,
+            .kerbcycle-qr-table td {
+                border: 1px solid #c3c4c7;
+                padding: 8px;
+                text-align: left;
+            }
+            .kerbcycle-qr-table th {
+                background: #f0f0f1;
+                font-weight: 600;
+            }
+        </style>
+        <table class="kerbcycle-qr-table">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e('ID', 'kerbcycle'); ?></th>
+                    <th><?php esc_html_e('QR Code', 'kerbcycle'); ?></th>
+                    <th><?php esc_html_e('User ID', 'kerbcycle'); ?></th>
+                    <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
+                    <th><?php esc_html_e('Assigned At', 'kerbcycle'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if (!empty($codes)) : ?>
+                    <?php foreach ($codes as $code) : ?>
+                        <tr>
+                            <td><?= esc_html($code->id); ?></td>
+                            <td><?= esc_html($code->qr_code); ?></td>
+                            <td><?= $code->user_id ? esc_html($code->user_id) : '—'; ?></td>
+                            <td><?= esc_html(ucfirst($code->status)); ?></td>
+                            <td><?= $code->assigned_at ? esc_html($code->assigned_at) : '—'; ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php else : ?>
+                    <tr>
+                        <td colspan="5" class="description"><?php esc_html_e('No QR codes found', 'kerbcycle'); ?></td>
+                    </tr>
+                <?php endif; ?>
+            </tbody>
+        </table>
         <?php
         return ob_get_clean();
     }


### PR DESCRIPTION
## Summary
- Introduce `[kerbcycle_qr_table]` shortcode to show QR code table on front-end
- Register new shortcode alongside existing scanner shortcode
- Render QR code details with inline styling and fallback message when empty

## Testing
- `php -l includes/Public/Shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68b35256c0cc832d868a2f5c762285b6