### PR TITLE
Display total QR code counts on dashboard

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -53,6 +53,19 @@ function initKerbcycleAdmin() {
     const importBtn = document.getElementById("import-qr-btn");
     const importFile = document.getElementById("import-qr-file");
 
+    function adjustCounts(availChange, assignChange) {
+        document.querySelectorAll('.qr-code-counts').forEach(el => {
+            const avail = el.querySelector('.qr-available-count');
+            const assign = el.querySelector('.qr-assigned-count');
+            if (avail) {
+                avail.textContent = parseInt(avail.textContent, 10) + availChange;
+            }
+            if (assign) {
+                assign.textContent = parseInt(assign.textContent, 10) + assignChange;
+            }
+        });
+    }
+
     function refreshDropdowns(oldCode, newCode) {
         [qrSelect, assignedSelect].forEach(select => {
             if (!select) return;
@@ -173,6 +186,7 @@ function initKerbcycleAdmin() {
                             assignedSelect._searchable.updateOptions();
                         }
                     }
+                    adjustCounts(-1, 1);
                 } else {
                     const err = data.data && data.data.message ? data.data.message : "Failed to assign QR code.";
                     showToast(err, true);
@@ -239,6 +253,7 @@ function initKerbcycleAdmin() {
                             assignedSelect._searchable.input.value = '';
                         }
                     }
+                    adjustCounts(1, -1);
                 } else {
                     showToast("Failed to release QR code.", true);
                 }
@@ -280,6 +295,7 @@ function initKerbcycleAdmin() {
                         }
                     }
                     newCodeInput.value = '';
+                    adjustCounts(1, 0);
                     if (data.data && data.data.row) {
                         const row = data.data.row;
                         const list = document.getElementById('qr-code-list');

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -75,6 +75,8 @@ class DashboardPage
         ]) : '';
 
         $available_codes = $wpdb->get_results("SELECT qr_code FROM $table WHERE status = 'available' ORDER BY id DESC");
+        $available_count = count($available_codes);
+        $assigned_count  = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE status = 'assigned'");
 
         $select_sql = "SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $table WHERE $where ORDER BY id DESC LIMIT %d OFFSET %d";
         $query_args = array_merge($params, [$per_page, $offset]);
@@ -180,6 +182,7 @@ class DashboardPage
                     <option value="delete"><?php esc_html_e('Delete', 'kerbcycle'); ?></option>
                 </select>
                 <button id="apply-bulk-top" class="button" data-target="bulk-action-top"><?php esc_html_e('Apply', 'kerbcycle'); ?></button>
+                <p class="qr-code-counts">QR Codes: <span class="qr-available-count"><?= esc_html($available_count); ?></span> Available <span class="qr-assigned-count"><?= esc_html($assigned_count); ?></span> Assigned</p>
                 <?php if ($pagination_links) : ?>
                     <div class="tablenav">
                         <div class="tablenav-pages">
@@ -216,6 +219,7 @@ class DashboardPage
                         </div>
                     </div>
                 <?php endif; ?>
+                <p class="qr-code-counts">QR Codes: <span class="qr-available-count"><?= esc_html($available_count); ?></span> Available <span class="qr-assigned-count"><?= esc_html($assigned_count); ?></span> Assigned</p>
                 <select id="bulk-action">
                     <option value=""><?php esc_html_e('Bulk actions', 'kerbcycle'); ?></option>
                     <option value="release"><?php esc_html_e('Release', 'kerbcycle'); ?></option>


### PR DESCRIPTION
## Summary
- show available and assigned QR code counts above and below the list table
- update counts dynamically in the browser when assigning, releasing or adding codes

## Testing
- `php -l includes/Admin/Pages/DashboardPage.php`
- `node --check assets/js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68c489f390b0832db6751e1aeb18226f