### PR TITLE
Rename admin menu items and reorder integrations

### DIFF
--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -33,8 +33,8 @@ class Admin
     public function register_admin_menu()
     {
         add_menu_page(
-            'QR Code Manager',
-            'QR Codes',
+            'QR Code Management',
+            'QR Code Management',
             'manage_options',
             'kerbcycle-qr-manager',
             [new Pages\DashboardPage(), 'render'],
@@ -45,7 +45,7 @@ class Admin
         add_submenu_page(
             'kerbcycle-qr-manager',
             'QR Code History',
-            'History',
+            'QR Code History',
             'manage_options',
             'kerbcycle-qr-history',
             [new Pages\HistoryPage(), 'render']
@@ -106,17 +106,8 @@ class Admin
 
         add_submenu_page(
             'kerbcycle-qr-manager',
-            'Plugin Integrations',
-            'Integrations',
-            'manage_options',
-            'kerbcycle-plugin-integrations',
-            [new Pages\IntegrationsPage(), 'render']
-        );
-
-        add_submenu_page(
-            'kerbcycle-qr-manager',
-            'Messages',
-            'Messages',
+            'Message Settings',
+            'Message Settings',
             'manage_options',
             'kerbcycle-messages',
             [new \Kerbcycle\QrCode\Services\MessagesService(), 'render_page']
@@ -129,6 +120,15 @@ class Admin
             'manage_options',
             'kerbcycle-sms',
             ['\Kerbcycle\QrCode\Services\SmsService', 'render_settings_page']
+        );
+
+        add_submenu_page(
+            'kerbcycle-qr-manager',
+            'Plugin Integrations',
+            'Integrations',
+            'manage_options',
+            'kerbcycle-plugin-integrations',
+            [new Pages\IntegrationsPage(), 'render']
         );
     }
 }

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -125,7 +125,7 @@ class DashboardPage
             }
         </style>
         <div class="wrap">
-            <h1>KerbCycle QR Code Manager</h1>
+            <h1>KerbCycle QR Code Management</h1>
             <div class="notice notice-info">
                 <p><?php esc_html_e('Select a customer and scan or choose a QR code to assign.', 'kerbcycle'); ?></p>
             </div>

--- a/includes/Services/MessagesService.php
+++ b/includes/Services/MessagesService.php
@@ -53,8 +53,8 @@ class MessagesService {
     public static function admin_menu() {
         add_submenu_page(
             'kerbcycle-qr-manager',
-            'KerbCycle Messages',
-            'Messages',
+            'KerbCycle Message Settings',
+            'Message Settings',
             'manage_options',
             'kerbcycle-messages',
             [__CLASS__, 'render_page']
@@ -156,7 +156,7 @@ class MessagesService {
         $types = self::types_map();
         ?>
         <div class="wrap">
-            <h1>KerbCycle Messages</h1>
+            <h1>KerbCycle Message Settings</h1>
             <h2 class="nav-tab-wrapper">
                 <a href="<?php echo esc_url(admin_url('admin.php?page=kerbcycle-messages&tab=edit')); ?>" class="nav-tab <?php echo $tab === 'edit' ? 'nav-tab-active' : ''; ?>">Edit Messages</a>
                 <a href="<?php echo esc_url(admin_url('admin.php?page=kerbcycle-messages&tab=test')); ?>" class="nav-tab <?php echo $tab === 'test' ? 'nav-tab-active' : ''; ?>">Test messages</a>


### PR DESCRIPTION
## Summary
- rename QR Codes main menu to QR Code Management
- label History submenu as QR Code History
- retitle Messages admin page to Message Settings and move Integrations to the end

## Testing
- `php -l includes/Admin/Admin.php`
- `php -l includes/Services/MessagesService.php`
- `php -l includes/Admin/Pages/DashboardPage.php`


------
https://chatgpt.com/codex/tasks/task_e_68b74dd300dc832db871272e7813c474