### PR TITLE
Prevent dashboard camera from altering admin dropdowns

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -175,6 +175,13 @@ async function createQrScannerAdapter({
 }
 // === End Adapter ===
 
+// Context helper: 'front' (shortcode page) vs 'admin' (dashboard)
+const KC_CONTEXT =
+  (typeof kerbcycle_ajax === "object" &&
+    kerbcycle_ajax &&
+    kerbcycle_ajax.context) ||
+  "front";
+
 function makeSearchableSelect(select) {
   if (!select || select._kcEnhanced || select._searchable) return;
 
@@ -596,17 +603,17 @@ function initResponsiveDates() {
 }
 
 function initKerbcycleScanner() {
-  document
-    .querySelectorAll("select.kc-searchable")
-    .forEach((select) => {
-      if (select._searchable) {
-        return;
-      }
-      if (!select.closest(".kerbcycle-qr-scanner-container")) {
+  const isFront = KC_CONTEXT === "front";
+  const container = document.querySelector(".kerbcycle-qr-scanner-container");
+
+  if (isFront && container) {
+    container.querySelectorAll("select.kc-searchable").forEach((select) => {
+      if (select._searchable || select._kcEnhanced) {
         return;
       }
       makeSearchableSelect(select);
     });
+  }
   const scannerAllowed = kerbcycle_ajax.scanner_enabled;
   const scanResult = document.getElementById("scan-result");
   const assignBtn = document.getElementById("assign-qr-btn");

--- a/includes/Admin/Assets/AdminAssets.php
+++ b/includes/Admin/Assets/AdminAssets.php
@@ -88,6 +88,7 @@ class AdminAssets
             'nonce'             => wp_create_nonce('kerbcycle_qr_nonce'),
             'scanner_enabled'   => $scanner_enabled,
             'drag_drop_disabled' => $drag_drop_disabled,
+            'context'           => 'admin',
         ]);
 
         if ($scanner_enabled) {

--- a/includes/Public/FrontAssets.php
+++ b/includes/Public/FrontAssets.php
@@ -88,6 +88,7 @@ class FrontAssets
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('kerbcycle_qr_nonce'),
             'scanner_enabled' => $has_scanner,
+            'context' => 'front',
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- tag localized script data with an explicit context for admin and front-end usage
- gate the combobox enhancement logic to the front-end scanner container to avoid re-skinning admin dropdowns

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cee196b040832dac9bd44ef8d687ff