### PR TITLE
Add compact mobile layout for QR table

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -95,3 +95,52 @@
     font-size: 16px;
   }
 }
+
+/* --- Compact 6-col table for phones --- */
+@media (max-width: 420px) {
+  .kerbcycle-qr-scanner-container.kc-compact table {
+    table-layout: fixed;
+    width: 100%;
+    font-size: 12px;                 /* tight but readable */
+  }
+  .kerbcycle-qr-scanner-container.kc-compact th,
+  .kerbcycle-qr-scanner-container.kc-compact td {
+    padding: 4px 6px;
+    vertical-align: middle;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  /* Column widths tuned to your data (sum = 100%) */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(1),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(1) { width: 10%; } /* ID (203) */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(2),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(2) { width: 18%; } /* QR Code (62754963) */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(3),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(3) { width: 10%; } /* User ID (5) */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(4),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(4) { width: 26%; } /* Customer */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(5),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(5) { width: 14%; } /* Status */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(6),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(6) { width: 22%; } /* Assigned At */
+
+  /* Short header labels on phones */
+  .kerbcycle-qr-scanner-container.kc-compact th[data-short]::after { content: attr(data-short); }
+  .kerbcycle-qr-scanner-container.kc-compact th[data-short] > * { display: none; }
+
+  /* Make digits align nicely */
+  .kerbcycle-qr-scanner-container.kc-compact td,
+  .kerbcycle-qr-scanner-container.kc-compact th {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Action buttons inside table (if any) */
+  .kerbcycle-qr-scanner-container.kc-compact .button,
+  .kerbcycle-qr-scanner-container.kc-compact button {
+    padding: 2px 6px;
+    line-height: 1.2;
+    font-size: 12px;
+  }
+}

--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -158,6 +158,22 @@ function makeSearchableSelect(select) {
   select._kcEnhanced = { input, btn, list, openList, closeList, refresh: buildList };
 }
 
+function shortenQrDates() {
+  const mm = window.matchMedia("(max-width: 420px)");
+  if (!mm.matches) return;
+  document
+    .querySelectorAll(
+      ".kerbcycle-qr-scanner-container.kc-compact td.kc-date",
+    )
+    .forEach((td) => {
+      const full = td.getAttribute("data-full") || td.textContent.trim();
+      const m = full.match(/^(\\d{4})-(\\d{2})-(\\d{2})\s+(\\d{2}):(\\d{2})/);
+      if (m) {
+        td.textContent = `${m[2]}/${m[3]} ${m[4]}:${m[5]}`;
+      }
+    });
+}
+
 function initKerbcycleScanner() {
   document
     .querySelectorAll("select.kc-searchable")
@@ -245,6 +261,7 @@ function initKerbcycleScanner() {
     const rowsPerPage = parseInt(pagination.dataset.rows || "10", 10);
     paginateQrTable(table, pagination, rowsPerPage);
   }
+  shortenQrDates();
 }
 
 if (document.readyState === "loading") {

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -103,17 +103,17 @@ class Shortcodes
                 color: #fff;
             }
         </style>
-        <div class="kerbcycle-qr-scanner-container">
+        <div class="kerbcycle-qr-scanner-container kc-compact">
         <div class="kerbcycle-table-wrap">
         <table class="kerbcycle-qr-table widefat fixed striped">
             <thead>
                 <tr>
-                    <th><?php esc_html_e('ID', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('QR Code', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('User ID', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('Customer', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('Assigned At', 'kerbcycle'); ?></th>
+                    <th data-short="ID"><?php esc_html_e('ID', 'kerbcycle'); ?></th>
+                    <th data-short="QR"><?php esc_html_e('QR Code', 'kerbcycle'); ?></th>
+                    <th data-short="UID"><?php esc_html_e('User ID', 'kerbcycle'); ?></th>
+                    <th data-short="Cust"><?php esc_html_e('Customer', 'kerbcycle'); ?></th>
+                    <th data-short="Sts"><?php esc_html_e('Status', 'kerbcycle'); ?></th>
+                    <th data-short="At"><?php esc_html_e('Assigned At', 'kerbcycle'); ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -121,11 +121,11 @@ class Shortcodes
                     <?php foreach ($codes as $code) : ?>
                         <tr>
                             <td><?= esc_html($code->id); ?></td>
-                            <td><?= esc_html($code->qr_code); ?></td>
+                            <td title="<?= esc_attr($code->qr_code); ?>"><?= esc_html($code->qr_code); ?></td>
                             <td><?= $code->user_id ? esc_html($code->user_id) : '—'; ?></td>
-                            <td><?= $code->display_name ? esc_html($code->display_name) : '—'; ?></td>
+                            <td title="<?= $code->display_name ? esc_attr($code->display_name) : ''; ?>"><?= $code->display_name ? esc_html($code->display_name) : '—'; ?></td>
                             <td><?= esc_html(ucfirst($code->status)); ?></td>
-                            <td><?= $code->assigned_at ? esc_html($code->assigned_at) : '—'; ?></td>
+                            <td class="kc-date" title="<?= $code->assigned_at ? esc_attr($code->assigned_at) : ''; ?>" data-full="<?= $code->assigned_at ? esc_attr($code->assigned_at) : ''; ?>"><?= $code->assigned_at ? esc_html($code->assigned_at) : '—'; ?></td>
                         </tr>
                     <?php endforeach; ?>
                 <?php else : ?>


### PR DESCRIPTION
## Summary
- refine compact smartphone layout with precise column widths
- add short header labels and date truncation helper for narrow screens

## Testing
- `php -l includes/Public/Shortcodes.php`
- `npm test` *(fails: package.json not found)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c6fdba38832db2af80128d598726