### PR TITLE
Add bulk delete action for available QR codes

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -173,6 +173,45 @@ function initKerbcycleAdmin() {
                         console.error('Error:', error);
                         alert('An unexpected error occurred. Please try again.');
                     });
+                } else if (action === 'delete') {
+                    const selected = Array.from(document.querySelectorAll('#qr-code-list .qr-select:checked'));
+                    if (!selected.length) {
+                        alert('Please select one or more QR codes to delete.');
+                        return;
+                    }
+
+                    const availableItems = selected.filter(cb => cb.closest('li').querySelector('.qr-status').textContent.trim().toLowerCase() === 'available');
+                    if (availableItems.length !== selected.length) {
+                        alert('Only QR codes with Available status can be deleted.');
+                        return;
+                    }
+
+                    const codes = availableItems.map(cb => cb.closest('li').dataset.code);
+
+                    if (!confirm('Are you sure you want to delete the selected QR codes?')) {
+                        return;
+                    }
+
+                    fetch(kerbcycle_ajax.ajax_url, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                        },
+                        body: `action=bulk_delete_qr_codes&qr_codes=${encodeURIComponent(codes.join(','))}&security=${kerbcycle_ajax.nonce}`
+                    })
+                    .then(res => res.json())
+                    .then(data => {
+                        if (data.success) {
+                            alert(data.data.message);
+                            location.reload();
+                        } else {
+                            alert('Error: ' + (data.data.message || 'Failed to delete QR codes.'));
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Error:', error);
+                        alert('An unexpected error occurred. Please try again.');
+                    });
                 }
             });
         });

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -117,6 +117,7 @@ class DashboardPage
                 <select id="bulk-action-top">
                     <option value=""><?php esc_html_e('Bulk actions', 'kerbcycle'); ?></option>
                     <option value="release"><?php esc_html_e('Release', 'kerbcycle'); ?></option>
+                    <option value="delete"><?php esc_html_e('Delete', 'kerbcycle'); ?></option>
                 </select>
                 <button id="apply-bulk-top" class="button" data-target="bulk-action-top"><?php esc_html_e('Apply', 'kerbcycle'); ?></button>
                 <ul id="qr-code-list">
@@ -142,6 +143,7 @@ class DashboardPage
                 <select id="bulk-action">
                     <option value=""><?php esc_html_e('Bulk actions', 'kerbcycle'); ?></option>
                     <option value="release"><?php esc_html_e('Release', 'kerbcycle'); ?></option>
+                    <option value="delete"><?php esc_html_e('Delete', 'kerbcycle'); ?></option>
                 </select>
                 <button id="apply-bulk" class="button" data-target="bulk-action"><?php esc_html_e('Apply', 'kerbcycle'); ?></button>
             </form>

--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -110,6 +110,19 @@ class QrCodeRepository
         return $released_count;
     }
 
+    public function bulk_delete_available(array $codes)
+    {
+        global $wpdb;
+        if (empty($codes)) {
+            return 0;
+        }
+
+        $placeholders = implode(',', array_fill(0, count($codes), '%s'));
+        $query = $wpdb->prepare("DELETE FROM $this->table WHERE status = 'available' AND qr_code IN ($placeholders)", $codes);
+        $wpdb->query($query);
+        return $wpdb->rows_affected;
+    }
+
     public function update_code($old_code, $new_code)
     {
         global $wpdb;

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -86,6 +86,11 @@ class QrService
         return $this->repository->bulk_release($codes);
     }
 
+    public function bulk_delete(array $codes)
+    {
+        return $this->repository->bulk_delete_available($codes);
+    }
+
     public function update($old_code, $new_code)
     {
         return $this->repository->update_code($old_code, $new_code);


### PR DESCRIPTION
## Summary
- add Delete option to QR code bulk action menus
- implement JS handler to delete only Available QR codes
- support deletion via new AJAX, service, and repository methods

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_68b6040dd200832d997ba66ae3f1fc54