### PR TITLE
Add pagination to QR codes and history pages

### DIFF
--- a/includes/Admin/Pages/HistoryPage.php
+++ b/includes/Admin/Pages/HistoryPage.php
@@ -23,10 +23,20 @@ class HistoryPage
     public function render()
     {
         global $wpdb;
-        $table_name = $wpdb->prefix . 'kerbcycle_qr_codes';
+        $table_name   = $wpdb->prefix . 'kerbcycle_qr_codes';
+        $per_page     = 20;
+        $current_page = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
+        $offset       = ($current_page - 1) * $per_page;
+
+        $total_items  = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table_name");
+        $total_pages  = (int) ceil($total_items / $per_page);
 
         $qr_codes = $wpdb->get_results(
-            $wpdb->prepare("SELECT * FROM $table_name ORDER BY assigned_at DESC LIMIT %d", 100)
+            $wpdb->prepare(
+                "SELECT * FROM $table_name ORDER BY assigned_at DESC LIMIT %d OFFSET %d",
+                $per_page,
+                $offset
+            )
         );
         ?>
         <div class="wrap">
@@ -58,6 +68,20 @@ class HistoryPage
                     <?php endif; ?>
                 </tbody>
             </table>
+            <?php if ($total_pages > 1) : ?>
+                <div class="tablenav">
+                    <div class="tablenav-pages">
+                        <?= paginate_links([
+                            'base'      => add_query_arg('paged', '%#%'),
+                            'format'    => '',
+                            'prev_text' => '&laquo;',
+                            'next_text' => '&raquo;',
+                            'total'     => $total_pages,
+                            'current'   => $current_page,
+                        ]); ?>
+                    </div>
+                </div>
+            <?php endif; ?>
         </div>
         <?php
     }


### PR DESCRIPTION
## Summary
- Split history listings into pages of 20 with navigation controls
- Paginate dashboard QR code list to show 20 codes per page

## Testing
- `php -l includes/Admin/Pages/HistoryPage.php`
- `php -l includes/Admin/Pages/DashboardPage.php`


------
https://chatgpt.com/codex/tasks/task_e_68b60751dd6c832da7273ed39a3bb2c4