### PR TITLE
Add mobile-friendly customer combobox on scanner page

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1,1 +1,97 @@
 /* Styles for the public pages */
+
+/* Combobox styles */
+.kc-combobox {
+  position: relative;
+  display: inline-flex;
+  gap: 6px;
+  align-items: stretch;
+  max-width: 100%;
+}
+
+.kc-combobox-input {
+  flex: 1 1 auto;
+  min-width: 200px;
+  padding: 8px 10px;
+  font-size: 16px; /* prevents iOS zoom */
+  border: 1px solid #c3c4c7;
+  border-radius: 4px;
+}
+
+.kc-combobox-toggle {
+  flex: 0 0 auto;
+  padding: 0 12px;
+  font-size: 18px;
+  line-height: 1;
+  border: 1px solid #c3c4c7;
+  border-radius: 4px;
+  background: #f6f7f7;
+  cursor: pointer;
+}
+
+.kc-combobox-list {
+  position: absolute;
+  z-index: 10000;
+  left: 0;
+  right: 0;
+  top: calc(100% + 4px);
+  max-height: 260px;
+  overflow: auto;
+  background: #fff;
+  border: 1px solid #c3c4c7;
+  border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+}
+
+.kc-combobox-item {
+  padding: 8px 10px;
+  cursor: pointer;
+}
+
+.kc-combobox-item:hover,
+.kc-combobox-item:focus {
+  background: #f0f0f0;
+  outline: none;
+}
+
+.kc-combobox-empty {
+  color: #777;
+  padding: 8px 10px;
+}
+
+/* Table responsiveness for the scanner page */
+.kerbcycle-qr-scanner-container .kerbcycle-table-wrap {
+  width: 100%;
+  overflow-x: auto;         /* important for small screens */
+  -webkit-overflow-scrolling: touch;
+}
+
+.kerbcycle-qr-scanner-container table {
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 640px;         /* let it scroll instead of squishing */
+  white-space: nowrap;      /* keep labels readable */
+}
+
+.kerbcycle-qr-scanner-container th,
+.kerbcycle-qr-scanner-container td {
+  padding: 8px 10px;
+}
+
+/* Larger tap targets for pagination on mobile */
+.kerbcycle-qr-pagination button {
+  min-width: 40px;
+  min-height: 40px;
+  margin: 2px;
+  border-radius: 6px;
+}
+
+/* Mobile text size to avoid iOS zoom on inputs */
+@media (max-width: 480px) {
+  .kc-combobox-input {
+    font-size: 16px;
+  }
+}

--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -1,33 +1,159 @@
 function makeSearchableSelect(select) {
-  if (!select) return;
-  const listId = select.id + "-list";
-  const dataList = document.createElement("datalist");
-  dataList.id = listId;
-  const input = document.createElement("input");
-  input.setAttribute("list", listId);
-  input.className = "kc-search-input";
-  input.style.minWidth = "200px";
-  const updateOptions = () => {
-    dataList.innerHTML = "";
-    Array.from(select.options).forEach((opt) => {
-      const option = document.createElement("option");
-      option.value = opt.textContent;
-      option.dataset.value = opt.value;
-      dataList.appendChild(option);
-    });
-  };
-  updateOptions();
-  input.addEventListener("input", () => {
-    const found = dataList.querySelector(
-      `option[value="${CSS.escape(input.value)}"]`,
-    );
-    select.value = found ? found.dataset.value : "";
-    select.dispatchEvent(new Event("change"));
-  });
-  select.parentNode.insertBefore(input, select);
-  select.parentNode.insertBefore(dataList, select);
+  if (!select || select._kcEnhanced) return;
+
+  // Wrapper
+  const wrapper = document.createElement("div");
+  wrapper.className = "kc-combobox";
+
+  // Hidden original select stays for value + form submit
   select.style.display = "none";
-  select._searchable = { input, updateOptions };
+  select.parentNode.insertBefore(wrapper, select);
+  wrapper.appendChild(select);
+
+  // Visible input + caret button
+  const input = document.createElement("input");
+  input.type = "text";
+  input.className = "kc-combobox-input";
+  input.placeholder = select.getAttribute("data-placeholder") || "Select…";
+  input.autocomplete = "off";
+  input.inputMode = "search";
+  input.setAttribute("aria-autocomplete", "list");
+  input.setAttribute("aria-expanded", "false");
+  input.setAttribute("role", "combobox");
+
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "kc-combobox-toggle";
+  btn.setAttribute("aria-label", "Open options");
+  btn.innerHTML = "▾";
+
+  const list = document.createElement("ul");
+  list.className = "kc-combobox-list";
+  list.setAttribute("role", "listbox");
+  list.hidden = true;
+
+  wrapper.appendChild(input);
+  wrapper.appendChild(btn);
+  wrapper.appendChild(list);
+
+  // Build items from <select> options
+  function buildList() {
+    list.innerHTML = "";
+    const q = input.value.trim().toLowerCase();
+    const opts = Array.from(select.options);
+    let any = false;
+    opts.forEach((opt) => {
+      const label = opt.textContent || "";
+      if (!q || label.toLowerCase().includes(q)) {
+        const li = document.createElement("li");
+        li.className = "kc-combobox-item";
+        li.textContent = label;
+        li.setAttribute("role", "option");
+        li.dataset.value = opt.value;
+        li.tabIndex = -1;
+        list.appendChild(li);
+        any = true;
+      }
+    });
+    if (!any) {
+      const li = document.createElement("li");
+      li.className = "kc-combobox-empty";
+      li.textContent = "No matches";
+      li.setAttribute("aria-disabled", "true");
+      list.appendChild(li);
+    }
+  }
+
+  function openList() {
+    buildList();
+    list.hidden = false;
+    input.setAttribute("aria-expanded", "true");
+  }
+
+  function closeList() {
+    list.hidden = true;
+    input.setAttribute("aria-expanded", "false");
+  }
+
+  function commitValue(label) {
+    // Find the option by label text
+    const found = Array.from(select.options).find(
+      (o) => (o.textContent || "").trim() === label.trim(),
+    );
+    if (found) {
+      select.value = found.value;
+      input.value = found.textContent;
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    } else {
+      // Clear if not an exact match
+      select.value = "";
+    }
+    closeList();
+  }
+
+  // Initialize input with currently selected option
+  if (select.value) {
+    const cur = select.options[select.selectedIndex];
+    if (cur) input.value = cur.textContent || "";
+  }
+
+  // Events — keyboard, click, touch
+  input.addEventListener("focus", openList);
+  input.addEventListener("input", openList);
+
+  // Enter/Arrow nav
+  input.addEventListener("keydown", (e) => {
+    if (list.hidden) return;
+    const items = Array.from(list.querySelectorAll(".kc-combobox-item"));
+    const active = document.activeElement;
+    const idx = items.indexOf(active);
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const next = items[Math.max(0, Math.min(items.length - 1, idx + 1))] || items[0];
+      next?.focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      const prev = items[Math.max(0, Math.min(items.length - 1, idx - 1))] || items[items.length - 1];
+      prev?.focus();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (active && active.classList.contains("kc-combobox-item")) {
+        commitValue(active.textContent || "");
+      } else if (items.length) {
+        commitValue(items[0].textContent || "");
+      }
+    } else if (e.key === "Escape") {
+      closeList();
+    }
+  });
+
+  // Click/tap on caret button toggles list
+  ["click", "pointerdown", "touchstart"].forEach((ev) => {
+    btn.addEventListener(ev, (e) => {
+      e.preventDefault();
+      if (list.hidden) openList();
+      else closeList();
+    });
+  });
+
+  // Click/tap on options
+  ["click", "pointerdown", "touchstart"].forEach((ev) => {
+    list.addEventListener(ev, (e) => {
+      const li = e.target.closest(".kc-combobox-item");
+      if (!li) return;
+      e.preventDefault();
+      commitValue(li.textContent || "");
+    });
+  });
+
+  // Close when clicking outside
+  document.addEventListener("click", (e) => {
+    if (!wrapper.contains(e.target)) closeList();
+  });
+
+  // Mark enhanced to avoid double init
+  select._kcEnhanced = { input, btn, list, openList, closeList, refresh: buildList };
 }
 
 function initKerbcycleScanner() {

--- a/includes/Public/FrontAssets.php
+++ b/includes/Public/FrontAssets.php
@@ -51,6 +51,13 @@ class FrontAssets
             $deps[] = 'html5-qrcode';
         }
 
+        wp_enqueue_style(
+            'kerbcycle-qr-frontend-css',
+            KERBCYCLE_QR_URL . 'assets/css/public.css',
+            [],
+            KERBCYCLE_QR_VERSION
+        );
+
         wp_enqueue_script(
             'kerbcycle-qr-frontend-js',
             KERBCYCLE_QR_URL . 'assets/js/qr-scanner.js',

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -38,14 +38,19 @@ class Shortcodes
         <div class="kerbcycle-qr-scanner-container">
             <h2>Assign QR Code</h2>
             <p><?php esc_html_e('Select the customer and scan the QR code to assign it.', 'kerbcycle'); ?></p>
-            <?php
-            wp_dropdown_users([
-                'name'             => 'customer_id',
-                'id'               => 'customer-id',
-                'class'            => 'kc-searchable',
-                'show_option_none' => __('Select Customer', 'kerbcycle')
-            ]);
+        <?php
+        wp_dropdown_users([
+            'name'             => 'customer_id',
+            'id'               => 'customer-id',
+            'class'            => 'kc-searchable',
+            'show_option_none' => __('Select Customer', 'kerbcycle')
+        ]);
         ?>
+            <script>
+                document
+                    .getElementById('customer-id')
+                    ?.setAttribute('data-placeholder', '<?php echo esc_js(__('Select Customer', 'kerbcycle')); ?>');
+            </script>
             <button id="assign-qr-btn" class="button button-primary">Assign QR Code</button>
             <div id="reader" style="width: 100%; max-width: 400px; margin-top: 20px;"></div>
             <div id="scan-result" class="updated" style="display: none;"></div>
@@ -97,7 +102,9 @@ class Shortcodes
                 color: #fff;
             }
         </style>
-        <table class="kerbcycle-qr-table">
+        <div class="kerbcycle-qr-scanner-container">
+        <div class="kerbcycle-table-wrap">
+        <table class="kerbcycle-qr-table widefat fixed striped">
             <thead>
                 <tr>
                     <th><?php esc_html_e('ID', 'kerbcycle'); ?></th>
@@ -127,7 +134,9 @@ class Shortcodes
                 <?php endif; ?>
             </tbody>
         </table>
+        </div>
         <div class="kerbcycle-qr-pagination" data-rows="10"></div>
+        </div>
         <?php
         return ob_get_clean();
     }


### PR DESCRIPTION
## Summary
- replace datalist with custom combobox for customer search
- load new frontend stylesheet and style responsive QR table
- wrap QR table in responsive container and set dropdown placeholder

## Testing
- `php -l includes/Public/Shortcodes.php`
- `php -l includes/Public/FrontAssets.php`
- `node --check assets/js/qr-scanner.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5b3fd128c832dbd790b0003dcba9a