### PR TITLE
Add scan reset control to frontend QR scanner

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -76,6 +76,14 @@
   white-space: nowrap; /* keep labels readable */
 }
 
+.kerbcycle-scanner-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+  align-items: center;
+}
+
 .kerbcycle-qr-scanner-container th,
 .kerbcycle-qr-scanner-container td {
   padding: 8px 10px;

--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -390,6 +390,7 @@ function initKerbcycleScanner() {
   const scannerAllowed = kerbcycle_ajax.scanner_enabled;
   const scanResult = document.getElementById("scan-result");
   const assignBtn = document.getElementById("assign-qr-btn");
+  const resetBtn = document.getElementById("reset-scan-btn");
   const customerIdField = document.getElementById("customer-id");
   let scannedCode = "";
 
@@ -575,6 +576,31 @@ function initKerbcycleScanner() {
             console.warn("Unable to resume scanner", resumeError);
           }
         });
+    });
+  }
+
+  if (resetBtn) {
+    resetBtn.addEventListener("click", () => {
+      scannedCode = "";
+
+      if (scanResult) {
+        scanResult.style.display = "none";
+        scanResult.classList.remove("error", "updated");
+        scanResult.innerHTML = "";
+      }
+
+      try {
+        if (scannerAllowed && scanner && typeof scanner.resume === "function") {
+          const resumeResult = scanner.resume();
+          if (resumeResult && typeof resumeResult.catch === "function") {
+            resumeResult.catch((resumeError) => {
+              console.warn("Unable to resume scanner", resumeError);
+            });
+          }
+        }
+      } catch (resumeError) {
+        console.warn("Unable to resume scanner", resumeError);
+      }
     });
   }
 

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -52,7 +52,10 @@ class Shortcodes
                     .getElementById('customer-id')
                     ?.setAttribute('data-placeholder', '<?php echo esc_js(__('Select Customer', 'kerbcycle')); ?>');
             </script>
-            <button id="assign-qr-btn" class="button button-primary">Assign QR Code</button>
+            <div class="kerbcycle-scanner-actions">
+                <button id="assign-qr-btn" class="button button-primary">Assign QR Code</button>
+                <button id="reset-scan-btn" class="button"><?php esc_html_e('Scan Reset', 'kerbcycle'); ?></button>
+            </div>
             <div id="reader" style="width: 100%; max-width: 400px; margin-top: 20px;"></div>
             <div id="scan-result" class="updated" style="display: none;"></div>
         </div>


### PR DESCRIPTION
## Summary
- add a Scan Reset control next to the Assign QR Code button in the frontend scanner shortcode
- wire the reset button to clear the last scanned value, hide the status message, and resume the QR scanner when needed
- introduce light styling so the new action buttons sit together neatly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd93687bf0832d8a06afbe6dcc4f21