### PR TITLE
Remove Customer Search text from scanner shortcode

### DIFF
--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -46,7 +46,6 @@ class Shortcodes
                 'show_option_none' => __('Select Customer', 'kerbcycle')
             ]);
             ?>
-            <p class="description"><?php esc_html_e('Customer Search', 'kerbcycle'); ?></p>
             <button id="assign-qr-btn" class="button button-primary">Assign QR Code</button>
             <div id="reader" style="width: 100%; max-width: 400px; margin-top: 20px;"></div>
             <div id="scan-result" class="updated" style="display: none;"></div>


### PR DESCRIPTION
## Summary
- remove redundant "Customer Search" helper text on frontend scanner shortcode

## Testing
- `php -l includes/Public/Shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68c48ef4405c832d87399b4eefc7160d