### PR TITLE
Add manual QR code entry description

### DIFF
--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -138,6 +138,7 @@ class DashboardPage
                     <input type="text" id="new-qr-code" placeholder="<?php esc_attr_e('Enter QR Code', 'kerbcycle'); ?>" />
                     <button id="add-qr-btn" class="button"><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></button>
                 </div>
+                <p class="description"><?php esc_html_e('Manually add a QR Code.', 'kerbcycle'); ?></p>
                 <div class="qr-select-group">
                     <input type="file" id="import-qr-file" accept=".csv" />
                 </div>


### PR DESCRIPTION
## Summary
- Add descriptive text under the QR code input field explaining manual addition

## Testing
- `php -l includes/Admin/Pages/DashboardPage.php`
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c4836d19bc832d85ef91d757fa536e