### PR TITLE
Add compact mobile layout for QR table

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -95,3 +95,80 @@
     font-size: 16px;
   }
 }
+
+/* Compact header: hide full text and show data-short only */
+@media (max-width: 480px) {
+  .kerbcycle-qr-scanner-container.kc-compact th[data-short] {
+    font-size: 0;
+    line-height: 1.2;
+  }
+  .kerbcycle-qr-scanner-container.kc-compact th[data-short]::after {
+    content: attr(data-short);
+    font-size: 12px;
+  }
+}
+
+/* --- Compact 6-col table for phones --- */
+@media (max-width: 480px) {
+  .kerbcycle-qr-scanner-container.kc-compact .kerbcycle-table-wrap {
+    overflow-x: visible;
+  }
+
+  .kerbcycle-qr-scanner-container.kc-compact table {
+    table-layout: fixed;
+    width: 100%;
+    min-width: 0 !important;     /* kill old 640px min-width */
+    border-collapse: collapse;
+    border-spacing: 0;
+    font-size: 12px;
+    box-sizing: border-box;
+  }
+
+  .kerbcycle-qr-scanner-container.kc-compact th,
+  .kerbcycle-qr-scanner-container.kc-compact td {
+    padding: 2px 4px !important;
+    vertical-align: middle;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    box-sizing: border-box;
+  }
+
+  /* Widths tuned to sample data (sum = 100%) */
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(1),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(1) { width: 8% !important; }
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(2),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(2) { width: 17% !important; }
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(3),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(3) { width: 8% !important; }
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(4),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(4) { width: 31% !important; }
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(5),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(5) { width: 12% !important; }
+  .kerbcycle-qr-scanner-container.kc-compact th:nth-child(6),
+  .kerbcycle-qr-scanner-container.kc-compact td:nth-child(6) { width: 24% !important; }
+
+  /* Make digits align nicely */
+  .kerbcycle-qr-scanner-container.kc-compact td,
+  .kerbcycle-qr-scanner-container.kc-compact th {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Buttons inside cells shouldn't force columns wide */
+  .kerbcycle-qr-scanner-container.kc-compact .button,
+  .kerbcycle-qr-scanner-container.kc-compact button,
+  .kerbcycle-qr-scanner-container.kc-compact .components-button {
+    padding: 1px 4px !important;
+    line-height: 1.1 !important;
+    font-size: 12px !important;
+    min-width: 0 !important;
+  }
+
+  /* If a QR thumbnail exists, cap it */
+  .kerbcycle-qr-scanner-container.kc-compact .qr-thumb {
+    max-width: 24px;
+    max-height: 24px;
+    display: inline-block;
+    vertical-align: middle;
+  }
+}

--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -158,6 +158,22 @@ function makeSearchableSelect(select) {
   select._kcEnhanced = { input, btn, list, openList, closeList, refresh: buildList };
 }
 
+function shortenQrDates() {
+  const mm = window.matchMedia("(max-width: 480px)");
+  if (!mm.matches) return;
+
+  document
+    .querySelectorAll(".kerbcycle-qr-scanner-container tbody tr")
+    .forEach((tr) => {
+      const td =
+        tr.querySelector("td.kc-date") || tr.querySelector("td:nth-child(6)");
+      if (!td) return;
+      const full = td.getAttribute("data-full") || td.textContent.trim();
+      const m = full.match(/^(\d{4})-(\d{2})-(\d{2})/);
+      if (m) td.textContent = `${m[2]}/${m[3]}`;
+    });
+}
+
 function initKerbcycleScanner() {
   document
     .querySelectorAll("select.kc-searchable")
@@ -251,6 +267,18 @@ if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", initKerbcycleScanner);
 } else {
   initKerbcycleScanner();
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", shortenQrDates);
+} else {
+  shortenQrDates();
+}
+
+const kcContainer = document.querySelector(".kerbcycle-qr-scanner-container");
+if (kcContainer) {
+  const mo = new MutationObserver(shortenQrDates);
+  mo.observe(kcContainer, { childList: true, subtree: true });
 }
 
 function paginateQrTable(table, pagination, rowsPerPage) {

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -35,7 +35,7 @@ class Shortcodes
     {
         ob_start();
         ?>
-        <div class="kerbcycle-qr-scanner-container">
+        <div class="kerbcycle-qr-scanner-container kc-compact">
             <h2>Assign QR Code</h2>
             <p><?php esc_html_e('Select the customer and scan the QR code to assign it.', 'kerbcycle'); ?></p>
         <?php
@@ -103,40 +103,47 @@ class Shortcodes
                 color: #fff;
             }
         </style>
-        <div class="kerbcycle-qr-scanner-container">
-        <div class="kerbcycle-table-wrap">
-        <table class="kerbcycle-qr-table widefat fixed striped">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e('ID', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('QR Code', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('User ID', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('Customer', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
-                    <th><?php esc_html_e('Assigned At', 'kerbcycle'); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php if (!empty($codes)) : ?>
-                    <?php foreach ($codes as $code) : ?>
+        <!-- Wrap the table so compact CSS/JS can target it -->
+        <div class="kerbcycle-qr-scanner-container kc-compact">
+            <div class="kerbcycle-table-wrap">
+                <table class="kerbcycle-qr-table widefat fixed striped">
+                    <thead>
                         <tr>
-                            <td><?= esc_html($code->id); ?></td>
-                            <td><?= esc_html($code->qr_code); ?></td>
-                            <td><?= $code->user_id ? esc_html($code->user_id) : '—'; ?></td>
-                            <td><?= $code->display_name ? esc_html($code->display_name) : '—'; ?></td>
-                            <td><?= esc_html(ucfirst($code->status)); ?></td>
-                            <td><?= $code->assigned_at ? esc_html($code->assigned_at) : '—'; ?></td>
+                            <th data-short="ID"><?php esc_html_e('ID', 'kerbcycle'); ?></th>
+                            <th data-short="QR"><?php esc_html_e('QR Code', 'kerbcycle'); ?></th>
+                            <th data-short="UID"><?php esc_html_e('User ID', 'kerbcycle'); ?></th>
+                            <th data-short="Cust"><?php esc_html_e('Customer', 'kerbcycle'); ?></th>
+                            <th data-short="Sts"><?php esc_html_e('Status', 'kerbcycle'); ?></th>
+                            <th data-short="At"><?php esc_html_e('Assigned At', 'kerbcycle'); ?></th>
                         </tr>
-                    <?php endforeach; ?>
-                <?php else : ?>
-                    <tr>
-                        <td colspan="6" class="description"><?php esc_html_e('No QR codes found', 'kerbcycle'); ?></td>
-                    </tr>
-                <?php endif; ?>
-            </tbody>
-        </table>
-        </div>
-        <div class="kerbcycle-qr-pagination" data-rows="10"></div>
+                    </thead>
+                    <tbody>
+                        <?php if (!empty($codes)) : ?>
+                            <?php foreach ($codes as $code) : ?>
+                                <tr>
+                                    <td><?= esc_html($code->id); ?></td>
+                                    <td title="<?= esc_attr($code->qr_code); ?>"><?= esc_html($code->qr_code); ?></td>
+                                    <td><?= $code->user_id ? esc_html($code->user_id) : '—'; ?></td>
+                                    <td title="<?= $code->display_name ? esc_attr($code->display_name) : '—'; ?>"><?= $code->display_name ? esc_html($code->display_name) : '—'; ?></td>
+                                    <td><?= esc_html(ucfirst($code->status)); ?></td>
+                                    <td
+                                        class="kc-date"
+                                        title="<?= $code->assigned_at ? esc_attr($code->assigned_at) : '—'; ?>"
+                                        data-full="<?= $code->assigned_at ? esc_attr($code->assigned_at) : ''; ?>"
+                                    >
+                                        <?= $code->assigned_at ? esc_html($code->assigned_at) : '—'; ?>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php else : ?>
+                            <tr>
+                                <td colspan="6" class="description"><?php esc_html_e('No QR codes found', 'kerbcycle'); ?></td>
+                            </tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+            <div class="kerbcycle-qr-pagination" data-rows="10"></div>
         </div>
         <?php
         return ob_get_clean();

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name: KerbCycle QR Code Manager
 Description: Manage QR code scanning and assignment with drag-and-drop, inline editing, bulk actions, and notification toggles
-Version: 2.0
+Version: 2.0.1
 Author: Your Name
 Text Domain: kerbcycle
 */
@@ -25,7 +25,8 @@ if (!defined('KERBCYCLE_QR_PATH')) {
 
 // Define plugin version constant
 if (!defined('KERBCYCLE_QR_VERSION')) {
-    define('KERBCYCLE_QR_VERSION', '2.0');
+    // bump to bust cached CSS/JS after compact layout changes
+    define('KERBCYCLE_QR_VERSION', '2.0.3');
 }
 
 // Require the autoloader


### PR DESCRIPTION
## Summary
- hide full headers and tighten spacing so all six QR columns fit on ≤480px screens, ensuring the scanner container carries the `kc-compact` class so the rules actually apply
- wrap the shortcode table output in the `.kerbcycle-qr-scanner-container`/`.kerbcycle-table-wrap` markup, expose `data-full` attributes, and keep tooltip fallbacks so the compact CSS and date shortener can target the rows
- shorten the timestamp column to `MM/DD` on narrow devices and reapply after DOM updates even if `.kc-compact` is omitted, by widening the date shortener's selectors

## Testing
- `php -l kerbcycle-qr-code-manager.php`
- `php -l includes/Public/Shortcodes.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c6fdba38832db2af80128d598726