### PR TITLE
Track QR code status history in separate table

### DIFF
--- a/includes/Admin/Pages/HistoryPage.php
+++ b/includes/Admin/Pages/HistoryPage.php
@@ -23,7 +23,7 @@ class HistoryPage
     public function render()
     {
         global $wpdb;
-        $table_name   = $wpdb->prefix . 'kerbcycle_qr_codes';
+        $table_name   = $wpdb->prefix . 'kerbcycle_qr_code_history';
         $per_page     = (int) get_option('kerbcycle_history_per_page', 20);
         $current_page = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
         $offset       = ($current_page - 1) * $per_page;
@@ -42,18 +42,18 @@ class HistoryPage
         }
 
         if ($start_date) {
-            $where   .= ' AND DATE(assigned_at) >= %s';
+            $where   .= ' AND DATE(changed_at) >= %s';
             $params[] = $start_date;
         }
 
         if ($end_date) {
-            $where   .= ' AND DATE(assigned_at) <= %s';
+            $where   .= ' AND DATE(changed_at) <= %s';
             $params[] = $end_date;
         }
 
         if ($search) {
             $like     = '%' . $wpdb->esc_like($search) . '%';
-            $where   .= ' AND (CAST(id AS CHAR) LIKE %s OR qr_code LIKE %s OR CAST(user_id AS CHAR) LIKE %s OR CAST(assigned_at AS CHAR) LIKE %s)';
+            $where   .= ' AND (CAST(id AS CHAR) LIKE %s OR qr_code LIKE %s OR CAST(user_id AS CHAR) LIKE %s OR CAST(changed_at AS CHAR) LIKE %s)';
             $params[] = $like;
             $params[] = $like;
             $params[] = $like;
@@ -73,7 +73,7 @@ class HistoryPage
             'current'   => $current_page,
         ]) : '';
 
-        $select_sql = "SELECT * FROM $table_name WHERE $where ORDER BY assigned_at DESC LIMIT %d OFFSET %d";
+        $select_sql = "SELECT * FROM $table_name WHERE $where ORDER BY changed_at DESC LIMIT %d OFFSET %d";
         $query_args = array_merge($params, [$per_page, $offset]);
         $qr_codes   = $wpdb->get_results($wpdb->prepare($select_sql, $query_args));
         ?>
@@ -84,7 +84,9 @@ class HistoryPage
                 <select name="status_filter">
                     <option value=""><?php esc_html_e('All Statuses', 'kerbcycle'); ?></option>
                     <option value="assigned" <?php selected($status_filter, 'assigned'); ?>><?php esc_html_e('Assigned', 'kerbcycle'); ?></option>
-                    <option value="available" <?php selected($status_filter, 'available'); ?>><?php esc_html_e('Available', 'kerbcycle'); ?></option>
+                    <option value="released" <?php selected($status_filter, 'released'); ?>><?php esc_html_e('Released', 'kerbcycle'); ?></option>
+                    <option value="deleted" <?php selected($status_filter, 'deleted'); ?>><?php esc_html_e('Deleted', 'kerbcycle'); ?></option>
+                    <option value="added" <?php selected($status_filter, 'added'); ?>><?php esc_html_e('Added', 'kerbcycle'); ?></option>
                 </select>
                 <input type="date" name="start_date" value="<?= esc_attr($start_date); ?>" />
                 <input type="date" name="end_date" value="<?= esc_attr($end_date); ?>" />
@@ -92,7 +94,7 @@ class HistoryPage
                 <button class="button"><?php esc_html_e('Filter', 'kerbcycle'); ?></button>
                 <a href="<?php echo esc_url(admin_url('admin.php?page=kerbcycle-qr-history')); ?>" class="button"><?php esc_html_e('Reset', 'kerbcycle'); ?></a>
             </form>
-            <p class="description">Recent QR code assignments</p>
+            <p class="description">Recent QR code activity</p>
             <?php if ($pagination_links) : ?>
                 <div class="tablenav">
                     <div class="tablenav-pages">
@@ -107,7 +109,7 @@ class HistoryPage
                         <th>QR Code</th>
                         <th>User ID</th>
                         <th>Status</th>
-                        <th>Assigned At</th>
+                        <th>Changed At</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -118,7 +120,7 @@ class HistoryPage
                                 <td><?= esc_html($qr->qr_code) ?></td>
                                 <td><?= $qr->user_id ? esc_html($qr->user_id) : '—' ?></td>
                                 <td><?= esc_html(ucfirst($qr->status)) ?></td>
-                                <td><?= $qr->assigned_at ? esc_html($qr->assigned_at) : '—' ?></td>
+                                <td><?= $qr->changed_at ? esc_html($qr->changed_at) : '—' ?></td>
                             </tr>
                         <?php endforeach; ?>
                     <?php else : ?>

--- a/includes/Data/Repositories/QrCodeHistoryRepository.php
+++ b/includes/Data/Repositories/QrCodeHistoryRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kerbcycle\QrCode\Data\Repositories;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Repository for QR code history.
+ *
+ * @since      1.0.0
+ * @package    Kerbcycle\QrCode
+ * @subpackage Kerbcycle\QrCode\Data\Repositories
+ */
+class QrCodeHistoryRepository
+{
+    private $table;
+
+    public function __construct()
+    {
+        global $wpdb;
+        $this->table = $wpdb->prefix . 'kerbcycle_qr_code_history';
+    }
+
+    public function log($qr_code, $user_id, $status)
+    {
+        global $wpdb;
+        return $wpdb->insert(
+            $this->table,
+            [
+                'qr_code'   => $qr_code,
+                'user_id'   => $user_id,
+                'status'    => $status,
+                'changed_at'=> current_time('mysql'),
+            ],
+            ['%s', '%d', '%s', '%s']
+        );
+    }
+
+    public function recent($limit)
+    {
+        global $wpdb;
+        $limit = absint($limit);
+        return $wpdb->get_results(
+            $wpdb->prepare("SELECT * FROM $this->table ORDER BY changed_at DESC LIMIT %d", $limit)
+        );
+    }
+}

--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -45,6 +45,22 @@ class Activator
         require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
         dbDelta($sql);
 
+        // Create QR code history table
+        $history_table = $wpdb->prefix . 'kerbcycle_qr_code_history';
+        $sql = "CREATE TABLE $history_table (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            qr_code varchar(255) NOT NULL,
+            user_id mediumint(9),
+            status varchar(20) NOT NULL,
+            changed_at datetime DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            KEY qr_code_idx (qr_code),
+            KEY status_idx (status),
+            KEY changed_idx (changed_at)
+        ) $charset_collate;";
+
+        dbDelta($sql);
+
         // Create message logs table
         $table_name = $wpdb->prefix . 'kerbcycle_message_logs';
 


### PR DESCRIPTION
## Summary
- log QR code status changes (added, assigned, released, deleted)
- display history from new `kerbcycle_qr_code_history` table
- create history table during plugin activation

## Testing
- `php -l includes/Data/Repositories/QrCodeHistoryRepository.php`
- `php -l includes/Data/Repositories/QrCodeRepository.php`
- `php -l includes/Admin/Pages/HistoryPage.php`
- `php -l includes/Install/Activator.php`


------
https://chatgpt.com/codex/tasks/task_e_68b630ed6b70832dba70fa85675ea39d