### PR TITLE
Add CSV import for QR codes

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -21,6 +21,8 @@ function initKerbcycleAdmin() {
     const releaseBtn = document.getElementById("release-qr-btn");
     const addBtn = document.getElementById("add-qr-btn");
     const newCodeInput = document.getElementById("new-qr-code");
+    const importBtn = document.getElementById("import-qr-btn");
+    const importFile = document.getElementById("import-qr-file");
 
     if (userField && assignedSelect) {
         userField.addEventListener("change", function () {
@@ -275,6 +277,38 @@ function initKerbcycleAdmin() {
             .catch(error => {
                 console.error('Error:', error);
                 showToast('An error occurred while adding the QR code.', true);
+            });
+        });
+    }
+
+    if (importBtn) {
+        importBtn.addEventListener("click", function () {
+            if (!importFile || !importFile.files.length) {
+                alert("Please select a CSV file.");
+                return;
+            }
+            const formData = new FormData();
+            formData.append('action', 'import_qr_codes');
+            formData.append('security', kerbcycle_ajax.nonce);
+            formData.append('import_file', importFile.files[0]);
+            fetch(kerbcycle_ajax.ajax_url, {
+                method: 'POST',
+                body: formData
+            })
+            .then(res => res.json())
+            .then(data => {
+                if (data.success) {
+                    const msg = data.data && data.data.message ? data.data.message : 'QR codes imported.';
+                    showToast(msg);
+                    location.reload();
+                } else {
+                    const err = data.data && data.data.message ? data.data.message : 'Failed to import QR codes.';
+                    showToast(err, true);
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                showToast('An error occurred while importing QR codes.', true);
             });
         });
     }

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -38,6 +38,7 @@ class AdminAjax
         add_action('wp_ajax_update_qr_code', [$this, 'update_qr_code']);
         add_action('wp_ajax_add_qr_code', [$this, 'add_qr_code']);
         add_action('wp_ajax_get_assigned_qr_codes', [$this, 'get_assigned_qr_codes']);
+        add_action('wp_ajax_import_qr_codes', [$this, 'import_qr_codes']);
         add_action('wp_ajax_kerbcycle_qr_report_data', [$this, 'ajax_report_data']);
         add_action('wp_ajax_kerbcycle_delete_logs', [$this, 'delete_logs']);
     }
@@ -237,6 +238,45 @@ class AdminAjax
             ]);
         } else {
             wp_send_json_error(['message' => __('Failed to add QR code due to a database error.', 'kerbcycle')]);
+        }
+    }
+
+    public function import_qr_codes()
+    {
+        Nonces::verify('kerbcycle_qr_nonce', 'security');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
+        }
+
+        if (empty($_FILES['import_file']) || !is_uploaded_file($_FILES['import_file']['tmp_name'])) {
+            wp_send_json_error(['message' => __('No file uploaded.', 'kerbcycle')]);
+        }
+
+        $handle = fopen($_FILES['import_file']['tmp_name'], 'r');
+        if (!$handle) {
+            wp_send_json_error(['message' => __('Could not read uploaded file.', 'kerbcycle')]);
+        }
+
+        $added = 0;
+        while (($data = fgetcsv($handle)) !== false) {
+            if (empty($data[0])) {
+                continue;
+            }
+            $code   = sanitize_text_field($data[0]);
+            $result = $this->qr_service->add($code);
+            if (!is_wp_error($result) && $result !== false) {
+                $added++;
+            }
+        }
+        fclose($handle);
+
+        if ($added > 0) {
+            wp_send_json_success([
+                'message' => sprintf(__('Imported %d QR code(s).', 'kerbcycle'), $added),
+                'added'   => $added,
+            ]);
+        } else {
+            wp_send_json_error(['message' => __('No QR codes were imported.', 'kerbcycle')]);
         }
     }
 

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -124,6 +124,9 @@ class DashboardPage
                 </div>
                 <input type="text" id="new-qr-code" placeholder="<?php esc_attr_e('Enter QR Code', 'kerbcycle'); ?>" />
                 <button id="add-qr-btn" class="button"><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></button>
+                <input type="file" id="import-qr-file" accept=".csv" />
+                <button id="import-qr-btn" class="button"><?php esc_html_e('Import QR Codes', 'kerbcycle'); ?></button>
+                <p class="description"><?php esc_html_e('Import QR Codes from a selected CSV File.', 'kerbcycle'); ?></p>
                 <?php if ($scanner_enabled) : ?>
                     <div id="reader" class="qr-reader"></div>
                 <?php else : ?>


### PR DESCRIPTION
## Summary
- allow QR code CSV import via new admin UI elements
- add AJAX handler to process uploaded CSV and insert codes
- wire up front-end JavaScript to upload and import codes

## Testing
- `php -l includes/Admin/Pages/DashboardPage.php`
- `php -l includes/Admin/Ajax/AdminAjax.php`


------
https://chatgpt.com/codex/tasks/task_e_68bca3a9e48c832daa2fc40cd2a49827