### PR TITLE
Improve OSRM test error reporting

### DIFF
--- a/includes/Admin/Pages/OsrmPage.php
+++ b/includes/Admin/Pages/OsrmPage.php
@@ -182,8 +182,15 @@ class OsrmPage
                         method: 'POST',
                         headers: {'Content-Type':'application/x-www-form-urlencoded'},
                         body: 'action=kc_osrm_test&_wpnonce=<?php echo wp_create_nonce('kc_osrm_test'); ?>'
-                    }).then(r=>r.json()).then(j=>{
-                        out.textContent = j.ok ? 'OK ('+j.ms+' ms)' : ('Error: '+(j.error||'unknown'));
+                    }).then(r=>r.text()).then(t=>{
+                        let j;
+                        try {
+                            j = JSON.parse(t);
+                        } catch(e) {
+                            out.textContent = 'Error: ' + t;
+                            return;
+                        }
+                        out.textContent = j.ok ? 'OK ('+j.ms+' ms)' : ('Error: ' + (typeof j.error !== 'undefined' ? j.error : 'unknown'));
                     }).catch(e=>{
                         out.textContent = 'Error: ' + e;
                     });


### PR DESCRIPTION
## Summary
- handle non-JSON admin-ajax responses in OSRM settings quick test
- surface any returned text when JSON parsing fails

## Testing
- `php -l includes/Admin/Pages/OsrmPage.php`

------
https://chatgpt.com/codex/tasks/task_e_68b8d234830c832db3a8c894eaa8fd6f