### PR TITLE
Add error logging admin page and repository

### DIFF
--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -107,6 +107,15 @@ class Admin
 
         add_submenu_page(
             'kerbcycle-qr-manager',
+            'Errors',
+            'Errors',
+            'manage_options',
+            'kerbcycle-errors',
+            [new Pages\ErrorsPage(), 'render']
+        );
+
+        add_submenu_page(
+            'kerbcycle-qr-manager',
             'Settings',
             'Settings',
             'manage_options',

--- a/includes/Admin/Pages/ErrorsPage.php
+++ b/includes/Admin/Pages/ErrorsPage.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Kerbcycle\QrCode\Admin\Pages;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+use Kerbcycle\QrCode\Data\Repositories\ErrorLogRepository;
+
+/**
+ * Admin page to display error and failure logs.
+ */
+class ErrorsPage
+{
+    protected $page_slug = 'kerbcycle-errors';
+    private $repository;
+
+    public function __construct()
+    {
+        $this->repository = new ErrorLogRepository();
+    }
+
+    public function render()
+    {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        $search   = isset($_GET['s']) ? sanitize_text_field(wp_unslash($_GET['s'])) : '';
+        $status   = isset($_GET['status']) ? sanitize_text_field(wp_unslash($_GET['status'])) : '';
+        $page_f   = isset($_GET['log_page']) ? sanitize_text_field(wp_unslash($_GET['log_page'])) : '';
+        $paged    = max(1, isset($_GET['paged']) ? absint($_GET['paged']) : 1);
+        $per_page = 20;
+
+        $table_ok = $this->repository->table_is_valid();
+        if (!$table_ok) {
+            \Kerbcycle\QrCode\Install\Activator::activate();
+        }
+
+        $available_pages = $table_ok ? $this->repository->get_pages() : [];
+        $logs  = $table_ok ? $this->repository->get_logs($search, $status, $page_f, $paged, $per_page) : [];
+        $total = $table_ok ? $this->repository->count_logs($search, $status, $page_f) : 0;
+        $pages = max(1, (int) ceil($total / $per_page));
+        $base_url = remove_query_arg(['paged'], admin_url('admin.php?page=' . $this->page_slug));
+?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Errors', 'kerbcycle'); ?></h1>
+            <form method="get" action="<?php echo esc_url(admin_url('admin.php')); ?>">
+                <input type="hidden" name="page" value="<?php echo esc_attr($this->page_slug); ?>" />
+                <p class="search-box" style="display:flex; gap:8px; align-items:center;">
+                    <label class="screen-reader-text" for="search-input"><?php esc_html_e('Search Logs', 'kerbcycle'); ?></label>
+                    <input type="search" id="search-input" name="s" value="<?php echo esc_attr($search); ?>" placeholder="<?php esc_attr_e('Search'); ?>" />
+                    <select name="status">
+                        <option value="" <?php selected($status, ''); ?>><?php esc_html_e('All Statuses', 'kerbcycle'); ?></option>
+                        <option value="success" <?php selected($status, 'success'); ?>><?php esc_html_e('Success', 'kerbcycle'); ?></option>
+                        <option value="failure" <?php selected($status, 'failure'); ?>><?php esc_html_e('Failure', 'kerbcycle'); ?></option>
+                    </select>
+                    <select name="log_page">
+                        <option value="" <?php selected($page_f, ''); ?>><?php esc_html_e('All Pages', 'kerbcycle'); ?></option>
+                        <?php foreach ($available_pages as $p) : ?>
+                            <option value="<?php echo esc_attr($p); ?>" <?php selected($page_f, $p); ?>><?php echo esc_html($p); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <input type="submit" class="button" value="<?php esc_attr_e('Filter'); ?>" />
+                    <a href="<?php echo esc_url(admin_url('admin.php?page=' . $this->page_slug)); ?>" class="button"><?php esc_html_e('Reset', 'kerbcycle'); ?></a>
+                </p>
+            </form>
+            <table class="wp-list-table widefat fixed striped">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e('ID', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Type', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Message', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Page', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Date', 'kerbcycle'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php if (empty($logs)) : ?>
+                    <tr><td colspan="6"><?php esc_html_e('No errors found.', 'kerbcycle'); ?></td></tr>
+                <?php else : ?>
+                    <?php foreach ($logs as $log) : ?>
+                    <tr>
+                        <td><?php echo esc_html($log->id); ?></td>
+                        <td><?php echo esc_html($log->type); ?></td>
+                        <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags($log->message), 20, '…')); ?></td>
+                        <td><?php echo esc_html($log->page); ?></td>
+                        <td><?php echo esc_html($log->status); ?></td>
+                        <td><?php echo esc_html(get_date_from_gmt($log->created_at, 'Y-m-d H:i:s')); ?></td>
+                    </tr>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+                </tbody>
+            </table>
+            <?php if ($pages > 1) : ?>
+                <div class="tablenav"><div class="tablenav-pages">
+                <?php
+                    echo paginate_links([
+                        'base'      => add_query_arg('paged', '%#%', $base_url),
+                        'format'    => '',
+                        'current'   => $paged,
+                        'total'     => $pages,
+                        'prev_text' => __('&laquo;'),
+                        'next_text' => __('&raquo;'),
+                    ]);
+                ?>
+                </div></div>
+            <?php endif; ?>
+        </div>
+<?php
+    }
+}

--- a/includes/Data/Repositories/ErrorLogRepository.php
+++ b/includes/Data/Repositories/ErrorLogRepository.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Kerbcycle\QrCode\Data\Repositories;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Repository for storing messages, alerts and notifications that occur within the plugin.
+ *
+ * @package    Kerbcycle\QrCode
+ * @subpackage Kerbcycle\QrCode\Data\Repositories
+ */
+class ErrorLogRepository
+{
+    private $table;
+
+    public function __construct()
+    {
+        global $wpdb;
+        $this->table = $wpdb->prefix . 'kerbcycle_error_logs';
+    }
+
+    /**
+     * Record a log entry for any message, alert or notification.
+     *
+     * @param array $args
+     * @return void
+     */
+    public static function log($args)
+    {
+        global $wpdb;
+
+        $defaults = [
+            'type'    => '',
+            'message' => '',
+            'page'    => '',
+            'status'  => '',
+        ];
+        $data = wp_parse_args($args, $defaults);
+
+        $row = [
+            'type'       => sanitize_text_field($data['type']),
+            'message'    => wp_kses_post($data['message']),
+            'page'       => sanitize_text_field($data['page']),
+            'status'     => sanitize_text_field($data['status']),
+            'created_at' => current_time('mysql', true), // UTC
+        ];
+
+        $table = $wpdb->prefix . 'kerbcycle_error_logs';
+        $wpdb->insert($table, $row, ['%s', '%s', '%s', '%s', '%s']);
+    }
+
+    /**
+     * Backwards compatibility for previous log_error calls.
+     *
+     * @param array $args
+     * @return void
+     */
+    public static function log_error($args)
+    {
+        self::log($args);
+    }
+
+    /**
+     * Retrieve logs from database.
+     */
+    public function get_logs($search, $status, $page, $paged, $per_page)
+    {
+        global $wpdb;
+
+        $where  = '1=1';
+        $params = [];
+
+        if ($search !== '') {
+            $like = '%' . $wpdb->esc_like($search) . '%';
+            $where .= ' AND (type LIKE %s OR message LIKE %s OR page LIKE %s OR status LIKE %s)';
+            array_push($params, $like, $like, $like, $like);
+        }
+        if ($status !== '') {
+            $where .= ' AND status = %s';
+            $params[] = $status;
+        }
+        if ($page !== '') {
+            $where .= ' AND page = %s';
+            $params[] = $page;
+        }
+
+        $offset = ($paged - 1) * $per_page;
+        $sql    = "SELECT * FROM {$this->table} WHERE $where ORDER BY id DESC LIMIT %d OFFSET %d";
+        $params[] = $per_page;
+        $params[] = $offset;
+
+        return $wpdb->get_results($wpdb->prepare($sql, $params));
+    }
+
+    /**
+     * Count logs in database.
+     */
+    public function count_logs($search, $status, $page)
+    {
+        global $wpdb;
+
+        $where  = '1=1';
+        $params = [];
+
+        if ($search !== '') {
+            $like = '%' . $wpdb->esc_like($search) . '%';
+            $where .= ' AND (type LIKE %s OR message LIKE %s OR page LIKE %s OR status LIKE %s)';
+            array_push($params, $like, $like, $like, $like);
+        }
+        if ($status !== '') {
+            $where .= ' AND status = %s';
+            $params[] = $status;
+        }
+        if ($page !== '') {
+            $where .= ' AND page = %s';
+            $params[] = $page;
+        }
+
+        $sql = "SELECT COUNT(*) FROM {$this->table} WHERE $where";
+        return (int) $wpdb->get_var($wpdb->prepare($sql, $params));
+    }
+
+    public function delete_by_ids(array $ids)
+    {
+        if (empty($ids)) {
+            return 0;
+        }
+
+        global $wpdb;
+        $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+        return $wpdb->query($wpdb->prepare("DELETE FROM {$this->table} WHERE id IN ($placeholders)", $ids));
+    }
+
+    public function table_is_valid()
+    {
+        global $wpdb;
+        $expected = ['id', 'type', 'message', 'page', 'status', 'created_at'];
+        $cols = $wpdb->get_col("SHOW COLUMNS FROM {$this->table}", 0);
+        if (empty($cols) || !is_array($cols)) {
+            return false;
+        }
+        foreach ($expected as $c) {
+            if (!in_array($c, $cols, true)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public function clear_all()
+    {
+        global $wpdb;
+        return $wpdb->query("TRUNCATE TABLE {$this->table}");
+    }
+
+    /**
+     * Get list of distinct pages recorded in the log.
+     *
+     * @return array
+     */
+    public function get_pages()
+    {
+        global $wpdb;
+        return $wpdb->get_col("SELECT DISTINCT page FROM {$this->table} WHERE page <> '' ORDER BY page ASC");
+    }
+}

--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -83,6 +83,23 @@ class Activator
 
         dbDelta($sql);
 
+        // Create error logs table
+        $errors_table = $wpdb->prefix . 'kerbcycle_error_logs';
+
+        $sql = "CREATE TABLE $errors_table (
+            id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+            type VARCHAR(100) NOT NULL,
+            message LONGTEXT NOT NULL,
+            page VARCHAR(255) DEFAULT '',
+            status VARCHAR(30) DEFAULT '',
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY  (id),
+            KEY type_idx (type),
+            KEY created_idx (created_at)
+        ) $charset_collate;";
+
+        dbDelta($sql);
+
         // Create QR generator repository table
         $repo_table = $wpdb->prefix . 'kerbcycle_qr_repo';
         $sql = "CREATE TABLE $repo_table (


### PR DESCRIPTION
## Summary
- add error logs table to installation routine
- implement ErrorLogRepository for recording and querying errors
- create admin Errors page with searchable table and pagination
- register Errors submenu before Settings
- add filters for status and page with filter/reset buttons

## Testing
- `php -l includes/Install/Activator.php`
- `php -l includes/Data/Repositories/ErrorLogRepository.php`
- `php -l includes/Admin/Pages/ErrorsPage.php`
- `php -l includes/Admin/Admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf280ee924832db358e7733b076162