### PR TITLE
Enhance QR Code generator options

### DIFF
--- a/assets/css/qr-generator.css
+++ b/assets/css/qr-generator.css
@@ -1,0 +1,8 @@
+.kc-card { background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:16px; margin-top:16px; }
+.kc-row { display:flex; gap:12px; align-items:center; margin:8px 0; }
+.kc-row label { width:160px; font-weight:600; }
+.kc-row input, .kc-row select { min-width:260px; }
+.kc-grid { display:grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap:16px; margin-top:16px; }
+.kc-card-grid { text-align:center; padding:12px; }
+.kc-card-grid .kc-code { margin-top:8px; font-weight:600; word-break:break-all; }
+.kc-qr canvas { padding:8px; background:#fff; }

--- a/assets/js/qr-generator.js
+++ b/assets/js/qr-generator.js
@@ -1,0 +1,61 @@
+(function($){
+  function toggleMode() {
+    const mode = $('#kc-gen-mode').val();
+    $('.kc-if-single').toggle(mode === 'single');
+    $('.kc-if-random').toggle(mode === 'random');
+    $('.kc-if-seq').toggle(mode === 'sequential');
+  }
+
+  $('#kc-gen-mode').on('change', toggleMode);
+  toggleMode();
+
+  $('#kc-generate-btn').on('click', function(){
+    const mode = $('#kc-gen-mode').val();
+    const payload = {
+      action: 'kerbcycle_generate_qr',
+      nonce: KerbcycleQRGen.nonce,
+      mode,
+      genType: mode
+    };
+
+    if (mode === 'single') {
+      payload.code = $('#kc-code').val().trim();
+    } else if (mode === 'random') {
+      payload.count  = parseInt($('#kc-count').val(), 10) || 1;
+      payload.prefix = $('#kc-prefix').val().trim();
+      payload.length = parseInt($('#kc-length').val(), 10) || 8;
+    } else if (mode === 'sequential') {
+      payload.seqPrefix = $('#kc-seq-prefix').val().trim();
+      payload.seqStart  = parseInt($('#kc-seq-start').val(), 10) || 1;
+      payload.seqCount  = parseInt($('#kc-seq-count').val(), 10) || 1;
+      payload.seqPad    = parseInt($('#kc-seq-pad').val(), 10) || 4;
+    }
+
+    const $btn = $(this).prop('disabled', true).text('Generating...');
+    $.post(KerbcycleQRGen.ajaxUrl, payload).done(function(resp){
+      $btn.prop('disabled', false).text('Generate & Save');
+      if (!resp || !resp.success) {
+        alert((resp && resp.data && resp.data.message) || 'Failed.');
+        return;
+      }
+      const saved   = resp.data.saved || [];
+      const skipped = resp.data.skipped || [];
+      const $out = $('#kc-generate-result').empty();
+
+      saved.forEach(function(code){
+        const card = $('<div class="kc-card kc-card-grid"></div>');
+        const qr   = $('<div class="kc-qr"></div>').appendTo(card);
+        $('<div class="kc-code"></div>').text(code).appendTo(card);
+        $out.append(card);
+        new QRCode(qr[0], { text: code, width: 128, height: 128, correctLevel: QRCode.CorrectLevel.M });
+      });
+
+      if (skipped.length) {
+        alert('Skipped existing duplicates:\n' + skipped.join(', '));
+      }
+    }).fail(function(){
+      $btn.prop('disabled', false).text('Generate & Save');
+      alert('Request failed.');
+    });
+  });
+})(jQuery);

--- a/assets/js/qrcode.min.js
+++ b/assets/js/qrcode.min.js
@@ -1,0 +1,116 @@
+/*
+ * Minimal QRCode generator (simplified).
+ * Provides QRCode global with makeCode() to draw codes on a canvas.
+ */
+(function(){
+  function QRCode(el, opts){
+    if(typeof el === 'string') el = document.getElementById(el);
+    this._el = el;
+    this._opts = opts || {};
+    this._opts.width = this._opts.width || 128;
+    this._opts.height = this._opts.height || 128;
+    if(this._opts.text){
+      this.makeCode(this._opts.text);
+    }
+  }
+  QRCode.CorrectLevel = {L:1,M:0,Q:3,H:2};
+  QRCode.prototype.makeCode = function(text){
+    var modules = buildMatrix(text);
+    var size = modules.length;
+    var scaleX = this._opts.width / size;
+    var scaleY = this._opts.height / size;
+    var canvas = document.createElement('canvas');
+    canvas.width = this._opts.width;
+    canvas.height = this._opts.height;
+    var ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(0,0,canvas.width,canvas.height);
+    ctx.fillStyle = '#000';
+    for(var r=0;r<size;r++){
+      for(var c=0;c<size;c++){
+        if(modules[r][c]) ctx.fillRect(c*scaleX,r*scaleY,scaleX,scaleY);
+      }
+    }
+    this._el.innerHTML='';
+    this._el.appendChild(canvas);
+  };
+
+  function buildMatrix(text){
+    var data=[];
+    for(var i=0;i<text.length;i++) data.push(text.charCodeAt(i) & 0xff);
+    var buffer=[];
+    buffer.push(0x40 | (text.length>>4));
+    buffer.push(((text.length&0xf)<<4) | (data[0]>>4));
+    var idx=1,cur=data[0]&0xf;
+    while(idx<data.length){
+      buffer.push((cur<<4)|(data[idx]>>4));
+      cur=data[idx]&0xf;idx++;
+    }
+    buffer.push(cur<<4);
+    while(buffer.length<16) buffer.push(buffer.length%2?0x11:0xec);
+    var ecc = rs(buffer,10);
+    var codewords = buffer.concat(ecc);
+    var size=21,modules=new Array(size);
+    for(i=0;i<size;i++){modules[i]=new Array(size);for(var j=0;j<size;j++)modules[i][j]=null;}
+    placeFinder(0,0,modules);placeFinder(size-7,0,modules);placeFinder(0,size-7,modules);
+    for(i=8;i<size-8;i++){modules[6][i]=i%2===0;modules[i][6]=i%2===0;}
+    modules[size-8][8]=true;
+    var row=size-1,col=size-1,dir=-1,byteIdx=0,bitIdx=7;
+    while(col>0){
+      if(col===6) col--;
+      for(var k=0;k<size;k++){
+        var r=row+dir*k;
+        for(var c=0;c<2;c++){
+          var x=col-c,y=r;
+          if(modules[y][x]==null){
+            var bit=(codewords[byteIdx]>>>bitIdx)&1;
+            modules[y][x]=((x+y)%2===0)?!bit:bit;
+            bitIdx--;
+            if(bitIdx<0){byteIdx++;bitIdx=7;}
+          }
+        }
+      }
+      row+=dir*(size-1);dir=-dir;col-=2;
+    }
+    var format=0b101010000010010;
+    for(i=0;i<15;i++){
+      var b=(format>>>i)&1;
+      if(i<6) modules[i][8]=b; else if(i<8) modules[i+1][8]=b; else modules[size-15+i][8]=b;
+      if(i<8) modules[8][size-1-i]=b; else if(i<9) modules[8][15-i]=b; else modules[8][14-i]=b;
+    }
+    return modules;
+  }
+  function placeFinder(r,c,m){
+    for(var i=-1;i<8;i++){
+      for(var j=-1;j<8;j++){
+        var y=r+i,x=c+j;
+        if(y<0||x<0||y>=m.length||x>=m.length) continue;
+        if((i>=0&&i<=6&&(j==0||j==6))||(j>=0&&j<=6&&(i==0||i==6))||(i>=2&&i<=4&&j>=2&&j<=4)) m[y][x]=true; else m[y][x]=false;
+      }
+    }
+  }
+  var GF256_EXP=new Array(512),GF256_LOG=new Array(256);
+  (function(){
+    var x=1;for(var i=0;i<255;i++){GF256_EXP[i]=x;GF256_LOG[x]=i;x<<=1;if(x&0x100)x^=0x11d;}for(i=255;i<512;i++)GF256_EXP[i]=GF256_EXP[i-255];
+  })();
+  function rs(data,ec){
+    var poly=[1];
+    for(var i=0;i<ec;i++) poly=polyMul(poly,[1,GF256_EXP[i]]);
+    var buf=data.slice();
+    for(i=0;i<ec;i++) buf.push(0);
+    for(i=0;i<data.length;i++){
+      var coef=buf[i];
+      if(coef!==0){
+        var log=GF256_LOG[coef];
+        for(var j=0;j<poly.length;j++) buf[i+j]^=GF256_EXP[log+GF256_LOG[poly[j]]];
+      }
+    }
+    return buf.slice(data.length);
+  }
+  function polyMul(a,b){
+    var res=new Array(a.length+b.length-1).fill(0);
+    for(var i=0;i<a.length;i++) for(var j=0;j<b.length;j++) if(a[i]&&b[j]) res[i+j]^=GF256_EXP[GF256_LOG[a[i]]+GF256_LOG[b[j]]];
+    return res;
+  }
+  window.QRCode=QRCode;
+})();

--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -69,6 +69,16 @@ class Admin
             [new Pages\ReportsPage(), 'render']
         );
 
+        $generator = Pages\GeneratorPage::instance();
+        add_submenu_page(
+            'kerbcycle-qr-manager',
+            'QR Code Generator',
+            'QR Code Generate',
+            'manage_options',
+            'kerbcycle-qr-generator',
+            [$generator, 'render']
+        );
+
         // Shortcut to Bookly appointments if Bookly is active
         $bookly_active = class_exists('Bookly\\Lib\\Plugin') || defined('BOOKLY_VERSION');
         if ($bookly_active) {

--- a/includes/Admin/Pages/GeneratorPage.php
+++ b/includes/Admin/Pages/GeneratorPage.php
@@ -1,0 +1,523 @@
+<?php
+
+namespace Kerbcycle\QrCode\Admin\Pages;
+
+use Kerbcycle\QrCode\Data\Repositories\QrRepoRepository;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Admin page for generating QR codes.
+ */
+class GeneratorPage
+{
+    /** @var self */
+    private static $instance;
+
+    /**
+     * Singleton instance.
+     */
+    public static function instance(): self
+    {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct()
+    {
+        add_action('admin_enqueue_scripts', [$this, 'assets']);
+        add_action('wp_ajax_kerbcycle_generate_qr', [$this, 'ajax_generate_qr']);
+        add_action('admin_post_kerbcycle_export_qr_csv', [$this, 'handle_export_csv']);
+    }
+
+    /**
+     * Register assets for the generator page.
+     */
+    public function assets($hook)
+    {
+        if (strpos($hook, 'kerbcycle-qr-generator') === false) {
+            return;
+        }
+
+        wp_enqueue_script(
+            'kerbcycle-qrcode',
+            KERBCYCLE_QR_URL . 'assets/js/qrcode.min.js',
+            [],
+            '1.0.0',
+            true
+        );
+
+        wp_enqueue_script(
+            'kerbcycle-qr-generator',
+            KERBCYCLE_QR_URL . 'assets/js/qr-generator.js',
+            ['jquery', 'kerbcycle-qrcode'],
+            '1.0.0',
+            true
+        );
+
+        wp_localize_script('kerbcycle-qr-generator', 'KerbcycleQRGen', [
+            'ajaxUrl' => admin_url('admin-ajax.php'),
+            'nonce'   => wp_create_nonce('kerbcycle_generate_qr'),
+        ]);
+
+        wp_enqueue_style(
+            'kerbcycle-qr-generator',
+            KERBCYCLE_QR_URL . 'assets/css/qr-generator.css',
+            [],
+            '1.0.0'
+        );
+    }
+
+    /**
+     * Render the admin page.
+     */
+    public function render()
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die('Insufficient permissions.');
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('QR Code Generator', 'kerbcycle'); ?></h1>
+
+            <div class="kc-card">
+                <h2><?php esc_html_e('Generate Codes', 'kerbcycle'); ?></h2>
+                <form id="kc-generate-form" onsubmit="return false;">
+  <div class="kc-row">
+    <label><?php esc_html_e('Mode', 'kerbcycle'); ?></label>
+    <select id="kc-gen-mode">
+      <option value="random"><?php esc_html_e('Random', 'kerbcycle'); ?></option>
+      <option value="sequential"><?php esc_html_e('Sequential', 'kerbcycle'); ?></option>
+      <option value="single"><?php esc_html_e('Single', 'kerbcycle'); ?></option>
+    </select>
+  </div>
+
+  <!-- Single -->
+  <div class="kc-row kc-if-single" style="display:none;">
+    <label><?php esc_html_e('Code', 'kerbcycle'); ?></label>
+    <input type="text" id="kc-code" placeholder="e.g. KC-2025-0001" />
+  </div>
+
+  <!-- Random -->
+  <div class="kc-row kc-if-random">
+    <label><?php esc_html_e('How many?', 'kerbcycle'); ?></label>
+    <input type="number" id="kc-count" min="1" max="5000" value="20" />
+  </div>
+  <div class="kc-row kc-if-random">
+    <label><?php esc_html_e('Prefix (optional)', 'kerbcycle'); ?></label>
+    <input type="text" id="kc-prefix" placeholder="e.g. KC-2025-" />
+  </div>
+  <div class="kc-row kc-if-random">
+    <label><?php esc_html_e('Length (random part)', 'kerbcycle'); ?></label>
+    <input type="number" id="kc-length" min="4" max="16" value="8" />
+  </div>
+
+  <!-- Sequential -->
+  <div class="kc-row kc-if-seq" style="display:none;">
+    <label><?php esc_html_e('Prefix', 'kerbcycle'); ?></label>
+    <input type="text" id="kc-seq-prefix" placeholder="e.g. KC-2025-" />
+  </div>
+  <div class="kc-row kc-if-seq" style="display:none;">
+    <label><?php esc_html_e('Start #', 'kerbcycle'); ?></label>
+    <input type="number" id="kc-seq-start" min="0" value="1" />
+  </div>
+  <div class="kc-row kc-if-seq" style="display:none;">
+    <label><?php esc_html_e('Count', 'kerbcycle'); ?></label>
+    <input type="number" id="kc-seq-count" min="1" max="5000" value="100" />
+  </div>
+  <div class="kc-row kc-if-seq" style="display:none;">
+    <label><?php esc_html_e('Pad Length', 'kerbcycle'); ?></label>
+    <input type="number" id="kc-seq-pad" min="1" max="10" value="4" />
+  </div>
+
+  <div class="kc-row">
+    <button class="button button-primary" id="kc-generate-btn"><?php esc_html_e('Generate & Save', 'kerbcycle'); ?></button>
+  </div>
+  <p class="description"><?php esc_html_e('Only unique codes are saved; duplicates are skipped.', 'kerbcycle'); ?></p>
+</form>
+<div id="kc-generate-result" class="kc-grid"></div>
+            </div>
+
+            <div class="kc-card">
+                <h2><?php esc_html_e('Export Repository (Date Range)', 'kerbcycle'); ?></h2>
+                <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                    <?php wp_nonce_field('kerbcycle_export_qr_csv', 'kc_export_nonce'); ?>
+                    <input type="hidden" name="action" value="kerbcycle_export_qr_csv" />
+                    <div class="kc-row">
+                        <label><?php esc_html_e('From', 'kerbcycle'); ?></label>
+                        <input type="date" name="from" required />
+                    </div>
+                    <div class="kc-row">
+                        <label><?php esc_html_e('To', 'kerbcycle'); ?></label>
+                        <input type="date" name="to" required />
+                    </div>
+                    <div class="kc-row">
+                        <label><?php esc_html_e('Export Type', 'kerbcycle'); ?></label>
+                        <select name="format">
+  <option value="print"><?php esc_html_e('Printable Sheet (grid)', 'kerbcycle'); ?></option>
+  <option value="print_labels_5160"><?php esc_html_e('Avery 5160 Labels (3×10)', 'kerbcycle'); ?></option>
+  <option value="csv"><?php esc_html_e('CSV file', 'kerbcycle'); ?></option>
+  <option value="zip_png"><?php esc_html_e('ZIP of PNG images', 'kerbcycle'); ?></option>
+  <option value="zip_svg"><?php esc_html_e('ZIP of SVG images', 'kerbcycle'); ?></option>
+</select>
+                    </div>
+                    <div class="kc-row">
+                        <button class="button"><?php esc_html_e('Export', 'kerbcycle'); ?></button>
+                    </div>
+                    <p class="description"><?php esc_html_e('“Printable Sheet” opens a formatted page you can print to paper or PDF. “CSV” downloads code data.', 'kerbcycle'); ?></p>
+                </form>
+            </div>
+        </div>
+        <?php
+    }
+
+    /**
+     * AJAX: generate and save unique codes.
+     */
+    public function ajax_generate_qr()
+    {
+        check_ajax_referer('kerbcycle_generate_qr', 'nonce');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => 'No permission'], 403);
+        }
+
+        $repo = new QrRepoRepository();
+        $user = get_current_user_id();
+        $raw_mode = isset($_POST['mode']) ? $_POST['mode'] : ($_POST['genType'] ?? 'single');
+        $mode = sanitize_text_field($raw_mode);
+        $allowed = ['single', 'random', 'sequential'];
+        if (!in_array($mode, $allowed, true)) {
+            $mode = 'single';
+        }
+        $result = ['saved' => [], 'skipped' => []];
+
+        if ($mode === 'single') {
+            $code = trim(sanitize_text_field($_POST['code'] ?? ''));
+            if ($code === '') {
+                wp_send_json_error(['message' => 'Code required.'], 400);
+            }
+
+            if ($repo->exists($code)) {
+                $result['skipped'][] = $code;
+            } else {
+                $repo->insert($code, $user);
+                $result['saved'][] = $code;
+            }
+            wp_send_json_success($result);
+        }
+
+        if ($mode === 'sequential') {
+            $prefix = sanitize_text_field($_POST['seqPrefix'] ?? '');
+            $start  = max(0, intval($_POST['seqStart'] ?? 1));
+            $count  = max(1, min(5000, intval($_POST['seqCount'] ?? 100)));
+            $pad    = max(1, min(10, intval($_POST['seqPad'] ?? 4)));
+
+            for ($i = 0; $i < $count; $i++) {
+                $num  = $start + $i;
+                $code = $prefix . str_pad((string) $num, $pad, '0', STR_PAD_LEFT);
+
+                if ($repo->exists($code)) {
+                    $result['skipped'][] = $code;
+                    continue;
+                }
+
+                $repo->insert($code, $user);
+                $result['saved'][] = $code;
+            }
+
+            wp_send_json_success($result);
+        }
+
+        // Random mode
+        $count  = max(1, min(5000, intval($_POST['count'] ?? 20)));
+        $prefix = sanitize_text_field($_POST['prefix'] ?? '');
+        $len    = max(4, min(16, intval($_POST['length'] ?? 8)));
+
+        for ($i = 0; $i < $count; $i++) {
+            $rand = wp_generate_password($len, false, false);
+            $code = $prefix . strtoupper($rand);
+            $tries = 0;
+            while ($tries < 3 && $repo->exists($code)) {
+                $rand = wp_generate_password($len, false, false);
+                $code = $prefix . strtoupper($rand);
+                $tries++;
+            }
+            if ($repo->exists($code)) {
+                $result['skipped'][] = $code;
+                continue;
+            }
+            $repo->insert($code, $user);
+            $result['saved'][] = $code;
+        }
+
+        wp_send_json_success($result);
+    }
+
+    /**
+     * Handle CSV or printable export.
+     */
+    public function handle_export_csv()
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die('No permission.');
+        }
+        if (!isset($_POST['kc_export_nonce']) || !wp_verify_nonce($_POST['kc_export_nonce'], 'kerbcycle_export_qr_csv')) {
+            wp_die('Bad nonce.');
+        }
+
+        $from   = sanitize_text_field($_POST['from'] ?? '');
+        $to     = sanitize_text_field($_POST['to'] ?? '');
+        $format = sanitize_text_field($_POST['format'] ?? 'csv');
+
+        if (!$from || !$to) {
+            wp_die('Date range required.');
+        }
+
+        $repo = new QrRepoRepository();
+        $rows = $repo->list_between($from, $to);
+
+        switch ($format) {
+            case 'print':
+                $this->render_printable($rows, $from, $to);
+                exit;
+            case 'print_labels_5160':
+                $this->render_printable_avery_5160($rows, $from, $to);
+                exit;
+            case 'zip_png':
+                $this->render_zip_png($rows, $from, $to);
+                exit;
+            case 'zip_svg':
+                $this->render_zip_svg($rows, $from, $to);
+                exit;
+            case 'csv':
+            default:
+                nocache_headers();
+                header('Content-Type: text/csv; charset=UTF-8');
+                header('Content-Disposition: attachment; filename=kerbcycle-qr-codes-' . $from . '_to_' . $to . '.csv');
+
+                $out = fopen('php://output', 'w');
+                fputcsv($out, ['ID', 'Code', 'Status', 'Created At']);
+                foreach ($rows as $r) {
+                    fputcsv($out, [$r['id'], $r['code'], $r['status'], $r['created_at']]);
+                }
+                fclose($out);
+                exit;
+        }
+    }
+
+    private function render_printable(array $rows, string $from, string $to)
+    {
+        ?>
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="utf-8"/>
+            <title>KerbCycle QR Codes: <?php echo esc_html($from); ?> to <?php echo esc_html($to); ?></title>
+            <style>
+                body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
+                .header { display:flex; justify-content:space-between; align-items:center; margin:16px 0; }
+                .grid { display:grid; grid-template-columns: repeat(3, 1fr); gap:16px; }
+                .card { border:1px solid #ddd; padding:12px; border-radius:12px; text-align:center; }
+                .code-text { margin-top:8px; font-weight:600; font-size:14px; word-break:break-all; }
+                @media print {
+                  .no-print { display:none; }
+                  .grid { gap:8px; }
+                  .card { padding:8px; }
+                }
+            </style>
+        </head>
+        <body>
+            <div class="header no-print">
+                <h1>QR Codes (<?php echo esc_html($from); ?> → <?php echo esc_html($to); ?>)</h1>
+                <button onclick="window.print()">Print</button>
+            </div>
+            <div class="grid" id="print-grid">
+                <?php foreach ($rows as $r): ?>
+                    <div class="card">
+                        <div class="qrc" data-code="<?php echo esc_attr($r['code']); ?>"></div>
+                        <div class="code-text"><?php echo esc_html($r['code']); ?></div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+
+            <script src="<?php echo esc_url(KERBCYCLE_QR_URL . 'assets/js/qrcode.min.js'); ?>"></script>
+            <script>
+            document.querySelectorAll('.qrc').forEach(function(el){
+                const code = el.getAttribute('data-code');
+                new QRCode(el, { text: code, width: 128, height: 128, correctLevel: QRCode.CorrectLevel.M });
+            });
+            </script>
+        </body>
+        </html>
+        <?php
+    }
+
+    private static function render_printable_avery_5160(array $rows, string $from, string $to)
+    {
+        ?>
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="utf-8"/>
+          <title>Avery 5160 — <?php echo esc_html("$from to $to"); ?></title>
+          <style>
+            @page { size: 8.5in 11in; margin: 0.5in; }
+            body { margin: 0.25in; font-family: system-ui, Arial, sans-serif; }
+            .sheet {
+              width: 8.5in;
+              display: grid;
+              grid-template-columns: repeat(3, 2.625in);
+              grid-auto-rows: 1in;
+              gap: 0in 0.125in;
+            }
+            .label {
+              width: 2.625in; height: 1in;
+              display:flex; align-items:center; justify-content:center;
+              flex-direction:row; gap:0.15in; overflow:hidden; background:#fff;
+            }
+            .label .qrc { width:0.8in; height:0.8in; }
+            .label .txt { font-size:10pt; max-width:1.5in; word-wrap:break-word; }
+            @media print { .no-print { display:none; } }
+          </style>
+        </head>
+        <body>
+          <div class="no-print" style="padding:8px">
+            <button onclick="window.print()">Print</button>
+          </div>
+          <div class="sheet">
+            <?php foreach ($rows as $r): ?>
+              <div class="label">
+                <div class="qrc" data-code="<?php echo esc_attr($r['code']); ?>"></div>
+                <div class="txt"><?php echo esc_html($r['code']); ?></div>
+              </div>
+            <?php endforeach; ?>
+          </div>
+          <script src="<?php echo esc_url(KERBCYCLE_QR_URL . 'assets/js/qrcode.min.js'); ?>"></script>
+          <script>
+            document.querySelectorAll('.qrc').forEach(function(el){
+              const code = el.getAttribute('data-code');
+              new QRCode(el, { text: code, width: 128, height: 128, correctLevel: QRCode.CorrectLevel.M });
+            });
+          </script>
+        </body>
+        </html>
+        <?php
+    }
+
+    private static function render_zip_png(array $rows, string $from, string $to)
+    {
+        ?>
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="utf-8"/>
+          <title>PNG ZIP — <?php echo esc_html("$from to $to"); ?></title>
+          <style>
+            body { font-family: system-ui, Arial, sans-serif; padding:16px; }
+            .grid { display:grid; grid-template-columns: repeat(5,1fr); gap:12px; }
+            .card { border:1px solid #ddd; border-radius:12px; padding:12px; text-align:center; }
+            .qrc { margin:auto; }
+            button { margin:12px 0; }
+          </style>
+        </head>
+        <body>
+          <h1>Build ZIP of PNGs</h1>
+          <button id="buildZip">Generate ZIP</button>
+          <div class="grid">
+            <?php foreach ($rows as $r): ?>
+              <div class="card">
+                <div class="qrc" data-code="<?php echo esc_attr($r['code']); ?>"></div>
+                <div class="txt"><?php echo esc_html($r['code']); ?></div>
+              </div>
+            <?php endforeach; ?>
+          </div>
+
+          <script src="<?php echo esc_url(KERBCYCLE_QR_URL . 'assets/js/qrcode.min.js'); ?>"></script>
+          <script src="<?php echo esc_url(KERBCYCLE_QR_URL . 'assets/js/jszip.min.js'); ?>"></script>
+          <script src="<?php echo esc_url(KERBCYCLE_QR_URL . 'assets/js/FileSaver.min.js'); ?>"></script>
+          <script>
+            const cards = document.querySelectorAll('.qrc');
+            cards.forEach(function(el){
+              const code = el.getAttribute('data-code');
+              new QRCode(el, { text: code, width: 256, height: 256, correctLevel: QRCode.CorrectLevel.M });
+            });
+
+            document.getElementById('buildZip').addEventListener('click', async () => {
+              const zip = new JSZip();
+              let i = 0;
+              for (const card of cards) {
+                const code = card.getAttribute('data-code');
+                const canvas = card.querySelector('canvas');
+                if (!canvas) continue;
+                const dataUrl = canvas.toDataURL('image/png');
+                const base64 = dataUrl.split(',')[1];
+                zip.file(code + '.png', base64, {base64:true});
+                i++;
+              }
+              const blob = await zip.generateAsync({type:'blob'});
+              saveAs(blob, 'kerbcycle-qr-png-<?php echo esc_js($from . "_to_" . $to); ?>.zip');
+            });
+          </script>
+        </body>
+        </html>
+        <?php
+    }
+
+    private static function render_zip_svg(array $rows, string $from, string $to)
+    {
+        ?>
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="utf-8"/>
+          <title>SVG ZIP — <?php echo esc_html("$from to $to"); ?></title>
+          <style> body { font-family: system-ui, Arial, sans-serif; padding:16px; } button { margin:12px 0; } </style>
+        </head>
+        <body>
+          <h1>Build ZIP of SVGs</h1>
+          <button id="buildZip">Generate ZIP</button>
+          <div id="status"></div>
+
+          <script src="<?php echo esc_url(KERBCYCLE_QR_URL . 'assets/js/jszip.min.js'); ?>"></script>
+          <script src="<?php echo esc_url(KERBCYCLE_QR_URL . 'assets/js/FileSaver.min.js'); ?>"></script>
+          <script src="<?php echo esc_url(KERBCYCLE_QR_URL . 'assets/js/qrcodegen.min.js'); ?>"></script>
+          <script>
+            function makeSvgString(text, size = 256, margin = 4) {
+              const ecl = qrcodegen.QrCode.Ecc.M;
+              const qr = qrcodegen.QrCode.encodeText(text, ecl);
+              const scale = Math.floor(size / (qr.size + margin * 2));
+              const dim = (qr.size + margin * 2) * scale;
+              let path = "";
+              for (let y = 0; y < qr.size; y++) {
+                for (let x = 0; x < qr.size; x++) {
+                  if (qr.getModule(x, y)) {
+                    path += `M${(x+margin)*scale},${(y+margin)*scale}h${scale}v${scale}h-${scale}z`;
+                  }
+                }
+              }
+              return `<svg xmlns="http://www.w3.org/2000/svg" width="${dim}" height="${dim}" viewBox="0 0 ${dim} ${dim}"><rect width="100%" height="100%" fill="#FFFFFF"/><path d="${path}" fill="#000000"/></svg>`;
+            }
+
+            document.getElementById('buildZip').addEventListener('click', async () => {
+              const zip = new JSZip();
+              const codes = <?php echo wp_json_encode(array_map(fn($r) => $r['code'], $rows)); ?>;
+              let i = 0;
+              for (const code of codes) {
+                const svg = makeSvgString(code, 256, 4);
+                zip.file(code + '.svg', svg);
+                i++;
+              }
+              const blob = await zip.generateAsync({type:'blob'});
+              saveAs(blob, 'kerbcycle-qr-svg-<?php echo esc_js($from . "_to_" . $to); ?>.zip');
+              document.getElementById('status').textContent = 'Done: ' + i + ' SVG files.';
+            });
+          </script>
+        </body>
+        </html>
+        <?php
+    }
+}

--- a/includes/Data/Repositories/QrRepoRepository.php
+++ b/includes/Data/Repositories/QrRepoRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Kerbcycle\QrCode\Data\Repositories;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Repository for QR code generator table.
+ */
+class QrRepoRepository
+{
+    /** @var string */
+    private $table;
+
+    public function __construct()
+    {
+        global $wpdb;
+        $this->table = $wpdb->prefix . 'kerbcycle_qr_repo';
+    }
+
+    /**
+     * Check if a code already exists in the repository.
+     */
+    public function exists(string $code): bool
+    {
+        global $wpdb;
+        return (bool) $wpdb->get_var($wpdb->prepare("SELECT id FROM $this->table WHERE code = %s", $code));
+    }
+
+    /**
+     * Insert a new code.
+     */
+    public function insert(string $code, ?int $user_id = null)
+    {
+        global $wpdb;
+        return $wpdb->insert(
+            $this->table,
+            [
+                'code'       => $code,
+                'status'     => 'available',
+                'created_by' => $user_id,
+            ],
+            ['%s', '%s', '%d']
+        );
+    }
+
+    /**
+     * Get codes created within a date range (inclusive).
+     *
+     * @return array[]
+     */
+    public function list_between(string $from, string $to): array
+    {
+        global $wpdb;
+        return $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT id, code, status, created_at FROM $this->table WHERE DATE(created_at) BETWEEN %s AND %s ORDER BY created_at ASC",
+                $from,
+                $to
+            ),
+            ARRAY_A
+        );
+    }
+}

--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -82,5 +82,21 @@ class Activator
         ) $charset_collate;";
 
         dbDelta($sql);
+
+        // Create QR generator repository table
+        $repo_table = $wpdb->prefix . 'kerbcycle_qr_repo';
+        $sql = "CREATE TABLE $repo_table (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            code VARCHAR(191) NOT NULL,
+            status VARCHAR(50) NOT NULL DEFAULT 'available',
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            created_by BIGINT UNSIGNED NULL,
+            PRIMARY KEY  (id),
+            UNIQUE KEY code_unique (code),
+            KEY created_at_idx (created_at),
+            KEY status_idx (status)
+        ) $charset_collate;";
+
+        dbDelta($sql);
     }
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -50,6 +50,7 @@ class Plugin
             new \Kerbcycle\QrCode\Admin\Assets\AdminAssets();
             new \Kerbcycle\QrCode\Admin\Ajax\AdminAjax();
             new \Kerbcycle\QrCode\Admin\Pages\SettingsPage();
+            \Kerbcycle\QrCode\Admin\Pages\GeneratorPage::instance();
             new \Kerbcycle\QrCode\Services\SmsService();
         }
 


### PR DESCRIPTION
## Summary
- add sequential mode and extra export options (Avery 5160, PNG/SVG ZIP)
- load QR library on print pages and wire up new client logic
- tweak generator styling with quiet-zone padding
- accept legacy `genType` parameter and send it from the client to prevent 400 errors during code generation

## Testing
- `php -l includes/Admin/Pages/GeneratorPage.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9e1a8a490832dbeea0339aa5b1607