### PR TITLE
Add filter options to QR code and history pages

### DIFF
--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -28,7 +28,40 @@ class DashboardPage
         $current_page = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
         $offset       = ($current_page - 1) * $per_page;
 
-        $total_items = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table");
+        $status_filter = isset($_GET['status_filter']) ? sanitize_text_field(wp_unslash($_GET['status_filter'])) : '';
+        $start_date    = isset($_GET['start_date']) ? sanitize_text_field(wp_unslash($_GET['start_date'])) : '';
+        $end_date      = isset($_GET['end_date']) ? sanitize_text_field(wp_unslash($_GET['end_date'])) : '';
+        $search        = isset($_GET['s']) ? sanitize_text_field(wp_unslash($_GET['s'])) : '';
+
+        $where  = '1=1';
+        $params = [];
+
+        if ($status_filter) {
+            $where   .= ' AND status = %s';
+            $params[] = $status_filter;
+        }
+
+        if ($start_date) {
+            $where   .= ' AND DATE(assigned_at) >= %s';
+            $params[] = $start_date;
+        }
+
+        if ($end_date) {
+            $where   .= ' AND DATE(assigned_at) <= %s';
+            $params[] = $end_date;
+        }
+
+        if ($search) {
+            $like     = '%' . $wpdb->esc_like($search) . '%';
+            $where   .= ' AND (CAST(id AS CHAR) LIKE %s OR qr_code LIKE %s OR CAST(user_id AS CHAR) LIKE %s OR CAST(assigned_at AS CHAR) LIKE %s)';
+            $params[] = $like;
+            $params[] = $like;
+            $params[] = $like;
+            $params[] = $like;
+        }
+
+        $count_sql   = "SELECT COUNT(*) FROM $table WHERE $where";
+        $total_items = (int) ($params ? $wpdb->get_var($wpdb->prepare($count_sql, $params)) : $wpdb->get_var($count_sql));
         $total_pages = (int) ceil($total_items / $per_page);
 
         $pagination_links = $total_pages > 1 ? paginate_links([
@@ -41,13 +74,10 @@ class DashboardPage
         ]) : '';
 
         $available_codes = $wpdb->get_results("SELECT qr_code FROM $table WHERE status = 'available' ORDER BY id DESC");
-        $all_codes = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT id, qr_code, user_id, status, assigned_at FROM $table ORDER BY id DESC LIMIT %d OFFSET %d",
-                $per_page,
-                $offset
-            )
-        );
+
+        $select_sql = "SELECT id, qr_code, user_id, status, assigned_at FROM $table WHERE $where ORDER BY id DESC LIMIT %d OFFSET %d";
+        $query_args = array_merge($params, [$per_page, $offset]);
+        $all_codes  = $wpdb->get_results($wpdb->prepare($select_sql, $query_args));
         ?>
         <style>
             #qr-code-list {
@@ -134,6 +164,19 @@ class DashboardPage
             </div>
 
             <h2><?php esc_html_e('Manage QR Codes', 'kerbcycle'); ?></h2>
+            <form method="get" class="qr-filters" style="margin-bottom:15px;">
+                <input type="hidden" name="page" value="kerbcycle-qr-manager" />
+                <select name="status_filter">
+                    <option value=""><?php esc_html_e('All Statuses', 'kerbcycle'); ?></option>
+                    <option value="assigned" <?php selected($status_filter, 'assigned'); ?>><?php esc_html_e('Assigned', 'kerbcycle'); ?></option>
+                    <option value="available" <?php selected($status_filter, 'available'); ?>><?php esc_html_e('Available', 'kerbcycle'); ?></option>
+                </select>
+                <input type="date" name="start_date" value="<?= esc_attr($start_date); ?>" />
+                <input type="date" name="end_date" value="<?= esc_attr($end_date); ?>" />
+                <input type="search" name="s" value="<?= esc_attr($search); ?>" placeholder="<?php esc_attr_e('Search', 'kerbcycle'); ?>" />
+                <button class="button"><?php esc_html_e('Filter', 'kerbcycle'); ?></button>
+                <a href="<?php echo esc_url(admin_url('admin.php?page=kerbcycle-qr-manager')); ?>" class="button"><?php esc_html_e('Reset', 'kerbcycle'); ?></a>
+            </form>
             <p class="description"><?php esc_html_e('Drag and drop to reorder, select multiple codes for bulk actions, or click a code to edit.', 'kerbcycle'); ?></p>
             <form id="qr-code-bulk-form">
                 <select id="bulk-action-top">

--- a/includes/Admin/Pages/HistoryPage.php
+++ b/includes/Admin/Pages/HistoryPage.php
@@ -28,7 +28,40 @@ class HistoryPage
         $current_page = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
         $offset       = ($current_page - 1) * $per_page;
 
-        $total_items  = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table_name");
+        $status_filter = isset($_GET['status_filter']) ? sanitize_text_field(wp_unslash($_GET['status_filter'])) : '';
+        $start_date    = isset($_GET['start_date']) ? sanitize_text_field(wp_unslash($_GET['start_date'])) : '';
+        $end_date      = isset($_GET['end_date']) ? sanitize_text_field(wp_unslash($_GET['end_date'])) : '';
+        $search        = isset($_GET['s']) ? sanitize_text_field(wp_unslash($_GET['s'])) : '';
+
+        $where  = '1=1';
+        $params = [];
+
+        if ($status_filter) {
+            $where   .= ' AND status = %s';
+            $params[] = $status_filter;
+        }
+
+        if ($start_date) {
+            $where   .= ' AND DATE(assigned_at) >= %s';
+            $params[] = $start_date;
+        }
+
+        if ($end_date) {
+            $where   .= ' AND DATE(assigned_at) <= %s';
+            $params[] = $end_date;
+        }
+
+        if ($search) {
+            $like     = '%' . $wpdb->esc_like($search) . '%';
+            $where   .= ' AND (CAST(id AS CHAR) LIKE %s OR qr_code LIKE %s OR CAST(user_id AS CHAR) LIKE %s OR CAST(assigned_at AS CHAR) LIKE %s)';
+            $params[] = $like;
+            $params[] = $like;
+            $params[] = $like;
+            $params[] = $like;
+        }
+
+        $count_sql   = "SELECT COUNT(*) FROM $table_name WHERE $where";
+        $total_items = (int) ($params ? $wpdb->get_var($wpdb->prepare($count_sql, $params)) : $wpdb->get_var($count_sql));
         $total_pages  = (int) ceil($total_items / $per_page);
 
         $pagination_links = $total_pages > 1 ? paginate_links([
@@ -40,16 +73,25 @@ class HistoryPage
             'current'   => $current_page,
         ]) : '';
 
-        $qr_codes = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT * FROM $table_name ORDER BY assigned_at DESC LIMIT %d OFFSET %d",
-                $per_page,
-                $offset
-            )
-        );
+        $select_sql = "SELECT * FROM $table_name WHERE $where ORDER BY assigned_at DESC LIMIT %d OFFSET %d";
+        $query_args = array_merge($params, [$per_page, $offset]);
+        $qr_codes   = $wpdb->get_results($wpdb->prepare($select_sql, $query_args));
         ?>
         <div class="wrap">
             <h1>QR Code History</h1>
+            <form method="get" class="qr-filters" style="margin-bottom:15px;">
+                <input type="hidden" name="page" value="kerbcycle-qr-history" />
+                <select name="status_filter">
+                    <option value=""><?php esc_html_e('All Statuses', 'kerbcycle'); ?></option>
+                    <option value="assigned" <?php selected($status_filter, 'assigned'); ?>><?php esc_html_e('Assigned', 'kerbcycle'); ?></option>
+                    <option value="available" <?php selected($status_filter, 'available'); ?>><?php esc_html_e('Available', 'kerbcycle'); ?></option>
+                </select>
+                <input type="date" name="start_date" value="<?= esc_attr($start_date); ?>" />
+                <input type="date" name="end_date" value="<?= esc_attr($end_date); ?>" />
+                <input type="search" name="s" value="<?= esc_attr($search); ?>" placeholder="<?php esc_attr_e('Search', 'kerbcycle'); ?>" />
+                <button class="button"><?php esc_html_e('Filter', 'kerbcycle'); ?></button>
+                <a href="<?php echo esc_url(admin_url('admin.php?page=kerbcycle-qr-history')); ?>" class="button"><?php esc_html_e('Reset', 'kerbcycle'); ?></a>
+            </form>
             <p class="description">Recent QR code assignments</p>
             <?php if ($pagination_links) : ?>
                 <div class="tablenav">


### PR DESCRIPTION
## Summary
- allow filtering QR codes by status, date range, or text search
- support the same filters on the QR code history page
- add reset controls to clear any applied filters

## Testing
- `php -l includes/Admin/Pages/DashboardPage.php`
- `php -l includes/Admin/Pages/HistoryPage.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b60d6a66f4832dbbfab483efb2fd8d