### PR TITLE
Use generic dashicon for admin menu

### DIFF
--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -38,7 +38,7 @@ class Admin
             'manage_options',
             'kerbcycle-qr-manager',
             [new Pages\DashboardPage(), 'render'],
-            'dashicons-qrcode',
+            'dashicons-admin-generic',
             20
         );
 


### PR DESCRIPTION
## Summary
- Display a generic Dashicon in the plugin's admin menu

## Testing
- `php -l includes/Admin/Admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68b75869b6a8832d833d6117617e1093