### PR TITLE
Add top bulk action controls on QR code admin page

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -137,41 +137,44 @@ function initKerbcycleAdmin() {
     if (bulkForm) {
         jQuery('#qr-code-list').sortable({ items: 'li.qr-item' });
 
-        document.getElementById('apply-bulk').addEventListener('click', function(e) {
-            e.preventDefault();
-            const action = document.getElementById('bulk-action').value;
-            if (action === 'release') {
-                const codes = Array.from(document.querySelectorAll('#qr-code-list .qr-select:checked')).map(cb => cb.closest('li').dataset.code);
-                if (!codes.length) {
-                    alert('Please select one or more QR codes to release.');
-                    return;
-                }
-
-                if (!confirm('Are you sure you want to release the selected QR codes?')) {
-                    return;
-                }
-
-                fetch(kerbcycle_ajax.ajax_url, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
-                    },
-                    body: `action=bulk_release_qr_codes&qr_codes=${encodeURIComponent(codes.join(','))}&security=${kerbcycle_ajax.nonce}`
-                })
-                .then(res => res.json())
-                .then(data => {
-                    if (data.success) {
-                        alert(data.data.message);
-                        location.reload();
-                    } else {
-                        alert('Error: ' + (data.data.message || 'Failed to release QR codes.'));
+        document.querySelectorAll('#apply-bulk, #apply-bulk-top').forEach(button => {
+            button.addEventListener('click', function(e) {
+                e.preventDefault();
+                const targetSelect = document.getElementById(button.dataset.target);
+                const action = targetSelect ? targetSelect.value : '';
+                if (action === 'release') {
+                    const codes = Array.from(document.querySelectorAll('#qr-code-list .qr-select:checked')).map(cb => cb.closest('li').dataset.code);
+                    if (!codes.length) {
+                        alert('Please select one or more QR codes to release.');
+                        return;
                     }
-                })
-                .catch(error => {
-                    console.error('Error:', error);
-                    alert('An unexpected error occurred. Please try again.');
-                });
-            }
+
+                    if (!confirm('Are you sure you want to release the selected QR codes?')) {
+                        return;
+                    }
+
+                    fetch(kerbcycle_ajax.ajax_url, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                        },
+                        body: `action=bulk_release_qr_codes&qr_codes=${encodeURIComponent(codes.join(','))}&security=${kerbcycle_ajax.nonce}`
+                    })
+                    .then(res => res.json())
+                    .then(data => {
+                        if (data.success) {
+                            alert(data.data.message);
+                            location.reload();
+                        } else {
+                            alert('Error: ' + (data.data.message || 'Failed to release QR codes.'));
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Error:', error);
+                        alert('An unexpected error occurred. Please try again.');
+                    });
+                }
+            });
         });
 
         document.querySelectorAll('#qr-code-list .qr-item .qr-text').forEach(span => {

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -114,6 +114,11 @@ class DashboardPage
             <h2><?php esc_html_e('Manage QR Codes', 'kerbcycle'); ?></h2>
             <p class="description"><?php esc_html_e('Drag and drop to reorder, select multiple codes for bulk actions, or click a code to edit.', 'kerbcycle'); ?></p>
             <form id="qr-code-bulk-form">
+                <select id="bulk-action-top">
+                    <option value=""><?php esc_html_e('Bulk actions', 'kerbcycle'); ?></option>
+                    <option value="release"><?php esc_html_e('Release', 'kerbcycle'); ?></option>
+                </select>
+                <button id="apply-bulk-top" class="button" data-target="bulk-action-top"><?php esc_html_e('Apply', 'kerbcycle'); ?></button>
                 <ul id="qr-code-list">
                     <li class="qr-header">
                         <input type="checkbox" class="qr-select" disabled style="visibility:hidden" aria-hidden="true" />
@@ -138,7 +143,7 @@ class DashboardPage
                     <option value=""><?php esc_html_e('Bulk actions', 'kerbcycle'); ?></option>
                     <option value="release"><?php esc_html_e('Release', 'kerbcycle'); ?></option>
                 </select>
-                <button id="apply-bulk" class="button"><?php esc_html_e('Apply', 'kerbcycle'); ?></button>
+                <button id="apply-bulk" class="button" data-target="bulk-action"><?php esc_html_e('Apply', 'kerbcycle'); ?></button>
             </form>
         </div>
         <?php


### PR DESCRIPTION
## Summary
- Duplicate bulk action dropdown and Apply button above the QR code list
- Wire up bulk actions JavaScript for both top and bottom controls

## Testing
- `php -l includes/Admin/Pages/DashboardPage.php`
- `node --check assets/js/admin.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b6009e57c0832d96d1b18602ef1048