### PR TITLE
Prevent QR code actions from submitting forms

### DIFF
--- a/assets/js/qr-assign-release.js
+++ b/assets/js/qr-assign-release.js
@@ -7,7 +7,8 @@ function initKerbcycleAssignRelease() {
     const releaseBtn = document.getElementById("release-qr-btn");
 
     if (assignBtn) {
-        assignBtn.addEventListener("click", function () {
+        assignBtn.addEventListener("click", function (event) {
+            event.preventDefault();
             const userField = document.getElementById("customer-id");
             const userId = userField ? userField.value : '';
             const qrCode = qrSelect ? qrSelect.value : '';
@@ -58,7 +59,8 @@ function initKerbcycleAssignRelease() {
     }
 
     if (releaseBtn) {
-        releaseBtn.addEventListener("click", function () {
+        releaseBtn.addEventListener("click", function (event) {
+            event.preventDefault();
             const qrCode = qrSelect ? qrSelect.value : '';
             const sendEmail = sendEmailCheckbox ? sendEmailCheckbox.checked : false;
             const sendSms = sendSmsCheckbox ? sendSmsCheckbox.checked : false;

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -96,8 +96,8 @@ class DashboardPage
                 <label><input type="checkbox" id="send-sms" <?php checked($sms_enabled); ?> <?php disabled(!$sms_enabled); ?>> <?php esc_html_e('Send SMS', 'kerbcycle'); ?></label>
                 <label><input type="checkbox" id="send-reminder" <?php checked($reminder_enabled); ?> <?php disabled(!$reminder_enabled); ?>> <?php esc_html_e('Schedule reminder', 'kerbcycle'); ?></label>
                 <p>
-                    <button id="assign-qr-btn" class="button button-primary"><?php esc_html_e('Assign QR Code', 'kerbcycle'); ?></button>
-                    <button id="release-qr-btn" class="button"><?php esc_html_e('Release QR Code', 'kerbcycle'); ?></button>
+                    <button type="button" id="assign-qr-btn" class="button button-primary"><?php esc_html_e('Assign QR Code', 'kerbcycle'); ?></button>
+                    <button type="button" id="release-qr-btn" class="button"><?php esc_html_e('Release QR Code', 'kerbcycle'); ?></button>
                 </p>
                 <?php if ($scanner_enabled) : ?>
                     <div id="reader" style="width: 100%; max-width: 400px; margin-top: 20px;"></div>


### PR DESCRIPTION
## Summary
- Ensure Dashboard assign and release buttons are non-submitting by adding `type="button"`
- Guard assign and release JS handlers against unintended form submissions with `event.preventDefault()`

## Testing
- `php -l includes/Admin/Pages/DashboardPage.php`
- `node --check assets/js/qr-assign-release.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b35e654cc4832daf9e93584e0816ed