### PR TITLE
Make message history page size configurable per tab

### DIFF
--- a/includes/Admin/Pages/MessagesHistoryPage.php
+++ b/includes/Admin/Pages/MessagesHistoryPage.php
@@ -127,7 +127,9 @@ class MessagesHistoryPage
         $from       = isset($_GET['from']) ? sanitize_text_field($_GET['from']) : '';
         $to         = isset($_GET['to']) ? sanitize_text_field($_GET['to']) : '';
         $paged      = max(1, isset($_GET['paged']) ? absint($_GET['paged']) : 1);
-        $per_page   = 25;
+        $per_page   = $active_tab === 'sms'
+            ? (int) get_option('kerbcycle_sms_history_per_page', 20)
+            : (int) get_option('kerbcycle_email_history_per_page', 20);
 
         // Validate table; provide repair notice if needed
         $table_ok = $this->repository->table_is_valid();
@@ -287,6 +289,23 @@ class MessagesHistoryPage
                     </a>
                 </form>
 
+                <?php if ($pages > 1) : ?>
+                    <div class="tablenav top" style="margin-bottom:12px;">
+                        <div class="tablenav-pages">
+                            <?php
+                            echo paginate_links([
+                                'base'      => esc_url(add_query_arg(['paged' => '%#%', 'tab' => $active_tab, 's' => $search, 'from' => $from, 'to' => $to], $base_url)),
+                                'format'    => '',
+                                'current'   => $paged,
+                                'total'     => $pages,
+                                'prev_text' => __('« Prev', 'kerbcycle'),
+                                'next_text' => __('Next »', 'kerbcycle'),
+                            ]);
+                            ?>
+                        </div>
+                    </div>
+                <?php endif; ?>
+
                 <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
                     <?php wp_nonce_field('kerbcycle_delete_logs'); ?>
                     <input type="hidden" name="action" value="kerbcycle_delete_logs" />
@@ -349,9 +368,8 @@ class MessagesHistoryPage
                     </button>
                 </form>
 
-                <?php
-                if ($pages > 1) : ?>
-                    <div class="tablenav" style="margin-top:12px;">
+                <?php if ($pages > 1) : ?>
+                    <div class="tablenav bottom" style="margin-top:12px;">
                         <div class="tablenav-pages">
                             <?php
                             echo paginate_links([

--- a/includes/Admin/Pages/SettingsPage.php
+++ b/includes/Admin/Pages/SettingsPage.php
@@ -59,6 +59,8 @@ class SettingsPage
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_scanner');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_codes_per_page');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_history_per_page');
+        register_setting('kerbcycle_qr_settings', 'kerbcycle_sms_history_per_page');
+        register_setting('kerbcycle_qr_settings', 'kerbcycle_email_history_per_page');
 
         add_settings_section(
             'kerbcycle_qr_main',
@@ -111,6 +113,22 @@ class SettingsPage
             'kerbcycle_history_per_page',
             __('History Entries per Page', 'kerbcycle'),
             [$this, 'render_history_per_page_field'],
+            'kerbcycle_qr_settings',
+            'kerbcycle_qr_main'
+        );
+
+        add_settings_field(
+            'kerbcycle_sms_history_per_page',
+            __('SMS History Entries per Page', 'kerbcycle'),
+            [$this, 'render_sms_history_per_page_field'],
+            'kerbcycle_qr_settings',
+            'kerbcycle_qr_main'
+        );
+
+        add_settings_field(
+            'kerbcycle_email_history_per_page',
+            __('Email History Entries per Page', 'kerbcycle'),
+            [$this, 'render_email_history_per_page_field'],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
@@ -167,6 +185,24 @@ class SettingsPage
         ?>
         <input type="number" min="1" name="kerbcycle_history_per_page" value="<?= esc_attr($value); ?>" />
         <span class="description"><?php esc_html_e('Number of history entries displayed per page', 'kerbcycle'); ?></span>
+        <?php
+    }
+
+    public function render_sms_history_per_page_field()
+    {
+        $value = get_option('kerbcycle_sms_history_per_page', 20);
+        ?>
+        <input type="number" min="1" name="kerbcycle_sms_history_per_page" value="<?= esc_attr($value); ?>" />
+        <span class="description"><?php esc_html_e('Number of SMS history entries displayed per page', 'kerbcycle'); ?></span>
+        <?php
+    }
+
+    public function render_email_history_per_page_field()
+    {
+        $value = get_option('kerbcycle_email_history_per_page', 20);
+        ?>
+        <input type="number" min="1" name="kerbcycle_email_history_per_page" value="<?= esc_attr($value); ?>" />
+        <span class="description"><?php esc_html_e('Number of email history entries displayed per page', 'kerbcycle'); ?></span>
         <?php
     }
 }


### PR DESCRIPTION
## Summary
- Add settings to customize SMS and email history entries per page individually
- Use selected settings to control pagination on Message History tabs

## Testing
- `php -l includes/Admin/Pages/SettingsPage.php`
- `php -l includes/Admin/Pages/MessagesHistoryPage.php`


------
https://chatgpt.com/codex/tasks/task_e_68b619cd1b58832d8437e1d1b3421a60