### PR TITLE
Ensure scanner resumes after assignment requests

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -559,6 +559,21 @@ function initKerbcycleScanner() {
         .finally(() => {
           assignBtn.disabled = false;
           assignBtn.removeAttribute("aria-busy");
+
+          // Always attempt to resume the scanner after handling the
+          // assignment request, even when the server returns an error.
+          try {
+            if (scannerAllowed && scanner && typeof scanner.resume === "function") {
+              const resumeResult = scanner.resume();
+              if (resumeResult && typeof resumeResult.catch === "function") {
+                resumeResult.catch((resumeError) => {
+                  console.warn("Unable to resume scanner", resumeError);
+                });
+              }
+            }
+          } catch (resumeError) {
+            console.warn("Unable to resume scanner", resumeError);
+          }
         });
     });
   }


### PR DESCRIPTION
## Summary
- always attempt to resume the QR scanner after assignment requests complete
- prevent the frontend scanner from remaining paused when the backend rejects a code (e.g., duplicates)

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc9534eed4832d99228bdaf735e05b