### PR TITLE
Add option to disable QR code drag-and-drop

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -134,7 +134,7 @@ function initKerbcycleAdmin() {
     }
 
     const bulkForm = document.getElementById('qr-code-bulk-form');
-    if (bulkForm) {
+    if (bulkForm && !kerbcycle_ajax.drag_drop_disabled) {
         jQuery('#qr-code-list').sortable({ items: 'li.qr-item' });
 
         const selectAll = document.getElementById('qr-select-all');

--- a/includes/Admin/Assets/AdminAssets.php
+++ b/includes/Admin/Assets/AdminAssets.php
@@ -59,21 +59,28 @@ class AdminAssets
             return;
         }
 
-        $scanner_enabled = (bool) get_option('kerbcycle_qr_enable_scanner', 1);
+        $scanner_enabled      = (bool) get_option('kerbcycle_qr_enable_scanner', 1);
+        $drag_drop_disabled   = (bool) get_option('kerbcycle_qr_disable_drag_drop', 0);
 
-        // Always enqueue the main admin script
+        $deps = [];
+        if (!$drag_drop_disabled) {
+            $deps[] = 'jquery-ui-sortable';
+        }
+
+        // Enqueue the main admin script
         wp_enqueue_script(
             'kerbcycle-qr-admin-js',
             KERBCYCLE_QR_URL . 'assets/js/admin.js',
-            ['jquery-ui-sortable'],
+            $deps,
             filemtime(KERBCYCLE_QR_PATH . 'assets/js/admin.js'),
             true
         );
 
         wp_localize_script('kerbcycle-qr-admin-js', 'kerbcycle_ajax', [
-            'ajax_url' => admin_url('admin-ajax.php'),
-            'nonce' => wp_create_nonce('kerbcycle_qr_nonce'),
-            'scanner_enabled' => $scanner_enabled,
+            'ajax_url'          => admin_url('admin-ajax.php'),
+            'nonce'             => wp_create_nonce('kerbcycle_qr_nonce'),
+            'scanner_enabled'   => $scanner_enabled,
+            'drag_drop_disabled'=> $drag_drop_disabled,
         ]);
 
         if ($scanner_enabled) {

--- a/includes/Admin/Pages/SettingsPage.php
+++ b/includes/Admin/Pages/SettingsPage.php
@@ -57,6 +57,7 @@ class SettingsPage
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_sms');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_reminders');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_scanner');
+        register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_disable_drag_drop');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_codes_per_page');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_history_per_page');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_sms_history_per_page');
@@ -97,6 +98,14 @@ class SettingsPage
             'kerbcycle_qr_enable_scanner',
             __('Enable Dashboard QR Scanner Camera', 'kerbcycle'),
             [$this, 'render_enable_scanner_field'],
+            'kerbcycle_qr_settings',
+            'kerbcycle_qr_main'
+        );
+
+        add_settings_field(
+            'kerbcycle_qr_disable_drag_drop',
+            __('Disable Drag and Drop Reordering', 'kerbcycle'),
+            [$this, 'render_disable_drag_drop_field'],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
@@ -167,6 +176,15 @@ class SettingsPage
         ?>
         <input type="checkbox" name="kerbcycle_qr_enable_scanner" value="1" <?php checked(1, $value); ?> />
         <span class="description"><?php esc_html_e('Allow camera use on the dashboard scanner', 'kerbcycle'); ?></span>
+        <?php
+    }
+
+    public function render_disable_drag_drop_field()
+    {
+        $value = get_option('kerbcycle_qr_disable_drag_drop', 0);
+        ?>
+        <input type="checkbox" name="kerbcycle_qr_disable_drag_drop" value="1" <?php checked(1, $value); ?> />
+        <span class="description"><?php esc_html_e('Prevent drag-and-drop reordering on the QR Codes table', 'kerbcycle'); ?></span>
         <?php
     }
 


### PR DESCRIPTION
## Summary
- allow admins to disable drag-and-drop reordering of QR codes via new setting
- localize drag/drop flag to admin script and conditionally load jQuery UI Sortable
- respect setting in admin.js to prevent sortable initialization

## Testing
- `php -l includes/Admin/Pages/SettingsPage.php`
- `php -l includes/Admin/Assets/AdminAssets.php`
- `node -e "new Function(require('fs').readFileSync('assets/js/admin.js','utf8'))"`

------
https://chatgpt.com/codex/tasks/task_e_68bc7ee3ca64832d9194550d343e7b6a