### PR TITLE
Add CSV import for QR codes

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -21,6 +21,8 @@ function initKerbcycleAdmin() {
     const releaseBtn = document.getElementById("release-qr-btn");
     const addBtn = document.getElementById("add-qr-btn");
     const newCodeInput = document.getElementById("new-qr-code");
+    const importBtn = document.getElementById("import-qr-btn");
+    const importFile = document.getElementById("import-qr-file");
 
     if (userField && assignedSelect) {
         userField.addEventListener("change", function () {
@@ -275,6 +277,38 @@ function initKerbcycleAdmin() {
             .catch(error => {
                 console.error('Error:', error);
                 showToast('An error occurred while adding the QR code.', true);
+            });
+        });
+    }
+
+    if (importBtn) {
+        importBtn.addEventListener("click", function () {
+            if (!importFile || !importFile.files.length) {
+                alert("Please select a CSV file.");
+                return;
+            }
+            const formData = new FormData();
+            formData.append('action', 'import_qr_codes');
+            formData.append('security', kerbcycle_ajax.nonce);
+            formData.append('import_file', importFile.files[0]);
+            fetch(kerbcycle_ajax.ajax_url, {
+                method: 'POST',
+                body: formData
+            })
+            .then(res => res.json())
+            .then(data => {
+                if (data.success) {
+                    const msg = data.data && data.data.message ? data.data.message : 'QR codes imported.';
+                    showToast(msg);
+                    location.reload();
+                } else {
+                    const err = data.data && data.data.message ? data.data.message : 'Failed to import QR codes.';
+                    showToast(err, true);
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                showToast('An error occurred while importing QR codes.', true);
             });
         });
     }

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -122,8 +122,17 @@ class DashboardPage
                         <button id="release-qr-btn" class="button"><?php esc_html_e('Release QR Code', 'kerbcycle'); ?></button>
                     </div>
                 </div>
-                <input type="text" id="new-qr-code" placeholder="<?php esc_attr_e('Enter QR Code', 'kerbcycle'); ?>" />
-                <button id="add-qr-btn" class="button"><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></button>
+                <div class="qr-select-group">
+                    <input type="text" id="new-qr-code" placeholder="<?php esc_attr_e('Enter QR Code', 'kerbcycle'); ?>" />
+                    <button id="add-qr-btn" class="button"><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></button>
+                </div>
+                <div class="qr-select-group">
+                    <input type="file" id="import-qr-file" accept=".csv" />
+                </div>
+                <p class="description"><?php esc_html_e('Import QR Codes from a selected CSV File.', 'kerbcycle'); ?></p>
+                <div class="qr-select-group">
+                    <button id="import-qr-btn" class="button"><?php esc_html_e('Import QR Codes', 'kerbcycle'); ?></button>
+                </div>
                 <?php if ($scanner_enabled) : ?>
                     <div id="reader" class="qr-reader"></div>
                 <?php else : ?>


### PR DESCRIPTION
## Summary
- allow QR code CSV import via new admin UI elements
- add AJAX handler to process uploaded CSV and insert codes
- wire up front-end JavaScript to upload and import codes
- import codes from CSV 'Code' column and reposition import controls below manual entry
- position "Import QR Codes" button below descriptive text

## Testing
- `php -l includes/Admin/Pages/DashboardPage.php`
- `php -l includes/Admin/Ajax/AdminAjax.php`


------
https://chatgpt.com/codex/tasks/task_e_68bca3a9e48c832daa2fc40cd2a49827