### PR TITLE
Add resume control for frontend QR scanner

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1,5 +1,38 @@
 /* Styles for the public pages */
 
+/* Resume scan button */
+#resume-scan-btn {
+  display: none;
+  width: 100%;
+  margin-top: 16px;
+  padding: 10px 16px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #2271b1;
+  background: #f6f7f7;
+  border: 1px solid #2271b1;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+#resume-scan-btn.is-visible {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#resume-scan-btn:hover:not([disabled]),
+#resume-scan-btn:focus-visible:not([disabled]) {
+  background: #2271b1;
+  color: #fff;
+}
+
+#resume-scan-btn[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Combobox styles */
 .kc-combobox {
   position: relative;

--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -348,6 +348,13 @@ function setScanResult(element, type, html) {
   element.innerHTML = html;
 }
 
+function clearScanResult(element) {
+  if (!element) return;
+  element.style.display = "none";
+  element.classList.remove("error", "updated");
+  element.innerHTML = "";
+}
+
 function updateQrDatesView(isMobile) {
   document
     .querySelectorAll(".kerbcycle-qr-scanner-container tbody tr")
@@ -391,9 +398,26 @@ function initKerbcycleScanner() {
   const scanResult = document.getElementById("scan-result");
   const assignBtn = document.getElementById("assign-qr-btn");
   const customerIdField = document.getElementById("customer-id");
+  const resumeBtn = document.getElementById("resume-scan-btn");
   let scannedCode = "";
 
   let scanner = null;
+
+  const hideResumeButton = () => {
+    if (!resumeBtn) return;
+    resumeBtn.classList.remove("is-visible");
+    resumeBtn.disabled = false;
+    resumeBtn.removeAttribute("aria-busy");
+  };
+
+  const showResumeButton = () => {
+    if (!resumeBtn) return;
+    resumeBtn.classList.add("is-visible");
+    resumeBtn.disabled = false;
+    resumeBtn.removeAttribute("aria-busy");
+  };
+
+  hideResumeButton();
 
   if (
     scannerAllowed &&
@@ -411,8 +435,9 @@ function initKerbcycleScanner() {
       setScanResult(
         scanResult,
         "success",
-        `<strong>✅ QR Code Scanned Successfully!</strong><br>Content: <code>${safeCode}</code>`,
+        `<strong>✅ QR Code Scanned Successfully!</strong><br>Content: <code>${safeCode}</code><br><em>Use "Scan Again" to capture a different code.</em>`,
       );
+      showResumeButton();
     }
 
     scanner
@@ -495,6 +520,7 @@ function initKerbcycleScanner() {
             messageParts.push("Scan another code to continue.");
 
             setScanResult(scanResult, "success", messageParts.join("<br>"));
+            hideResumeButton();
 
             if (customerIdField) {
               const placeholderIndex = Array.from(
@@ -528,10 +554,12 @@ function initKerbcycleScanner() {
                 if (resumeResult && typeof resumeResult.catch === "function") {
                   resumeResult.catch((resumeError) => {
                     console.warn("Unable to resume scanner", resumeError);
+                    showResumeButton();
                   });
                 }
               } catch (resumeError) {
                 console.warn("Unable to resume scanner", resumeError);
+                showResumeButton();
               }
             }
           } else {
@@ -560,6 +588,73 @@ function initKerbcycleScanner() {
           assignBtn.disabled = false;
           assignBtn.removeAttribute("aria-busy");
         });
+    });
+  }
+
+  if (resumeBtn) {
+    resumeBtn.addEventListener("click", () => {
+      if (resumeBtn.disabled) {
+        return;
+      }
+
+      resumeBtn.disabled = true;
+      resumeBtn.setAttribute("aria-busy", "true");
+
+      const onResumeSuccess = () => {
+        scannedCode = "";
+        clearScanResult(scanResult);
+        hideResumeButton();
+      };
+
+      const onResumeFailure = (resumeError) => {
+        console.warn("Unable to resume scanner", resumeError);
+        const resumeMessage =
+          resumeError && typeof resumeError === "object" && "message" in resumeError
+            ? resumeError.message
+            : String(resumeError);
+        setScanResult(
+          scanResult,
+          "error",
+          `<strong>❌ Unable to resume the scanner.</strong><br>${escapeHtml(
+            resumeMessage,
+          )}`,
+        );
+        showResumeButton();
+      };
+
+      const finalizeResumeAttempt = () => {
+        resumeBtn.disabled = false;
+        resumeBtn.removeAttribute("aria-busy");
+      };
+
+      if (!scanner || typeof scanner.resume !== "function") {
+        onResumeFailure(
+          new Error("Scanner resume method is unavailable. Please refresh the page."),
+        );
+        finalizeResumeAttempt();
+        return;
+      }
+
+      try {
+        const resumeOutcome = scanner.resume();
+        if (resumeOutcome && typeof resumeOutcome.then === "function") {
+          resumeOutcome
+            .then(() => {
+              onResumeSuccess();
+            })
+            .catch((resumeError) => {
+              onResumeFailure(resumeError);
+            })
+            .finally(finalizeResumeAttempt);
+          return;
+        }
+
+        onResumeSuccess();
+      } catch (resumeError) {
+        onResumeFailure(resumeError);
+      }
+
+      finalizeResumeAttempt();
     });
   }
 

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -54,6 +54,7 @@ class Shortcodes
             </script>
             <button id="assign-qr-btn" class="button button-primary">Assign QR Code</button>
             <div id="reader" style="width: 100%; max-width: 400px; margin-top: 20px;"></div>
+            <button id="resume-scan-btn" type="button" class="kc-resume-scan"><?php esc_html_e('Scan Again', 'kerbcycle'); ?></button>
             <div id="scan-result" class="updated" style="display: none;"></div>
         </div>
         <?php


### PR DESCRIPTION
## Summary
- add a "Scan Again" button to the public scanner shortcode so the camera can be resumed without reloading the page
- update the scanner script to manage resume button state, clear status messages, and show actionable feedback when resuming fails
- style the new control so it fits the existing frontend layout

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc769ed1cc832daaab40121b77b285