### PR TITLE
Allow extra variables for notification messages

### DIFF
--- a/includes/Services/EmailService.php
+++ b/includes/Services/EmailService.php
@@ -24,20 +24,23 @@ class EmailService
      * @param int    $user_id The user ID.
      * @param string $qr_code The QR code.
      * @param string $type    The type of notification (e.g., 'assigned', 'released').
+     * @param array  $vars    Additional placeholder variables.
      *
      * @return bool|\WP_Error True on success, WP_Error on failure.
      */
-    public function send_notification($user_id, $qr_code, $type = 'assigned')
+    public function send_notification($user_id, $qr_code, $type = 'assigned', array $vars = [])
     {
         $user = get_userdata($user_id);
         if (!$user || empty($user->user_email)) {
             return new \WP_Error('email_config', __('Missing user email', 'kerbcycle'));
         }
 
-        $rendered = MessagesService::render($type, [
+        $vars = array_merge([
             'user' => $user->display_name ?: $user->user_login,
             'code' => $qr_code,
-        ]);
+        ], $vars);
+
+        $rendered = MessagesService::render($type, $vars);
 
         $subject = 'KerbCycle: ' . ucfirst($type);
         $sent    = wp_mail($user->user_email, $subject, $rendered['email']);

--- a/includes/Services/MessagesService.php
+++ b/includes/Services/MessagesService.php
@@ -92,9 +92,12 @@ class MessagesService {
         /** =========================
          *  TEST HANDLER (Preview/Send)
          *  ========================= */
-        $test_preview_sms = '';
+        $test_preview_sms   = '';
         $test_preview_email = '';
-        $test_type = 'assigned';
+        $test_type          = 'assigned';
+        $t_user = $t_code = $t_amount = $t_wallet = '';
+        $t_to_sms = $t_to_email = '';
+        $do_send_sms = $do_send_email = false;
         if (!empty($_POST['kc_msgs_test'])) {
             Nonces::verify('kc_msgs_test_nonce', 'kc_msgs_test_nonce_f');
             $t_type   = sanitize_text_field($_POST['kc_test_type'] ?? 'assigned');
@@ -224,10 +227,10 @@ class MessagesService {
                         <tr>
                             <th scope="row">Variables</th>
                             <td>
-                                <input type="text" name="kc_test_user"   placeholder="user e.g. Sam"   style="width:200px" />
-                                <input type="text" name="kc_test_code"   placeholder="code e.g. QR123" style="width:200px" />
-                                <input type="text" name="kc_test_amount" placeholder="amount e.g. $10"  style="width:200px" />
-                                <input type="text" name="kc_test_wallet" placeholder="wallet e.g. TeraWallet" style="width:220px" />
+                                <input type="text" name="kc_test_user"   placeholder="user e.g. Sam"   style="width:200px" value="<?php echo esc_attr($t_user); ?>" />
+                                <input type="text" name="kc_test_code"   placeholder="code e.g. QR123" style="width:200px" value="<?php echo esc_attr($t_code); ?>" />
+                                <input type="text" name="kc_test_amount" placeholder="amount e.g. $10"  style="width:200px" value="<?php echo esc_attr($t_amount); ?>" />
+                                <input type="text" name="kc_test_wallet" placeholder="wallet e.g. TeraWallet" style="width:220px" value="<?php echo esc_attr($t_wallet); ?>" />
                                 <p class="description">Only variables used in the selected template are needed.</p>
                             </td>
                         </tr>
@@ -235,10 +238,10 @@ class MessagesService {
                         <tr>
                             <th scope="row">Send Options</th>
                             <td>
-                                <label><input type="checkbox" name="kc_test_send_sms" value="1" /> Send SMS to:</label>
-                                <input type="text" name="kc_test_to_sms" placeholder="+15551234567" style="width:200px; margin-right:20px;" />
-                                <label><input type="checkbox" name="kc_test_send_email" value="1" /> Send Email to:</label>
-                                <input type="email" name="kc_test_to_email" placeholder="you@example.com" style="width:240px" />
+                                <label><input type="checkbox" name="kc_test_send_sms" value="1" <?php checked($do_send_sms); ?> /> Send SMS to:</label>
+                                <input type="text" name="kc_test_to_sms" placeholder="+15551234567" style="width:200px; margin-right:20px;" value="<?php echo esc_attr($t_to_sms); ?>" />
+                                <label><input type="checkbox" name="kc_test_send_email" value="1" <?php checked($do_send_email); ?> /> Send Email to:</label>
+                                <input type="email" name="kc_test_to_email" placeholder="you@example.com" style="width:240px" value="<?php echo esc_attr($t_to_email); ?>" />
                                 <p class="description">Leave unchecked to just preview below.</p>
                             </td>
                         </tr>

--- a/includes/Services/SmsService.php
+++ b/includes/Services/SmsService.php
@@ -373,10 +373,11 @@ class SmsService
      * @param int    $user_id The user ID.
      * @param string $qr_code The QR code.
      * @param string $type    The type of notification (e.g., 'assigned', 'released').
+     * @param array  $vars    Additional placeholder variables.
      *
      * @return bool|\WP_Error True on success, WP_Error on failure.
      */
-    public function send_notification($user_id, $qr_code, $type = 'assigned')
+    public function send_notification($user_id, $qr_code, $type = 'assigned', array $vars = [])
     {
         $to = get_user_meta($user_id, 'phone_number', true);
         if (empty($to)) {
@@ -387,11 +388,13 @@ class SmsService
             return new \WP_Error('sms_config', __('Missing phone number', 'kerbcycle'));
         }
 
-        $user     = get_userdata($user_id);
-        $rendered = MessagesService::render($type, [
+        $user = get_userdata($user_id);
+        $vars = array_merge([
             'user' => $user ? ($user->display_name ?: $user->user_login) : '',
             'code' => $qr_code,
-        ]);
+        ], $vars);
+
+        $rendered = MessagesService::render($type, $vars);
 
         $body   = $rendered['sms'];
         $result = self::send($to, $body);


### PR DESCRIPTION
## Summary
- Allow SMS and email notification helpers to accept extra placeholder variables
- Preserve variables entered on the test message form so previews and sent messages stay in sync

## Testing
- `php -l includes/Services/MessagesService.php`
- `php -l includes/Services/EmailService.php`
- `php -l includes/Services/SmsService.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5cd19eae4832d9589a69ba44572a8