### PR TITLE
Improve scanner reset reliability

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -395,6 +395,137 @@ function initKerbcycleScanner() {
   let scannedCode = "";
 
   let scanner = null;
+  const scannerCameraConfig = { facingMode: "environment" };
+  const scannerStartConfig = { fps: 10, qrbox: 250 };
+  let scannerStateHint = "NOT_STARTED";
+  let scannerActivationPromise = null;
+
+  function getScannerState() {
+    if (scanner && typeof scanner.getState === "function") {
+      try {
+        return scanner.getState();
+      } catch (stateError) {
+        // Fall back to our internal hint when the library cannot report the state.
+        return scannerStateHint;
+      }
+    }
+    return scannerStateHint;
+  }
+
+  function updateScannerStateHint(state) {
+    if (typeof state === "string" && state) {
+      scannerStateHint = state;
+    }
+  }
+
+  function pauseActiveScanner() {
+    if (!scannerAllowed || !scanner || typeof scanner.pause !== "function") {
+      return;
+    }
+
+    const currentState = getScannerState();
+    if (currentState === "PAUSED") {
+      updateScannerStateHint("PAUSED");
+      return;
+    }
+
+    try {
+      const pauseResult = scanner.pause(true);
+      updateScannerStateHint("PAUSED");
+      if (pauseResult && typeof pauseResult.catch === "function") {
+        pauseResult.catch((pauseError) => {
+          console.warn("Unable to pause scanner", pauseError);
+          updateScannerStateHint("SCANNING");
+        });
+      }
+    } catch (pauseError) {
+      console.warn("Unable to pause scanner", pauseError);
+      updateScannerStateHint("SCANNING");
+    }
+  }
+
+  function displayScannerStartError(error) {
+    if (!scanResult) {
+      return;
+    }
+    const safeErr = escapeHtml(String(error));
+    setScanResult(
+      scanResult,
+      "error",
+      `<strong>❌ Unable to start scanner.</strong> Please ensure you have a camera and have granted permission.<br>${safeErr}`,
+    );
+  }
+
+  function activateScanner(options = {}) {
+    const { clearCode = false, showError = false } = options;
+
+    if (clearCode) {
+      scannedCode = "";
+    }
+
+    if (!scannerAllowed || !scanner) {
+      return;
+    }
+
+    if (scannerActivationPromise) {
+      return;
+    }
+
+    const currentState = getScannerState();
+    if (currentState === "SCANNING") {
+      updateScannerStateHint("SCANNING");
+      return;
+    }
+
+    let activation;
+    if (currentState === "PAUSED" && typeof scanner.resume === "function") {
+      try {
+        activation = scanner.resume();
+      } catch (resumeError) {
+        console.warn("Unable to resume scanner", resumeError);
+        if (showError) {
+          displayScannerStartError(resumeError);
+        }
+        return;
+      }
+    } else {
+      try {
+        activation = scanner.start(
+          scannerCameraConfig,
+          scannerStartConfig,
+          onScanSuccess,
+        );
+      } catch (startError) {
+        console.error("Unable to start scanning", startError);
+        if (showError) {
+          displayScannerStartError(startError);
+        }
+        updateScannerStateHint("STOPPED");
+        return;
+      }
+    }
+
+    if (activation && typeof activation.then === "function") {
+      scannerActivationPromise = activation;
+      activation
+        .then(() => {
+          updateScannerStateHint("SCANNING");
+        })
+        .catch((activationError) => {
+          console.error("Unable to activate scanner", activationError);
+          if (showError) {
+            displayScannerStartError(activationError);
+          }
+        })
+        .finally(() => {
+          if (scannerActivationPromise === activation) {
+            scannerActivationPromise = null;
+          }
+        });
+    } else {
+      updateScannerStateHint("SCANNING");
+    }
+  }
 
   if (
     scannerAllowed &&
@@ -404,9 +535,7 @@ function initKerbcycleScanner() {
     scanner = new Html5Qrcode("reader", true);
 
     function onScanSuccess(decodedText) {
-      if (scanner && typeof scanner.pause === "function") {
-        scanner.pause();
-      }
+      pauseActiveScanner();
       scannedCode = decodedText || "";
       const safeCode = escapeHtml(decodedText || "");
       setScanResult(
@@ -415,22 +544,7 @@ function initKerbcycleScanner() {
         `<strong>✅ QR Code Scanned Successfully!</strong><br>Content: <code>${safeCode}</code>`,
       );
     }
-
-    scanner
-      .start(
-        { facingMode: "environment" },
-        { fps: 10, qrbox: 250 },
-        onScanSuccess,
-      )
-      .catch((err) => {
-        console.error(`Unable to start scanning, error: ${err}`);
-        const safeErr = escapeHtml(String(err));
-        setScanResult(
-          scanResult,
-          "error",
-          `<strong>❌ Unable to start scanner.</strong> Please ensure you have a camera and have granted permission.<br>${safeErr}`,
-        );
-      });
+    activateScanner({ showError: true });
   }
 
   if (assignBtn) {
@@ -523,18 +637,6 @@ function initKerbcycleScanner() {
             }
 
             scannedCode = "";
-            if (scanner && typeof scanner.resume === "function") {
-              try {
-                const resumeResult = scanner.resume();
-                if (resumeResult && typeof resumeResult.catch === "function") {
-                  resumeResult.catch((resumeError) => {
-                    console.warn("Unable to resume scanner", resumeError);
-                  });
-                }
-              } catch (resumeError) {
-                console.warn("Unable to resume scanner", resumeError);
-              }
-            }
           } else {
             const err =
               data.data && data.data.message
@@ -561,20 +663,9 @@ function initKerbcycleScanner() {
           assignBtn.disabled = false;
           assignBtn.removeAttribute("aria-busy");
 
-          // Always attempt to resume the scanner after handling the
+          // Always attempt to reactivate the scanner after handling the
           // assignment request, even when the server returns an error.
-          try {
-            if (scannerAllowed && scanner && typeof scanner.resume === "function") {
-              const resumeResult = scanner.resume();
-              if (resumeResult && typeof resumeResult.catch === "function") {
-                resumeResult.catch((resumeError) => {
-                  console.warn("Unable to resume scanner", resumeError);
-                });
-              }
-            }
-          } catch (resumeError) {
-            console.warn("Unable to resume scanner", resumeError);
-          }
+          activateScanner({ showError: true });
         });
     });
   }
@@ -589,18 +680,7 @@ function initKerbcycleScanner() {
         scanResult.innerHTML = "";
       }
 
-      try {
-        if (scannerAllowed && scanner && typeof scanner.resume === "function") {
-          const resumeResult = scanner.resume();
-          if (resumeResult && typeof resumeResult.catch === "function") {
-            resumeResult.catch((resumeError) => {
-              console.warn("Unable to resume scanner", resumeError);
-            });
-          }
-        }
-      } catch (resumeError) {
-        console.warn("Unable to resume scanner", resumeError);
-      }
+      activateScanner({ clearCode: true, showError: true });
     });
   }
 


### PR DESCRIPTION
## Summary
- add reusable helpers to pause and reactivate the Html5Qrcode instance safely
- ensure the scanner restarts after assignments and when pressing the Scan Reset button
- surface scanner start errors consistently when activation fails

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cd97bd48f8832d97b0464ea7dd512a