### PR TITLE
Fix admin scanner dependencies

### DIFF
--- a/includes/Admin/Assets/AdminAssets.php
+++ b/includes/Admin/Assets/AdminAssets.php
@@ -91,12 +91,27 @@ class AdminAssets
         ]);
 
         if ($scanner_enabled) {
-            wp_enqueue_script('html5-qrcode', 'https://unpkg.com/html5-qrcode', [], null, true);
+            wp_enqueue_script(
+                'zxing-browser',
+                'https://unpkg.com/@zxing/browser@latest',
+                [],
+                null,
+                true
+            );
+
+            wp_enqueue_script(
+                'jsqr',
+                'https://unpkg.com/jsqr/dist/jsQR.js',
+                [],
+                null,
+                true
+            );
+
             wp_enqueue_script(
                 'kerbcycle-qr-scanner-js',
                 KERBCYCLE_QR_URL . 'assets/js/qr-scanner.js',
-                ['html5-qrcode', 'kerbcycle-qr-admin-js'],
-                '1.0',
+                ['zxing-browser', 'jsqr', 'kerbcycle-qr-admin-js'],
+                filemtime(KERBCYCLE_QR_PATH . 'assets/js/qr-scanner.js'),
                 true
             );
         }


### PR DESCRIPTION
## Summary
- enqueue ZXing and jsQR for the admin dashboard scanner when enabled
- update the admin scanner bundle enqueue to use filemtime for cache busting

## Testing
- php -l includes/Admin/Assets/AdminAssets.php

------
https://chatgpt.com/codex/tasks/task_e_68cec7653624832d9ab0b9bf0cb33f68