### PR TITLE
Add setting to disable scanner auto-adding QR codes

### DIFF
--- a/includes/Admin/Pages/SettingsPage.php
+++ b/includes/Admin/Pages/SettingsPage.php
@@ -57,6 +57,7 @@ class SettingsPage
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_sms');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_reminders');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_scanner');
+        register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_disable_scanner_auto_add');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_disable_drag_drop');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_codes_per_page');
         register_setting('kerbcycle_qr_settings', 'kerbcycle_history_per_page');
@@ -98,6 +99,14 @@ class SettingsPage
             'kerbcycle_qr_enable_scanner',
             __('Enable Dashboard QR Scanner Camera', 'kerbcycle'),
             [$this, 'render_enable_scanner_field'],
+            'kerbcycle_qr_settings',
+            'kerbcycle_qr_main'
+        );
+
+        add_settings_field(
+            'kerbcycle_qr_disable_scanner_auto_add',
+            __('Disable Scanner Auto-Adding QR Codes', 'kerbcycle'),
+            [$this, 'render_disable_scanner_auto_add_field'],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
@@ -176,6 +185,15 @@ class SettingsPage
         ?>
         <input type="checkbox" name="kerbcycle_qr_enable_scanner" value="1" <?php checked(1, $value); ?> />
         <span class="description"><?php esc_html_e('Allow camera use on the dashboard scanner', 'kerbcycle'); ?></span>
+        <?php
+    }
+
+    public function render_disable_scanner_auto_add_field()
+    {
+        $value = get_option('kerbcycle_qr_disable_scanner_auto_add', 0);
+        ?>
+        <input type="checkbox" name="kerbcycle_qr_disable_scanner_auto_add" value="1" <?php checked(1, $value); ?> />
+        <span class="description"><?php esc_html_e('Require QR codes to exist in the repository before scanner assignments.', 'kerbcycle'); ?></span>
         <?php
     }
 

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -69,12 +69,24 @@ class QrService
             return new \WP_Error('qr_code_already_assigned', $message);
         }
 
+        $available_exists = false;
+        if (!$existing || !isset($existing->status) || $existing->status !== 'available') {
+            $available_exists = $this->repository->available_exists($qr_code);
+        }
+
+        if (!$existing && !$available_exists && get_option('kerbcycle_qr_disable_scanner_auto_add', 0)) {
+            return new \WP_Error(
+                'qr_scanner_auto_add_disabled',
+                __('Adding new QR codes via the scanner is disabled. Please add the QR code to the repository before assigning it.', 'kerbcycle')
+            );
+        }
+
         $user = get_userdata($user_id);
         $name = $user ? $user->display_name : '';
 
         if ($existing && isset($existing->status) && $existing->status === 'available') {
             $result = $this->repository->update_available_to_assigned($qr_code, $user_id, $name);
-        } elseif ($this->repository->available_exists($qr_code)) {
+        } elseif ($available_exists) {
             $result = $this->repository->update_available_to_assigned($qr_code, $user_id, $name);
         } else {
             $result = $this->repository->insert_assigned($qr_code, $user_id, $name);


### PR DESCRIPTION
## Summary
- add a settings checkbox that allows administrators to disable auto-adding QR codes from the scanner
- respect the new option in the QR assignment service so scans can no longer create new codes when disabled

## Testing
- php -l includes/Admin/Pages/SettingsPage.php
- php -l includes/Services/QrService.php

------
https://chatgpt.com/codex/tasks/task_e_68cdcc75d7b0832d8427570cd3edc9ba