### PR TITLE
Limit message history pages to 20 entries

### DIFF
--- a/includes/Admin/Pages/MessagesHistoryPage.php
+++ b/includes/Admin/Pages/MessagesHistoryPage.php
@@ -127,7 +127,7 @@ class MessagesHistoryPage
         $from       = isset($_GET['from']) ? sanitize_text_field($_GET['from']) : '';
         $to         = isset($_GET['to']) ? sanitize_text_field($_GET['to']) : '';
         $paged      = max(1, isset($_GET['paged']) ? absint($_GET['paged']) : 1);
-        $per_page   = 25;
+        $per_page   = 20;
 
         // Validate table; provide repair notice if needed
         $table_ok = $this->repository->table_is_valid();


### PR DESCRIPTION
## Summary
- Limit Message History pagination to 20 entries per page for both SMS and email tabs

## Testing
- `php -l includes/Admin/Pages/MessagesHistoryPage.php`


------
https://chatgpt.com/codex/tasks/task_e_68b619cd1b58832d8437e1d1b3421a60