### PR TITLE
Add top bulk actions controls on QR code dashboard

### DIFF
--- a/assets/js/qr-assign-release.js
+++ b/assets/js/qr-assign-release.js
@@ -102,41 +102,43 @@ function initKerbcycleAssignRelease() {
     if (bulkForm) {
         jQuery('#qr-code-list').sortable({ items: 'li.qr-item' });
 
-        document.getElementById('apply-bulk').addEventListener('click', function(e) {
-            e.preventDefault();
-            const action = document.getElementById('bulk-action').value;
-            if (action === 'release') {
-                const codes = Array.from(document.querySelectorAll('#qr-code-list .qr-select:checked')).map(cb => cb.closest('li').dataset.code);
-                if (!codes.length) {
-                    alert('Please select one or more QR codes to release.');
-                    return;
-                }
-
-                if (!confirm('Are you sure you want to release the selected QR codes?')) {
-                    return;
-                }
-
-                fetch(kerbcycle_ajax.ajax_url, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
-                    },
-                    body: `action=bulk_release_qr_codes&qr_codes=${encodeURIComponent(codes.join(','))}&security=${kerbcycle_ajax.nonce}`
-                })
-                .then(res => res.json())
-                .then(data => {
-                    if (data.success) {
-                        alert(data.data.message);
-                        location.reload();
-                    } else {
-                        alert('Error: ' + (data.data.message || 'Failed to release QR codes.'));
+        bulkForm.querySelectorAll('.apply-bulk').forEach(function(btn) {
+            btn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const action = btn.parentElement.querySelector('.bulk-action').value;
+                if (action === 'release') {
+                    const codes = Array.from(document.querySelectorAll('#qr-code-list .qr-select:checked')).map(cb => cb.closest('li').dataset.code);
+                    if (!codes.length) {
+                        alert('Please select one or more QR codes to release.');
+                        return;
                     }
-                })
-                .catch(error => {
-                    console.error('Error:', error);
-                    alert('An unexpected error occurred. Please try again.');
-                });
-            }
+
+                    if (!confirm('Are you sure you want to release the selected QR codes?')) {
+                        return;
+                    }
+
+                    fetch(kerbcycle_ajax.ajax_url, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                        },
+                        body: `action=bulk_release_qr_codes&qr_codes=${encodeURIComponent(codes.join(','))}&security=${kerbcycle_ajax.nonce}`
+                    })
+                    .then(res => res.json())
+                    .then(data => {
+                        if (data.success) {
+                            alert(data.data.message);
+                            location.reload();
+                        } else {
+                            alert('Error: ' + (data.data.message || 'Failed to release QR codes.'));
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Error:', error);
+                        alert('An unexpected error occurred. Please try again.');
+                    });
+                }
+            });
         });
 
         document.querySelectorAll('#qr-code-list .qr-item .qr-text').forEach(span => {

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -112,6 +112,13 @@ class DashboardPage
             <h2><?php esc_html_e('Manage QR Codes', 'kerbcycle'); ?></h2>
             <p class="description"><?php esc_html_e('Drag and drop to reorder, select multiple codes for bulk actions, or click a code to edit.', 'kerbcycle'); ?></p>
             <form id="qr-code-bulk-form">
+                <div class="bulk-actions">
+                    <select class="bulk-action">
+                        <option value=""><?php esc_html_e('Bulk actions', 'kerbcycle'); ?></option>
+                        <option value="release"><?php esc_html_e('Release', 'kerbcycle'); ?></option>
+                    </select>
+                    <button class="apply-bulk button"><?php esc_html_e('Apply', 'kerbcycle'); ?></button>
+                </div>
                 <ul id="qr-code-list">
                     <li class="qr-header">
                         <input type="checkbox" class="qr-select" disabled style="visibility:hidden" aria-hidden="true" />
@@ -132,11 +139,13 @@ class DashboardPage
                         </li>
                     <?php endforeach; ?>
                 </ul>
-                <select id="bulk-action">
-                    <option value=""><?php esc_html_e('Bulk actions', 'kerbcycle'); ?></option>
-                    <option value="release"><?php esc_html_e('Release', 'kerbcycle'); ?></option>
-                </select>
-                <button id="apply-bulk" class="button"><?php esc_html_e('Apply', 'kerbcycle'); ?></button>
+                <div class="bulk-actions">
+                    <select class="bulk-action">
+                        <option value=""><?php esc_html_e('Bulk actions', 'kerbcycle'); ?></option>
+                        <option value="release"><?php esc_html_e('Release', 'kerbcycle'); ?></option>
+                    </select>
+                    <button class="apply-bulk button"><?php esc_html_e('Apply', 'kerbcycle'); ?></button>
+                </div>
             </form>
         </div>
         <?php


### PR DESCRIPTION
## Summary
- Add bulk actions dropdown and apply button above QR code list for easier access
- Switch bulk actions controls to class-based selectors and support multiple apply buttons in JS

## Testing
- `php -l includes/Admin/Pages/DashboardPage.php`
- `node --check assets/js/qr-assign-release.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b35a4fbe0c832d9f51f75db04201a4