### PR TITLE
Add pagination to frontend QR table

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -93,10 +93,47 @@ function initKerbcycleScanner() {
             });
         });
     }
+
+    const table = document.querySelector('.kerbcycle-qr-table');
+    const pagination = document.querySelector('.kerbcycle-qr-pagination');
+    if (table && pagination) {
+        const rowsPerPage = parseInt(pagination.dataset.rows || '10', 10);
+        paginateQrTable(table, pagination, rowsPerPage);
+    }
 }
 
 if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initKerbcycleScanner);
 } else {
     initKerbcycleScanner();
+}
+
+function paginateQrTable(table, pagination, rowsPerPage) {
+    const rows = Array.from(table.querySelectorAll('tbody tr'));
+    const totalPages = Math.ceil(rows.length / rowsPerPage);
+    let currentPage = 1;
+
+    const renderPage = (page) => {
+        currentPage = page;
+        const start = (page - 1) * rowsPerPage;
+        const end = start + rowsPerPage;
+        rows.forEach((row, index) => {
+            row.style.display = index >= start && index < end ? '' : 'none';
+        });
+        pagination.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
+        const active = pagination.querySelector(`button[data-page="${page}"]`);
+        if (active) active.classList.add('active');
+    };
+
+    for (let i = 1; i <= totalPages; i++) {
+        const btn = document.createElement('button');
+        btn.textContent = i;
+        btn.dataset.page = i;
+        btn.addEventListener('click', () => renderPage(i));
+        pagination.appendChild(btn);
+    }
+
+    if (totalPages > 0) {
+        renderPage(1);
+    }
 }

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -83,6 +83,19 @@ class Shortcodes
                 background: #f0f0f1;
                 font-weight: 600;
             }
+            .kerbcycle-qr-pagination {
+                text-align: center;
+                margin-top: 1em;
+            }
+            .kerbcycle-qr-pagination button {
+                margin: 0 2px;
+                padding: 4px 8px;
+                cursor: pointer;
+            }
+            .kerbcycle-qr-pagination button.active {
+                background: #2271b1;
+                color: #fff;
+            }
         </style>
         <table class="kerbcycle-qr-table">
             <thead>
@@ -114,6 +127,7 @@ class Shortcodes
                 <?php endif; ?>
             </tbody>
         </table>
+        <div class="kerbcycle-qr-pagination" data-rows="10"></div>
         <?php
         return ob_get_clean();
     }


### PR DESCRIPTION
## Summary
- add pagination controls and styling for QR code table shortcode
- paginate QR table on frontend with 10 rows per page via JS

## Testing
- `php -l includes/Public/Shortcodes.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_68c491ca05cc832db8ce25498453fd46