### PR TITLE
Fix manual QR code duplicates regardless of status

### DIFF
--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -28,8 +28,9 @@ class QrService
 
     public function add($qr_code)
     {
-        if ($this->repository->available_exists($qr_code)) {
-            return new \WP_Error('duplicate_qr_code', __('This QR code is already available.', 'kerbcycle'));
+        // Prevent duplicates regardless of current status (available or assigned)
+        if ($this->repository->find_by_qr_code($qr_code)) {
+            return new \WP_Error('duplicate_qr_code', __('This QR code already exists.', 'kerbcycle'));
         }
         $inserted = $this->repository->insert_available($qr_code);
         if ($inserted === false) {


### PR DESCRIPTION
## Summary
- Prevent manual QR code additions that match any existing code, even if assigned

## Testing
- `php -l includes/Services/QrService.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc8f0cc9e4832d8e5a3a518976b195