### PR TITLE
Fix 'Add QR code' button functionality

### DIFF
--- a/assets/js/qr-assign-release.js
+++ b/assets/js/qr-assign-release.js
@@ -5,6 +5,8 @@ function initKerbcycleAssignRelease() {
     const sendReminderCheckbox = document.getElementById("send-reminder");
     const assignBtn = document.getElementById("assign-qr-btn");
     const releaseBtn = document.getElementById("release-qr-btn");
+    const addBtn = document.getElementById("add-qr-btn");
+    const newCodeInput = document.getElementById("new-qr-code");
 
     if (assignBtn) {
         assignBtn.addEventListener("click", function () {
@@ -94,6 +96,39 @@ function initKerbcycleAssignRelease() {
             .catch(error => {
                 console.error('Error:', error);
                 alert("An error occurred while releasing the QR code.");
+            });
+        });
+    }
+
+    if (addBtn) {
+        addBtn.addEventListener("click", function () {
+            const qrCode = newCodeInput ? newCodeInput.value.trim() : '';
+            if (!qrCode) {
+                alert("Please enter a QR code.");
+                return;
+            }
+
+            fetch(kerbcycle_ajax.ajax_url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                },
+                body: `action=add_qr_code&qr_code=${encodeURIComponent(qrCode)}&security=${kerbcycle_ajax.nonce}`
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    const msg = data.data && data.data.message ? data.data.message : 'QR code added successfully.';
+                    alert(msg);
+                    location.reload();
+                } else {
+                    const err = data.data && data.data.message ? data.data.message : 'Failed to add QR code.';
+                    alert(err);
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('An error occurred while adding the QR code.');
             });
         });
     }

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -35,6 +35,7 @@ class AdminAjax
         add_action('wp_ajax_release_qr_code', [$this, 'release_qr_code']);
         add_action('wp_ajax_bulk_release_qr_codes', [$this, 'bulk_release_qr_codes']);
         add_action('wp_ajax_update_qr_code', [$this, 'update_qr_code']);
+        add_action('wp_ajax_add_qr_code', [$this, 'add_qr_code']);
         add_action('wp_ajax_kerbcycle_qr_report_data', [$this, 'ajax_report_data']);
         add_action('wp_ajax_kerbcycle_delete_logs', [$this, 'delete_logs']);
     }
@@ -153,6 +154,28 @@ class AdminAjax
             wp_send_json_success(['message' => 'QR code updated']);
         } else {
             wp_send_json_error(['message' => 'Failed to update QR code']);
+        }
+    }
+
+    public function add_qr_code()
+    {
+        Nonces::verify('kerbcycle_qr_nonce', 'security');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => 'Unauthorized'], 403);
+        }
+
+        $qr_code = sanitize_text_field($_POST['qr_code']);
+
+        if (empty($qr_code)) {
+            wp_send_json_error(['message' => 'Invalid QR code']);
+        }
+
+        $result = $this->qr_service->add($qr_code);
+
+        if ($result !== false) {
+            wp_send_json_success(['message' => 'QR code added']);
+        } else {
+            wp_send_json_error(['message' => 'Failed to add QR code']);
         }
     }
 

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -86,6 +86,8 @@ class DashboardPage
                         <option value="<?= esc_attr($code->qr_code); ?>"><?= esc_html($code->qr_code); ?></option>
                     <?php endforeach; ?>
                 </select>
+                <input type="text" id="new-qr-code" placeholder="<?php esc_attr_e('Enter QR Code', 'kerbcycle'); ?>" />
+                <button id="add-qr-btn" class="button"><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></button>
                 <?php
                 $email_enabled    = (bool) get_option('kerbcycle_qr_enable_email', 1);
                 $sms_enabled      = (bool) get_option('kerbcycle_qr_enable_sms', 0);

--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -23,6 +23,19 @@ class QrCodeRepository
         $this->table = $wpdb->prefix . 'kerbcycle_qr_codes';
     }
 
+    public function insert_available($qr_code)
+    {
+        global $wpdb;
+        return $wpdb->insert(
+            $this->table,
+            [
+                'qr_code' => $qr_code,
+                'status'  => 'available',
+            ],
+            ['%s', '%s']
+        );
+    }
+
     public function insert_assigned($qr_code, $user_id)
     {
         global $wpdb;
@@ -138,6 +151,11 @@ class QrCodeRepository
     public function assign($qr_code, $user_id)
     {
         return $this->insert_assigned($qr_code, $user_id);
+    }
+
+    public function add($qr_code)
+    {
+        return $this->insert_available($qr_code);
     }
 
     public function release($qr_code)

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -26,6 +26,11 @@ class QrService
         $this->repository = new QrCodeRepository();
     }
 
+    public function add($qr_code)
+    {
+        return $this->repository->insert_available($qr_code);
+    }
+
     public function assign($qr_code, $user_id, $send_email, $send_sms, $send_reminder)
     {
         $result = $this->repository->insert_assigned($qr_code, $user_id);


### PR DESCRIPTION
## Summary
- wire up manual QR code entry button to call `add_qr_code` AJAX endpoint
- display server success/error messages and refresh list on success
- confirm backend routes add codes as `available`

## Testing
- `php -l includes/Data/Repositories/QrCodeRepository.php`
- `php -l includes/Services/QrService.php`
- `php -l includes/Admin/Ajax/AdminAjax.php`
- `php -l includes/Admin/Pages/DashboardPage.php`
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e1065bd0832da9b70800ac6b73b5