### PR TITLE
Add reset control to frontend customer search combobox

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -29,6 +29,25 @@
   cursor: pointer;
 }
 
+.kc-combobox-reset {
+  flex: 0 0 auto;
+  padding: 0 12px;
+  font-size: 14px;
+  line-height: 1;
+  border: 1px solid #c3c4c7;
+  border-radius: 4px;
+  background: #f6f7f7;
+  cursor: pointer;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+}
+
+.kc-combobox-reset:hover,
+.kc-combobox-reset:focus {
+  background: #e0e0e0;
+}
+
 .kc-combobox-list {
   position: absolute;
   z-index: 10000;

--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -187,7 +187,7 @@ function makeSearchableSelect(select) {
   select.parentNode.insertBefore(wrapper, select);
   wrapper.appendChild(select);
 
-  // Visible input + caret button
+  // Visible input + caret button (+ optional reset button)
   const input = document.createElement("input");
   input.type = "text";
   input.className = "kc-combobox-input";
@@ -209,8 +209,23 @@ function makeSearchableSelect(select) {
   list.setAttribute("role", "listbox");
   list.hidden = true;
 
+  let resetBtn = null;
+  const enableReset = select.hasAttribute("data-resettable");
+  if (enableReset) {
+    resetBtn = document.createElement("button");
+    resetBtn.type = "button";
+    resetBtn.className = "kc-combobox-reset";
+    const resetLabel =
+      select.getAttribute("data-reset-label") || "Reset";
+    resetBtn.textContent = resetLabel;
+    resetBtn.setAttribute("aria-label", resetLabel);
+  }
+
   wrapper.appendChild(input);
   wrapper.appendChild(btn);
+  if (resetBtn) {
+    wrapper.appendChild(resetBtn);
+  }
   wrapper.appendChild(list);
 
   // Build items from <select> options
@@ -334,14 +349,34 @@ function makeSearchableSelect(select) {
     if (!wrapper.contains(e.target)) closeList();
   });
 
+  function clearSelection({ triggerChange = true } = {}) {
+    const hadValue = select.value;
+    select.value = "";
+    input.value = "";
+    closeList();
+    buildList();
+    if (triggerChange && hadValue !== select.value) {
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+  }
+
+  if (resetBtn) {
+    resetBtn.addEventListener("click", () => {
+      clearSelection({ triggerChange: true });
+      input.focus();
+    });
+  }
+
   // Mark enhanced to avoid double init
   select._kcEnhanced = {
     input,
     btn,
+    resetBtn,
     list,
     openList,
     closeList,
     refresh: buildList,
+    reset: clearSelection,
   };
 }
 
@@ -854,11 +889,15 @@ function initKerbcycleScanner() {
               );
 
               const enhanced = customerIdField._kcEnhanced;
-              if (enhanced && enhanced.input) {
-                enhanced.input.value = "";
-              }
-              if (enhanced && typeof enhanced.closeList === "function") {
-                enhanced.closeList();
+              if (enhanced && typeof enhanced.reset === "function") {
+                enhanced.reset({ triggerChange: false });
+              } else {
+                if (enhanced && enhanced.input) {
+                  enhanced.input.value = "";
+                }
+                if (enhanced && typeof enhanced.closeList === "function") {
+                  enhanced.closeList();
+                }
               }
             }
 

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -48,9 +48,16 @@ class Shortcodes
         ]);
         ?>
             <script>
-                document
-                    .getElementById('customer-id')
-                    ?.setAttribute('data-placeholder', '<?php echo esc_js(__('Select Customer', 'kerbcycle')); ?>');
+                (function () {
+                    const select = document.getElementById('customer-id');
+                    if (!select) {
+                        return;
+                    }
+
+                    select.setAttribute('data-placeholder', '<?php echo esc_js(__('Select Customer', 'kerbcycle')); ?>');
+                    select.setAttribute('data-resettable', 'true');
+                    select.setAttribute('data-reset-label', '<?php echo esc_js(__('Reset', 'kerbcycle')); ?>');
+                })();
             </script>
             <div class="kerbcycle-scanner-actions">
                 <button id="assign-qr-btn" class="button button-primary">Assign QR Code</button>


### PR DESCRIPTION
## Summary
- mark the frontend customer selector as resettable via shortcode output
- extend the combobox enhancer to render an optional reset control and expose a reset helper
- style the new reset control so it sits alongside the dropdown toggle

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cdca1def74832d83ad7813a3f447dd