### PR TITLE
Add pagination to QR codes and history pages

### DIFF
--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -23,9 +23,31 @@ class DashboardPage
     public function render()
     {
         global $wpdb;
-        $table = $wpdb->prefix . 'kerbcycle_qr_codes';
+        $table        = $wpdb->prefix . 'kerbcycle_qr_codes';
+        $per_page     = 20;
+        $current_page = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
+        $offset       = ($current_page - 1) * $per_page;
+
+        $total_items = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table");
+        $total_pages = (int) ceil($total_items / $per_page);
+
+        $pagination_links = $total_pages > 1 ? paginate_links([
+            'base'      => add_query_arg('paged', '%#%'),
+            'format'    => '',
+            'prev_text' => '&laquo;',
+            'next_text' => '&raquo;',
+            'total'     => $total_pages,
+            'current'   => $current_page,
+        ]) : '';
+
         $available_codes = $wpdb->get_results("SELECT qr_code FROM $table WHERE status = 'available' ORDER BY id DESC");
-        $all_codes = $wpdb->get_results("SELECT id, qr_code, user_id, status, assigned_at FROM $table ORDER BY id DESC");
+        $all_codes = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT id, qr_code, user_id, status, assigned_at FROM $table ORDER BY id DESC LIMIT %d OFFSET %d",
+                $per_page,
+                $offset
+            )
+        );
         ?>
         <style>
             #qr-code-list {
@@ -120,6 +142,13 @@ class DashboardPage
                     <option value="delete"><?php esc_html_e('Delete', 'kerbcycle'); ?></option>
                 </select>
                 <button id="apply-bulk-top" class="button" data-target="bulk-action-top"><?php esc_html_e('Apply', 'kerbcycle'); ?></button>
+                <?php if ($pagination_links) : ?>
+                    <div class="tablenav">
+                        <div class="tablenav-pages">
+                            <?= $pagination_links; ?>
+                        </div>
+                    </div>
+                <?php endif; ?>
                 <ul id="qr-code-list">
                     <li class="qr-header">
                         <input type="checkbox" class="qr-select" disabled style="visibility:hidden" aria-hidden="true" />
@@ -140,6 +169,13 @@ class DashboardPage
                         </li>
                     <?php endforeach; ?>
                 </ul>
+                <?php if ($pagination_links) : ?>
+                    <div class="tablenav">
+                        <div class="tablenav-pages">
+                            <?= $pagination_links; ?>
+                        </div>
+                    </div>
+                <?php endif; ?>
                 <select id="bulk-action">
                     <option value=""><?php esc_html_e('Bulk actions', 'kerbcycle'); ?></option>
                     <option value="release"><?php esc_html_e('Release', 'kerbcycle'); ?></option>

--- a/includes/Admin/Pages/HistoryPage.php
+++ b/includes/Admin/Pages/HistoryPage.php
@@ -23,15 +23,41 @@ class HistoryPage
     public function render()
     {
         global $wpdb;
-        $table_name = $wpdb->prefix . 'kerbcycle_qr_codes';
+        $table_name   = $wpdb->prefix . 'kerbcycle_qr_codes';
+        $per_page     = 20;
+        $current_page = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
+        $offset       = ($current_page - 1) * $per_page;
+
+        $total_items  = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table_name");
+        $total_pages  = (int) ceil($total_items / $per_page);
+
+        $pagination_links = $total_pages > 1 ? paginate_links([
+            'base'      => add_query_arg('paged', '%#%'),
+            'format'    => '',
+            'prev_text' => '&laquo;',
+            'next_text' => '&raquo;',
+            'total'     => $total_pages,
+            'current'   => $current_page,
+        ]) : '';
 
         $qr_codes = $wpdb->get_results(
-            $wpdb->prepare("SELECT * FROM $table_name ORDER BY assigned_at DESC LIMIT %d", 100)
+            $wpdb->prepare(
+                "SELECT * FROM $table_name ORDER BY assigned_at DESC LIMIT %d OFFSET %d",
+                $per_page,
+                $offset
+            )
         );
         ?>
         <div class="wrap">
             <h1>QR Code History</h1>
             <p class="description">Recent QR code assignments</p>
+            <?php if ($pagination_links) : ?>
+                <div class="tablenav">
+                    <div class="tablenav-pages">
+                        <?= $pagination_links; ?>
+                    </div>
+                </div>
+            <?php endif; ?>
             <table class="wp-list-table widefat fixed striped">
                 <thead>
                     <tr>
@@ -58,6 +84,13 @@ class HistoryPage
                     <?php endif; ?>
                 </tbody>
             </table>
+            <?php if ($pagination_links) : ?>
+                <div class="tablenav">
+                    <div class="tablenav-pages">
+                        <?= $pagination_links; ?>
+                    </div>
+                </div>
+            <?php endif; ?>
         </div>
         <?php
     }


### PR DESCRIPTION
## Summary
- Split history listings into pages of 20 with navigation links above and below the table
- Paginate dashboard QR code list to show 20 codes per page with navigation controls on top and bottom

## Testing
- `php -l includes/Admin/Pages/HistoryPage.php`
- `php -l includes/Admin/Pages/DashboardPage.php`


------
https://chatgpt.com/codex/tasks/task_e_68b60751dd6c832da7273ed39a3bb2c4