### PR TITLE
Add searchable customer dropdown to frontend scanner

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -1,4 +1,35 @@
+function makeSearchableSelect(select) {
+    if (!select) return;
+    const listId = select.id + '-list';
+    const dataList = document.createElement('datalist');
+    dataList.id = listId;
+    const input = document.createElement('input');
+    input.setAttribute('list', listId);
+    input.className = 'kc-search-input';
+    input.style.minWidth = '200px';
+    const updateOptions = () => {
+        dataList.innerHTML = '';
+        Array.from(select.options).forEach(opt => {
+            const option = document.createElement('option');
+            option.value = opt.textContent;
+            option.dataset.value = opt.value;
+            dataList.appendChild(option);
+        });
+    };
+    updateOptions();
+    input.addEventListener('input', () => {
+        const found = dataList.querySelector(`option[value="${CSS.escape(input.value)}"]`);
+        select.value = found ? found.dataset.value : '';
+        select.dispatchEvent(new Event('change'));
+    });
+    select.parentNode.insertBefore(input, select);
+    select.parentNode.insertBefore(dataList, select);
+    select.style.display = 'none';
+    select._searchable = { input, updateOptions };
+}
+
 function initKerbcycleScanner() {
+    document.querySelectorAll('select.kc-searchable').forEach(makeSearchableSelect);
     const scannerAllowed = kerbcycle_ajax.scanner_enabled;
     const scanResult = document.getElementById("scan-result");
     const assignBtn = document.getElementById("assign-qr-btn");
@@ -30,7 +61,7 @@ function initKerbcycleScanner() {
             const userId = customerIdField ? customerIdField.value : '';
 
             if (!userId || !scannedCode) {
-                alert("Please enter a customer ID and scan a QR code.");
+                alert("Please select a customer and scan a QR code.");
                 return;
             }
 

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -37,8 +37,16 @@ class Shortcodes
         ?>
         <div class="kerbcycle-qr-scanner-container">
             <h2>Assign QR Code</h2>
-            <p>Enter the customer ID and scan the QR code to assign it.</p>
-            <input type="number" id="customer-id" class="regular-text" placeholder="Enter Customer ID" />
+            <p><?php esc_html_e('Select the customer and scan the QR code to assign it.', 'kerbcycle'); ?></p>
+            <?php
+            wp_dropdown_users([
+                'name'             => 'customer_id',
+                'id'               => 'customer-id',
+                'class'            => 'kc-searchable',
+                'show_option_none' => __('Select Customer', 'kerbcycle')
+            ]);
+            ?>
+            <p class="description"><?php esc_html_e('Customer Search', 'kerbcycle'); ?></p>
             <button id="assign-qr-btn" class="button button-primary">Assign QR Code</button>
             <div id="reader" style="width: 100%; max-width: 400px; margin-top: 20px;"></div>
             <div id="scan-result" class="updated" style="display: none;"></div>


### PR DESCRIPTION
## Summary
- replace numeric customer ID field on scanner shortcode with dropdown that searches customers by name
- enable predictive search on the frontend by mirroring admin dropdown behavior

## Testing
- `php -l includes/Public/Shortcodes.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4876d53ec832d853fda8ae54e918e