### PR TITLE
Add compact mobile layout for QR table

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -95,3 +95,68 @@
     font-size: 16px;
   }
 }
+
+/* --- Compact 6-column mode (<= 420px) --- */
+@media (max-width: 420px) {
+  .kerbcycle-qr-scanner-container.kc-compact table {
+    table-layout: fixed;
+    width: 100%;
+    font-size: 12px;
+  }
+  .kerbcycle-qr-scanner-container.kc-compact th,
+  .kerbcycle-qr-scanner-container.kc-compact td {
+    padding: 4px 6px;
+    vertical-align: middle;
+  }
+  .kerbcycle-qr-scanner-container.kc-compact th,
+  .kerbcycle-qr-scanner-container.kc-compact td {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  /* Suggested column widths — adjust to your real data */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(1),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(1) { width: 10%; } /* ID */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(2),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(2) { width: 22%; } /* QR Code */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(3),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(3) { width: 18%; } /* User */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(4),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(4) { width: 15%; } /* Status */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(5),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(5) { width: 20%; } /* Assigned */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(6),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(6) { width: 15%; } /* Actions */
+
+  /* Abbreviate long headers using data-short attr */
+  .kerbcycle-qr-scanner-container.kc-compact th[data-short]::after {
+    content: attr(data-short);
+  }
+  .kerbcycle-qr-scanner-container.kc-compact th[data-short] > * {
+    display: none;
+  }
+
+  /* Make action buttons tappable but tiny */
+  .kerbcycle-qr-scanner-container.kc-compact .button,
+  .kerbcycle-qr-scanner-container.kc-compact button,
+  .kerbcycle-qr-scanner-container.kc-compact .components-button {
+    padding: 2px 6px;
+    line-height: 1.2;
+    font-size: 12px;
+  }
+
+  /* If you display a QR image thumbnail, cap it */
+  .kerbcycle-qr-scanner-container.kc-compact .qr-thumb {
+    max-width: 28px;
+    max-height: 28px;
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  /* Allow designated cells to wrap if needed */
+  .kerbcycle-qr-scanner-container.kc-compact td.wrap {
+    white-space: normal;
+    word-break: break-word;
+  }
+}

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -103,17 +103,17 @@ class Shortcodes
                 color: #fff;
             }
         </style>
-        <div class="kerbcycle-qr-scanner-container">
+        <div class="kerbcycle-qr-scanner-container kc-compact">
         <div class="kerbcycle-table-wrap">
         <table class="kerbcycle-qr-table widefat fixed striped">
             <thead>
                 <tr>
-                    <th><?php esc_html_e('ID', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('QR Code', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('User ID', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('Customer', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('Assigned At', 'kerbcycle'); ?></th>
+                    <th data-short="ID"><?php esc_html_e('ID', 'kerbcycle'); ?></th>
+                    <th data-short="QR"><?php esc_html_e('QR Code', 'kerbcycle'); ?></th>
+                    <th data-short="User"><?php esc_html_e('User ID', 'kerbcycle'); ?></th>
+                    <th data-short="Cust"><?php esc_html_e('Customer', 'kerbcycle'); ?></th>
+                    <th data-short="Sts"><?php esc_html_e('Status', 'kerbcycle'); ?></th>
+                    <th data-short="Asg"><?php esc_html_e('Assigned At', 'kerbcycle'); ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -121,11 +121,11 @@ class Shortcodes
                     <?php foreach ($codes as $code) : ?>
                         <tr>
                             <td><?= esc_html($code->id); ?></td>
-                            <td><?= esc_html($code->qr_code); ?></td>
+                            <td title="<?= esc_attr($code->qr_code); ?>"><?= esc_html($code->qr_code); ?></td>
                             <td><?= $code->user_id ? esc_html($code->user_id) : '—'; ?></td>
-                            <td><?= $code->display_name ? esc_html($code->display_name) : '—'; ?></td>
+                            <td title="<?= $code->display_name ? esc_attr($code->display_name) : ''; ?>"><?= $code->display_name ? esc_html($code->display_name) : '—'; ?></td>
                             <td><?= esc_html(ucfirst($code->status)); ?></td>
-                            <td><?= $code->assigned_at ? esc_html($code->assigned_at) : '—'; ?></td>
+                            <td title="<?= $code->assigned_at ? esc_attr($code->assigned_at) : ''; ?>"><?= $code->assigned_at ? esc_html($code->assigned_at) : '—'; ?></td>
                         </tr>
                     <?php endforeach; ?>
                 <?php else : ?>


### PR DESCRIPTION
## Summary
- enable compact smartphone layout for scanner table
- abbreviate table headers and add tooltips for truncated values

## Testing
- `php -l includes/Public/Shortcodes.php`
- `npm test` *(fails: package.json not found)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c6fdba38832db2af80128d598726