### PR TITLE
Improve QR code admin UX and harden endpoints

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,1 +1,94 @@
 /* Styles for the admin pages */
+
+#qr-code-list {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    border: 1px solid #c3c4c7;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+    background: #fff;
+}
+
+.qr-header,
+.qr-item {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid #c3c4c7;
+    padding: 8px 10px;
+}
+
+.qr-header {
+    font-weight: 600;
+    background: #f0f0f1;
+}
+
+.qr-item:last-child {
+    border-bottom: none;
+}
+
+.qr-select {
+    flex-basis: 30px;
+    flex-shrink: 0;
+    margin-right: 10px;
+}
+
+.qr-id,
+.qr-user,
+.qr-status {
+    flex-basis: 80px;
+    padding: 0 8px;
+}
+
+.qr-name {
+    flex-basis: 150px;
+    padding: 0 8px;
+}
+
+.qr-text {
+    flex-grow: 1;
+    padding: 0 8px;
+}
+
+.qr-assigned {
+    flex-basis: 150px;
+    padding: 0 8px;
+}
+
+.qr-reader {
+    width: 100%;
+    max-width: 400px;
+    margin-top: 20px;
+}
+
+.qr-warning {
+    margin-top: 20px;
+}
+
+.qr-filters {
+    margin-bottom: 15px;
+}
+
+#scan-result {
+    display: none;
+}
+
+#qr-toast {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background: #32373c;
+    color: #fff;
+    padding: 10px 20px;
+    border-radius: 4px;
+    opacity: 0;
+    transition: opacity .3s;
+    z-index: 100000;
+}
+
+#qr-toast.show {
+    opacity: 1;
+}
+
+#qr-toast.error {
+    background: #d63638;
+}

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -45,11 +45,11 @@ class AdminAjax
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Unauthorized'], 403);
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
 
-        $qr_code      = sanitize_text_field($_POST['qr_code']);
-        $user_id      = intval($_POST['customer_id']);
+        $qr_code      = sanitize_text_field(wp_unslash($_POST['qr_code']));
+        $user_id      = intval(wp_unslash($_POST['customer_id']));
         $send_email   = !empty($_POST['send_email']) && get_option('kerbcycle_qr_enable_email', 1);
         $send_sms     = !empty($_POST['send_sms']) && get_option('kerbcycle_qr_enable_sms', 0);
         $send_reminder = !empty($_POST['send_reminder']) && get_option('kerbcycle_qr_enable_reminders', 0);
@@ -78,10 +78,10 @@ class AdminAjax
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Unauthorized'], 403);
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
 
-        $qr_code   = sanitize_text_field($_POST['qr_code']);
+        $qr_code   = sanitize_text_field(wp_unslash($_POST['qr_code']));
         $send_email = !empty($_POST['send_email']) && get_option('kerbcycle_qr_enable_email', 1);
         $send_sms   = !empty($_POST['send_sms']) && get_option('kerbcycle_qr_enable_sms', 0);
 
@@ -105,14 +105,14 @@ class AdminAjax
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Unauthorized'], 403);
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
 
         if (empty($_POST['qr_codes'])) {
-            wp_send_json_error(['message' => 'No QR codes were selected.']);
+            wp_send_json_error(['message' => __('No QR codes were selected.', 'kerbcycle')]);
         }
 
-        $raw_codes = explode(',', $_POST['qr_codes']);
+        $raw_codes = explode(',', wp_unslash($_POST['qr_codes']));
         $codes = array_map('trim', array_map('sanitize_text_field', $raw_codes));
         $codes = array_filter($codes);
 
@@ -139,14 +139,14 @@ class AdminAjax
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Unauthorized'], 403);
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
 
         if (empty($_POST['qr_codes'])) {
-            wp_send_json_error(['message' => 'No QR codes were selected.']);
+            wp_send_json_error(['message' => __('No QR codes were selected.', 'kerbcycle')]);
         }
 
-        $raw_codes = explode(',', $_POST['qr_codes']);
+        $raw_codes = explode(',', wp_unslash($_POST['qr_codes']));
         $codes = array_map('trim', array_map('sanitize_text_field', $raw_codes));
         $codes = array_filter($codes);
 
@@ -173,22 +173,26 @@ class AdminAjax
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Unauthorized'], 403);
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
 
-        $old_code = sanitize_text_field($_POST['old_code']);
-        $new_code = sanitize_text_field($_POST['new_code']);
+        $old_code = sanitize_text_field(wp_unslash($_POST['old_code']));
+        $new_code = sanitize_text_field(wp_unslash($_POST['new_code']));
 
         if (empty($old_code) || empty($new_code)) {
-            wp_send_json_error(['message' => 'Invalid QR code']);
+            wp_send_json_error(['message' => __('Invalid QR code', 'kerbcycle')]);
         }
 
         $result = $this->qr_service->update($old_code, $new_code);
 
+        if (is_wp_error($result)) {
+            wp_send_json_error(['message' => $result->get_error_message()]);
+        }
+
         if ($result !== false) {
-            wp_send_json_success(['message' => 'QR code updated']);
+            wp_send_json_success(['message' => __('QR code updated', 'kerbcycle')]);
         } else {
-            wp_send_json_error(['message' => 'Failed to update QR code']);
+            wp_send_json_error(['message' => __('Failed to update QR code', 'kerbcycle')]);
         }
     }
 
@@ -196,13 +200,13 @@ class AdminAjax
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Unauthorized'], 403);
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
 
-        $qr_code = sanitize_text_field($_POST['qr_code']);
+        $qr_code = sanitize_text_field(wp_unslash($_POST['qr_code']));
 
         if (empty($qr_code)) {
-            wp_send_json_error(['message' => 'Invalid QR code']);
+            wp_send_json_error(['message' => __('Invalid QR code', 'kerbcycle')]);
         }
 
         $result = $this->qr_service->add($qr_code);
@@ -210,9 +214,9 @@ class AdminAjax
         if (is_wp_error($result)) {
             wp_send_json_error(['message' => $result->get_error_message()]);
         } elseif ($result !== false) {
-            wp_send_json_success(['message' => 'QR code added successfully.']);
+            wp_send_json_success(['message' => __('QR code added successfully.', 'kerbcycle')]);
         } else {
-            wp_send_json_error(['message' => 'Failed to add QR code due to a database error.']);
+            wp_send_json_error(['message' => __('Failed to add QR code due to a database error.', 'kerbcycle')]);
         }
     }
 
@@ -220,7 +224,7 @@ class AdminAjax
     {
         Nonces::verify('kerbcycle_qr_report_nonce', 'security');
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Unauthorized'], 403);
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
         $report_service = new ReportService();
         $data = $report_service->get_report_data();
@@ -231,12 +235,12 @@ class AdminAjax
     {
         Nonces::verify('kerbcycle_delete_logs', 'security');
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Unauthorized'], 403);
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
 
-        $ids = isset($_POST['log_ids']) && is_array($_POST['log_ids']) ? array_map('absint', $_POST['log_ids']) : [];
+        $ids = isset($_POST['log_ids']) && is_array($_POST['log_ids']) ? array_map('absint', wp_unslash($_POST['log_ids'])) : [];
         if (!$ids) {
-            wp_send_json_error(['message' => 'No logs selected']);
+            wp_send_json_error(['message' => __('No logs selected', 'kerbcycle')]);
         }
 
         $repo = new MessageLogRepository();

--- a/includes/Admin/Assets/AdminAssets.php
+++ b/includes/Admin/Assets/AdminAssets.php
@@ -62,6 +62,13 @@ class AdminAssets
         $scanner_enabled      = (bool) get_option('kerbcycle_qr_enable_scanner', 1);
         $drag_drop_disabled   = (bool) get_option('kerbcycle_qr_disable_drag_drop', 0);
 
+        wp_enqueue_style(
+            'kerbcycle-qr-admin-css',
+            KERBCYCLE_QR_URL . 'assets/css/admin.css',
+            [],
+            filemtime(KERBCYCLE_QR_PATH . 'assets/css/admin.css')
+        );
+
         $deps = [];
         if (!$drag_drop_disabled) {
             $deps[] = 'jquery-ui-sortable';

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -80,50 +80,6 @@ class DashboardPage
         $query_args = array_merge($params, [$per_page, $offset]);
         $all_codes  = $wpdb->get_results($wpdb->prepare($select_sql, $query_args));
         ?>
-        <style>
-            #qr-code-list {
-                display: flex;
-                flex-direction: column;
-                padding: 0;
-                border: 1px solid #c3c4c7;
-                box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
-                background: #fff;
-            }
-            .qr-header, .qr-item {
-                display: flex;
-                align-items: center;
-                border-bottom: 1px solid #c3c4c7;
-                padding: 8px 10px;
-            }
-            .qr-header {
-                font-weight: 600;
-                background: #f0f0f1;
-            }
-            .qr-item:last-child {
-                border-bottom: none;
-            }
-            .qr-select {
-                flex-basis: 30px;
-                flex-shrink: 0;
-                margin-right: 10px;
-            }
-            .qr-id, .qr-user, .qr-status {
-                flex-basis: 80px;
-                padding: 0 8px;
-            }
-            .qr-name {
-                flex-basis: 150px;
-                padding: 0 8px;
-            }
-            .qr-text {
-                flex-grow: 1;
-                padding: 0 8px;
-            }
-            .qr-assigned {
-                flex-basis: 150px;
-                padding: 0 8px;
-            }
-        </style>
         <div class="wrap">
             <h1>KerbCycle QR Code Manager</h1>
             <div class="notice notice-info">
@@ -160,17 +116,17 @@ class DashboardPage
                     <button id="release-qr-btn" class="button"><?php esc_html_e('Release QR Code', 'kerbcycle'); ?></button>
                 </p>
                 <?php if ($scanner_enabled) : ?>
-                    <div id="reader" style="width: 100%; max-width: 400px; margin-top: 20px;"></div>
+                    <div id="reader" class="qr-reader"></div>
                 <?php else : ?>
-                    <div class="notice notice-warning" style="margin-top: 20px;">
+                    <div class="notice notice-warning qr-warning">
                         <p><?php esc_html_e('QR code scanner camera is disabled in settings.', 'kerbcycle'); ?></p>
                     </div>
                 <?php endif; ?>
-                <div id="scan-result" class="updated" style="display: none;"></div>
+                <div id="scan-result" class="updated"></div>
             </div>
 
             <h2><?php esc_html_e('Manage QR Codes', 'kerbcycle'); ?></h2>
-            <form method="get" class="qr-filters" style="margin-bottom:15px;">
+            <form method="get" class="qr-filters">
                 <input type="hidden" name="page" value="kerbcycle-qr-manager" />
                 <select name="status_filter">
                     <option value=""><?php esc_html_e('All Statuses', 'kerbcycle'); ?></option>

--- a/includes/Helpers/Nonces.php
+++ b/includes/Helpers/Nonces.php
@@ -36,10 +36,17 @@ class Nonces
         $nonce = sanitize_text_field($nonce);
 
         if (!wp_verify_nonce($nonce, $action)) {
+            $message = __('Security check failed', 'kerbcycle');
+
             if ($request instanceof \WP_REST_Request) {
-                return new \WP_Error('rest_nonce_invalid', __('Security check failed', 'kerbcycle'), ['status' => 403]);
+                return new \WP_Error('rest_nonce_invalid', $message, ['status' => 403]);
             }
-            wp_die(__('Security check failed', 'kerbcycle'), __('Error', 'kerbcycle'), 403);
+
+            if (wp_doing_ajax()) {
+                wp_send_json_error(['message' => $message], 403);
+            }
+
+            wp_die($message, __('Error', 'kerbcycle'), 403);
         }
 
         return true;

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -100,6 +100,9 @@ class QrService
 
     public function update($old_code, $new_code)
     {
+        if ($this->repository->find_by_qr_code($new_code)) {
+            return new \WP_Error('duplicate_qr_code', __('This QR code already exists.', 'kerbcycle'));
+        }
         return $this->repository->update_code($old_code, $new_code);
     }
 }


### PR DESCRIPTION
## Summary
- Replace inline QR list styles with enqueued stylesheet and toast UI
- Validate and retry QR batch generation until requested count achieved
- Harden AJAX/REST handlers with unslashed input, capability checks, and duplicate protection

## Testing
- `php -l includes/Helpers/Nonces.php`
- `php -l includes/Admin/Pages/GeneratorPage.php`
- `php -l includes/Admin/Ajax/AdminAjax.php`
- `php -l includes/Services/QrService.php`
- `php -l includes/Data/Repositories/QrCodeRepository.php`
- `php -l includes/Api/Controllers/QrController.php`
- `php -l includes/Admin/Assets/AdminAssets.php`
- `php -l includes/Admin/Pages/DashboardPage.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc82b8e3fc832db2559e19a12de48a