### PR TITLE
Add Customer display name column for QR codes

### DIFF
--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -53,7 +53,8 @@ class DashboardPage
 
         if ($search) {
             $like     = '%' . $wpdb->esc_like($search) . '%';
-            $where   .= ' AND (CAST(id AS CHAR) LIKE %s OR qr_code LIKE %s OR CAST(user_id AS CHAR) LIKE %s OR CAST(assigned_at AS CHAR) LIKE %s)';
+            $where   .= ' AND (CAST(id AS CHAR) LIKE %s OR qr_code LIKE %s OR CAST(user_id AS CHAR) LIKE %s OR display_name LIKE %s OR CAST(assigned_at AS CHAR) LIKE %s)';
+            $params[] = $like;
             $params[] = $like;
             $params[] = $like;
             $params[] = $like;
@@ -75,7 +76,7 @@ class DashboardPage
 
         $available_codes = $wpdb->get_results("SELECT qr_code FROM $table WHERE status = 'available' ORDER BY id DESC");
 
-        $select_sql = "SELECT id, qr_code, user_id, status, assigned_at FROM $table WHERE $where ORDER BY id DESC LIMIT %d OFFSET %d";
+        $select_sql = "SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $table WHERE $where ORDER BY id DESC LIMIT %d OFFSET %d";
         $query_args = array_merge($params, [$per_page, $offset]);
         $all_codes  = $wpdb->get_results($wpdb->prepare($select_sql, $query_args));
         ?>
@@ -108,6 +109,10 @@ class DashboardPage
             }
             .qr-id, .qr-user, .qr-status {
                 flex-basis: 80px;
+                padding: 0 8px;
+            }
+            .qr-name {
+                flex-basis: 150px;
                 padding: 0 8px;
             }
             .qr-text {
@@ -199,6 +204,7 @@ class DashboardPage
                         <span class="qr-id"><?php esc_html_e('ID', 'kerbcycle'); ?></span>
                         <span class="qr-text"><?php esc_html_e('QR Code', 'kerbcycle'); ?></span>
                         <span class="qr-user"><?php esc_html_e('User ID', 'kerbcycle'); ?></span>
+                        <span class="qr-name"><?php esc_html_e('Customer', 'kerbcycle'); ?></span>
                         <span class="qr-status"><?php esc_html_e('Status', 'kerbcycle'); ?></span>
                         <span class="qr-assigned"><?php esc_html_e('Assigned At', 'kerbcycle'); ?></span>
                     </li>
@@ -208,6 +214,7 @@ class DashboardPage
                             <span class="qr-id"><?= esc_html($code->id); ?></span>
                             <span class="qr-text" contenteditable="true"><?= esc_html($code->qr_code); ?></span>
                             <span class="qr-user"><?= $code->user_id ? esc_html($code->user_id) : '—'; ?></span>
+                            <span class="qr-name"><?= $code->display_name ? esc_html($code->display_name) : '—'; ?></span>
                             <span class="qr-status"><?= esc_html(ucfirst($code->status)); ?></span>
                             <span class="qr-assigned"><?= $code->assigned_at ? esc_html($code->assigned_at) : '—'; ?></span>
                         </li>

--- a/includes/Api/Controllers/QrController.php
+++ b/includes/Api/Controllers/QrController.php
@@ -41,15 +41,18 @@ class QrController
         global $wpdb;
         $table = $wpdb->prefix . 'kerbcycle_qr_codes';
 
+        $user  = get_userdata($user_id);
+        $name  = $user ? $user->display_name : '';
         $result = $wpdb->insert(
             $table,
             [
-                'qr_code' => $qr_code,
-                'user_id' => $user_id,
-                'status' => 'assigned',
+                'qr_code'     => $qr_code,
+                'user_id'     => $user_id,
+                'display_name'=> $name,
+                'status'      => 'assigned',
                 'assigned_at' => current_time('mysql')
             ],
-            ['%s', '%d', '%s', '%s']
+            ['%s', '%d', '%s', '%s', '%s']
         );
 
         if ($result === false) {
@@ -60,10 +63,11 @@ class QrController
         }
 
         return new WP_REST_Response([
-            'success' => true,
-            'message' => 'QR code processed',
-            'qr_code' => $qr_code,
-            'user_id' => $user_id
+            'success'      => true,
+            'message'      => 'QR code processed',
+            'qr_code'      => $qr_code,
+            'user_id'      => $user_id,
+            'display_name' => $name,
         ], 200);
     }
 

--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -44,7 +44,7 @@ class QrCodeRepository
         return $result;
     }
 
-    public function insert_assigned($qr_code, $user_id)
+    public function insert_assigned($qr_code, $user_id, $display_name)
     {
         global $wpdb;
         $result = $wpdb->insert(
@@ -52,10 +52,11 @@ class QrCodeRepository
             [
                 'qr_code'     => $qr_code,
                 'user_id'     => $user_id,
+                'display_name'=> $display_name,
                 'status'      => 'assigned',
                 'assigned_at' => current_time('mysql')
             ],
-            ['%s', '%d', '%s', '%s']
+            ['%s', '%d', '%s', '%s', '%s']
         );
 
         if ($result !== false) {
@@ -79,12 +80,13 @@ class QrCodeRepository
             $result = $wpdb->update(
                 $this->table,
                 [
-                    'user_id'     => null,
-                    'status'      => 'available',
-                    'assigned_at' => null,
+                    'user_id'      => null,
+                    'status'       => 'available',
+                    'assigned_at'  => null,
+                    'display_name' => null,
                 ],
                 ['id' => $row->id],
-                ['%d', '%s', '%s'],
+                ['%d', '%s', '%s', '%s'],
                 ['%d']
             );
 
@@ -113,12 +115,13 @@ class QrCodeRepository
                 $result = $wpdb->update(
                     $this->table,
                     [
-                        'user_id'     => null,
-                        'status'      => 'available',
-                        'assigned_at' => null,
+                        'user_id'      => null,
+                        'status'       => 'available',
+                        'assigned_at'  => null,
+                        'display_name' => null,
                     ],
                     ['id' => $row->id],
-                    ['%d', '%s', '%s'],
+                    ['%d', '%s', '%s', '%s'],
                     ['%d']
                 );
 
@@ -192,7 +195,7 @@ class QrCodeRepository
     public function list_all()
     {
         global $wpdb;
-        return $wpdb->get_results("SELECT id, qr_code, user_id, status, assigned_at FROM $this->table ORDER BY id DESC");
+        return $wpdb->get_results("SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $this->table ORDER BY id DESC");
     }
 
     public function recent_history($limit)
@@ -201,9 +204,9 @@ class QrCodeRepository
     }
 
     // Legacy wrappers
-    public function assign($qr_code, $user_id)
+    public function assign($qr_code, $user_id, $display_name = '')
     {
-        return $this->insert_assigned($qr_code, $user_id);
+        return $this->insert_assigned($qr_code, $user_id, $display_name);
     }
 
     public function add($qr_code)

--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -36,6 +36,7 @@ class Activator
             id mediumint(9) NOT NULL AUTO_INCREMENT,
             qr_code varchar(255) NOT NULL,
             user_id mediumint(9),
+            display_name varchar(255) DEFAULT NULL,
             status varchar(20) DEFAULT 'available',
             assigned_at datetime DEFAULT NULL,
             created_at datetime DEFAULT CURRENT_TIMESTAMP,

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -56,7 +56,7 @@ class Shortcodes
     {
         global $wpdb;
         $table = $wpdb->prefix . 'kerbcycle_qr_codes';
-        $codes = $wpdb->get_results("SELECT id, qr_code, user_id, status, assigned_at FROM $table ORDER BY id DESC");
+        $codes = $wpdb->get_results("SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $table ORDER BY id DESC");
 
         ob_start();
         ?>
@@ -83,6 +83,7 @@ class Shortcodes
                     <th><?php esc_html_e('ID', 'kerbcycle'); ?></th>
                     <th><?php esc_html_e('QR Code', 'kerbcycle'); ?></th>
                     <th><?php esc_html_e('User ID', 'kerbcycle'); ?></th>
+                    <th><?php esc_html_e('Customer', 'kerbcycle'); ?></th>
                     <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
                     <th><?php esc_html_e('Assigned At', 'kerbcycle'); ?></th>
                 </tr>
@@ -94,13 +95,14 @@ class Shortcodes
                             <td><?= esc_html($code->id); ?></td>
                             <td><?= esc_html($code->qr_code); ?></td>
                             <td><?= $code->user_id ? esc_html($code->user_id) : '—'; ?></td>
+                            <td><?= $code->display_name ? esc_html($code->display_name) : '—'; ?></td>
                             <td><?= esc_html(ucfirst($code->status)); ?></td>
                             <td><?= $code->assigned_at ? esc_html($code->assigned_at) : '—'; ?></td>
                         </tr>
                     <?php endforeach; ?>
                 <?php else : ?>
                     <tr>
-                        <td colspan="5" class="description"><?php esc_html_e('No QR codes found', 'kerbcycle'); ?></td>
+                        <td colspan="6" class="description"><?php esc_html_e('No QR codes found', 'kerbcycle'); ?></td>
                     </tr>
                 <?php endif; ?>
             </tbody>

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -36,7 +36,9 @@ class QrService
 
     public function assign($qr_code, $user_id, $send_email, $send_sms, $send_reminder)
     {
-        $result = $this->repository->insert_assigned($qr_code, $user_id);
+        $user      = get_userdata($user_id);
+        $name      = $user ? $user->display_name : '';
+        $result = $this->repository->insert_assigned($qr_code, $user_id, $name);
 
         if ($result === false) {
             return new \WP_Error('db_error', 'Failed to assign QR code in database.');


### PR DESCRIPTION
## Summary
- add `display_name` column to QR code table and persist customer names
- show new "Customer" column on admin and public QR code lists
- include display names in API responses

## Testing
- `php -l includes/Install/Activator.php`
- `php -l includes/Data/Repositories/QrCodeRepository.php`
- `php -l includes/Services/QrService.php`
- `php -l includes/Admin/Pages/DashboardPage.php`
- `php -l includes/Public/Shortcodes.php`
- `php -l includes/Api/Controllers/QrController.php`


------
https://chatgpt.com/codex/tasks/task_e_68b64f344d18832da405b7925ad6b865