### PR TITLE
Add dashboard scanner controls for adding and resetting

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -60,6 +60,13 @@
   margin-top: 20px;
 }
 
+.qr-scanner-actions {
+  margin-top: 20px;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
 .qr-warning {
   margin-top: 20px;
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -301,52 +301,66 @@ function initKerbcycleAdmin() {
     });
   }
 
-  if (addBtn) {
-    addBtn.addEventListener("click", function () {
-      const qrCode = newCodeInput ? newCodeInput.value.trim() : "";
-      if (!qrCode) {
-        alert("Please enter a QR code.");
-        return;
-      }
+  function addQrCodeToRepository(rawQrCode, options = {}) {
+    const {
+      showAlertOnEmpty = false,
+      clearInput = false,
+      source = "manual",
+    } = options;
 
-      fetch(kerbcycle_ajax.ajax_url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-        },
-        body: `action=add_qr_code&qr_code=${encodeURIComponent(qrCode)}&security=${kerbcycle_ajax.nonce}`,
-      })
-        .then((response) => response.json())
-        .then((data) => {
-          if (data.success) {
-            const msg =
-              data.data && data.data.message
-                ? data.data.message
-                : "QR code added successfully.";
-            showToast(msg);
-            if (
-              qrSelect &&
-              !qrSelect.querySelector(`option[value="${qrCode}"]`)
-            ) {
-              const opt = document.createElement("option");
-              opt.value = qrCode;
-              opt.textContent = qrCode;
-              qrSelect.appendChild(opt);
-              if (qrSelect._searchable) {
-                qrSelect._searchable.updateOptions();
-              }
+    const qrCode = rawQrCode ? rawQrCode.trim() : "";
+
+    if (!qrCode) {
+      if (showAlertOnEmpty) {
+        alert("Please enter a QR code.");
+      }
+      document.dispatchEvent(
+        new CustomEvent("kerbcycle-qr-code-add-failed", {
+          detail: { code: qrCode, source, reason: "empty" },
+        }),
+      );
+      return Promise.resolve({ success: false, reason: "empty" });
+    }
+
+    const payload = `action=add_qr_code&qr_code=${encodeURIComponent(qrCode)}&security=${kerbcycle_ajax.nonce}`;
+
+    return fetch(kerbcycle_ajax.ajax_url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+      },
+      body: payload,
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.success) {
+          const msg =
+            data.data && data.data.message
+              ? data.data.message
+              : "QR code added successfully.";
+          showToast(msg);
+          if (qrSelect && !qrSelect.querySelector(`option[value="${qrCode}"]`)) {
+            const opt = document.createElement("option");
+            opt.value = qrCode;
+            opt.textContent = qrCode;
+            qrSelect.appendChild(opt);
+            if (qrSelect._searchable) {
+              qrSelect._searchable.updateOptions();
             }
+          }
+          if (clearInput && newCodeInput) {
             newCodeInput.value = "";
-            adjustCounts(1, 0);
-            if (data.data && data.data.row) {
-              const row = data.data.row;
-              const list = document.getElementById("qr-code-list");
-              if (list) {
-                const li = document.createElement("li");
-                li.className = "qr-item";
-                li.dataset.code = row.qr_code;
-                li.dataset.id = row.id;
-                li.innerHTML = `
+          }
+          adjustCounts(1, 0);
+          if (data.data && data.data.row) {
+            const row = data.data.row;
+            const list = document.getElementById("qr-code-list");
+            if (list) {
+              const li = document.createElement("li");
+              li.className = "qr-item";
+              li.dataset.code = row.qr_code;
+              li.dataset.id = row.id;
+              li.innerHTML = `
 <input type="checkbox" class="qr-select" />
 <span class="qr-id">${row.id}</span>
 <span class="qr-text" contenteditable="true">${row.qr_code}</span>
@@ -354,83 +368,108 @@ function initKerbcycleAdmin() {
 <span class="qr-name">—</span>
 <span class="qr-status">Available</span>
 <span class="qr-assigned">—</span>`;
-                const header = list.querySelector(".qr-header");
-                if (header && header.nextSibling) {
-                  list.insertBefore(li, header.nextSibling);
-                } else {
-                  list.appendChild(li);
-                }
-                const checkbox = li.querySelector(".qr-select");
-                if (checkbox) {
-                  checkbox.addEventListener("change", function () {
-                    const items = document.querySelectorAll(
-                      "#qr-code-list .qr-item .qr-select",
-                    );
-                    const allChecked = Array.from(items).every(
-                      (cb) => cb.checked,
-                    );
-                    const anyChecked = Array.from(items).some(
-                      (cb) => cb.checked,
-                    );
-                    const selectAll = document.getElementById("qr-select-all");
-                    if (selectAll) {
-                      selectAll.checked = allChecked;
-                      selectAll.indeterminate = !allChecked && anyChecked;
-                    }
-                  });
-                }
-                const span = li.querySelector(".qr-text");
-                if (span) {
-                  span.addEventListener("blur", function () {
-                    const liElem = span.closest("li");
-                    const oldCode = liElem.dataset.code;
-                    const newCode = span.textContent.trim();
-                    if (oldCode === newCode) {
-                      return;
-                    }
-                    fetch(kerbcycle_ajax.ajax_url, {
-                      method: "POST",
-                      headers: {
-                        "Content-Type":
-                          "application/x-www-form-urlencoded; charset=UTF-8",
-                      },
-                      body: `action=update_qr_code&old_code=${encodeURIComponent(oldCode)}&new_code=${encodeURIComponent(newCode)}&security=${kerbcycle_ajax.nonce}`,
-                    })
-                      .then((res) => res.json())
-                      .then((data) => {
-                        if (data.success) {
-                          liElem.dataset.code = newCode;
-                          const msg =
-                            data.data && data.data.message
-                              ? data.data.message
-                              : "QR code updated";
-                          showToast(msg);
-                          refreshDropdowns(oldCode, newCode);
-                        } else {
-                          const err =
-                            data.data && data.data.message
-                              ? data.data.message
-                              : "Failed to update QR code";
-                          showToast(err, true);
-                          span.textContent = oldCode;
-                        }
-                      });
-                  });
-                }
+              const header = list.querySelector(".qr-header");
+              if (header && header.nextSibling) {
+                list.insertBefore(li, header.nextSibling);
+              } else {
+                list.appendChild(li);
+              }
+              const checkbox = li.querySelector(".qr-select");
+              if (checkbox) {
+                checkbox.addEventListener("change", function () {
+                  const items = document.querySelectorAll(
+                    "#qr-code-list .qr-item .qr-select",
+                  );
+                  const allChecked = Array.from(items).every((cb) => cb.checked);
+                  const anyChecked = Array.from(items).some((cb) => cb.checked);
+                  const selectAll = document.getElementById("qr-select-all");
+                  if (selectAll) {
+                    selectAll.checked = allChecked;
+                    selectAll.indeterminate = !allChecked && anyChecked;
+                  }
+                });
+              }
+              const span = li.querySelector(".qr-text");
+              if (span) {
+                span.addEventListener("blur", function () {
+                  const liElem = span.closest("li");
+                  const oldCode = liElem.dataset.code;
+                  const newCode = span.textContent.trim();
+                  if (oldCode === newCode) {
+                    return;
+                  }
+                  fetch(kerbcycle_ajax.ajax_url, {
+                    method: "POST",
+                    headers: {
+                      "Content-Type":
+                        "application/x-www-form-urlencoded; charset=UTF-8",
+                    },
+                    body: `action=update_qr_code&old_code=${encodeURIComponent(oldCode)}&new_code=${encodeURIComponent(newCode)}&security=${kerbcycle_ajax.nonce}`,
+                  })
+                    .then((res) => res.json())
+                    .then((updateData) => {
+                      if (updateData.success) {
+                        liElem.dataset.code = newCode;
+                        const msg =
+                          updateData.data && updateData.data.message
+                            ? updateData.data.message
+                            : "QR code updated";
+                        showToast(msg);
+                        refreshDropdowns(oldCode, newCode);
+                      } else {
+                        const err =
+                          updateData.data && updateData.data.message
+                            ? updateData.data.message
+                            : "Failed to update QR code";
+                        showToast(err, true);
+                        span.textContent = oldCode;
+                      }
+                    });
+                });
               }
             }
-          } else {
-            const err =
-              data.data && data.data.message
-                ? data.data.message
-                : "Failed to add QR code.";
-            showToast(err, true);
           }
-        })
-        .catch((error) => {
-          console.error("Error:", error);
-          showToast("An error occurred while adding the QR code.", true);
-        });
+          document.dispatchEvent(
+            new CustomEvent("kerbcycle-qr-code-added", {
+              detail: { code: qrCode, data, source },
+            }),
+          );
+          return { success: true, data };
+        }
+
+        const err =
+          data.data && data.data.message
+            ? data.data.message
+            : "Failed to add QR code.";
+        showToast(err, true);
+        document.dispatchEvent(
+          new CustomEvent("kerbcycle-qr-code-add-failed", {
+            detail: { code: qrCode, data, source },
+          }),
+        );
+        return { success: false, data };
+      })
+      .catch((error) => {
+        console.error("Error:", error);
+        showToast("An error occurred while adding the QR code.", true);
+        document.dispatchEvent(
+          new CustomEvent("kerbcycle-qr-code-add-error", {
+            detail: { code: qrCode, error, source },
+          }),
+        );
+        return { success: false, error };
+      });
+  }
+
+  window.kerbcycleAddQrCodeToRepository = addQrCodeToRepository;
+
+  if (addBtn) {
+    addBtn.addEventListener("click", function () {
+      addQrCodeToRepository(newCodeInput ? newCodeInput.value : "", {
+        showAlertOnEmpty: true,
+        clearInput: true,
+        source: "manual",
+      });
     });
   }
 

--- a/assets/js/dashboard-scanner.js
+++ b/assets/js/dashboard-scanner.js
@@ -215,7 +215,26 @@ function initDashboardScanner() {
   const readerEl = document.getElementById("reader");
   const scanResult = document.getElementById("scan-result");
   const scannerEnabled = kerbcycle_ajax.scanner_enabled;
+  const addFromScannerBtn = document.getElementById("dashboard-add-qr-btn");
+  const resetScannerBtn = document.getElementById("dashboard-reset-scan-btn");
   let scanner = null;
+  let lastScannedCode = "";
+  let addInProgress = false;
+
+  function updateAddButtonState() {
+    if (!addFromScannerBtn) {
+      return;
+    }
+    const shouldDisable =
+      addInProgress || !scannerEnabled || !lastScannedCode;
+    addFromScannerBtn.disabled = shouldDisable;
+  }
+
+  updateAddButtonState();
+
+  if (resetScannerBtn && !scannerEnabled) {
+    resetScannerBtn.disabled = true;
+  }
 
   function pauseActiveScanner() {
     if (scanner && typeof scanner.pause === "function") {
@@ -225,6 +244,198 @@ function initDashboardScanner() {
         console.warn("Unable to pause dashboard scanner", e);
       }
     }
+  }
+
+  if (addFromScannerBtn) {
+    addFromScannerBtn.addEventListener("click", () => {
+      if (!scannerEnabled) {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ QR code scanner is disabled in settings.</strong>",
+        );
+        return;
+      }
+
+      if (addInProgress) {
+        return;
+      }
+
+      if (!lastScannedCode) {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ Please scan a QR code before adding.</strong>",
+        );
+        return;
+      }
+
+      const addHandler = window.kerbcycleAddQrCodeToRepository;
+      if (typeof addHandler !== "function") {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ Unable to add QR code.</strong> Please use the manual form below.",
+        );
+        return;
+      }
+
+      const safeCode = escapeHtml(lastScannedCode);
+      addInProgress = true;
+      addFromScannerBtn.setAttribute("aria-busy", "true");
+      updateAddButtonState();
+
+      setScanResult(
+        scanResult,
+        "success",
+        `<strong>⏳ Adding QR Code...</strong><br>Code: <code>${safeCode}</code>`,
+      );
+
+      let addPromise;
+      try {
+        addPromise = addHandler(lastScannedCode, {
+          source: "dashboard-scanner",
+          showAlertOnEmpty: false,
+          clearInput: false,
+        });
+      } catch (error) {
+        addInProgress = false;
+        addFromScannerBtn.removeAttribute("aria-busy");
+        updateAddButtonState();
+        console.error("Unable to add QR code from dashboard scanner", error);
+        setScanResult(
+          scanResult,
+          "error",
+          `<strong>❌ Unable to add QR code.</strong> ${escapeHtml(
+            error && error.message ? error.message : String(error),
+          )}`,
+        );
+        return;
+      }
+
+      Promise.resolve(addPromise)
+        .then((result) => {
+          if (result && result.success) {
+            lastScannedCode = "";
+            setScanResult(
+              scanResult,
+              "success",
+              `<strong>✅ QR Code added to repository.</strong><br>Code: <code>${safeCode}</code><br>Use "Scan Reset" to scan another code.`,
+            );
+            return;
+          }
+
+          if (result && result.reason === "empty") {
+            setScanResult(
+              scanResult,
+              "error",
+              "<strong>❌ Please scan a QR code before adding.</strong>",
+            );
+            return;
+          }
+
+          const errMessage =
+            (result &&
+              result.data &&
+              result.data.data &&
+              result.data.data.message) ||
+            (result && result.data && result.data.message) ||
+            (result && result.error && result.error.message) ||
+            (result &&
+              typeof result.error === "string" &&
+              result.error) ||
+            "Failed to add QR code.";
+
+          setScanResult(
+            scanResult,
+            "error",
+            `<strong>❌ ${escapeHtml(errMessage)}</strong>`,
+          );
+        })
+        .catch((error) => {
+          console.error("Unable to add QR code from dashboard scanner", error);
+          setScanResult(
+            scanResult,
+            "error",
+            `<strong>❌ Unable to add QR code.</strong> ${escapeHtml(
+              error && error.message ? error.message : String(error),
+            )}`,
+          );
+        })
+        .finally(() => {
+          addInProgress = false;
+          addFromScannerBtn.removeAttribute("aria-busy");
+          updateAddButtonState();
+        });
+    });
+  }
+
+  if (resetScannerBtn) {
+    resetScannerBtn.addEventListener("click", () => {
+      if (!scannerEnabled) {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ QR code scanner is disabled in settings.</strong>",
+        );
+        return;
+      }
+
+      lastScannedCode = "";
+      updateAddButtonState();
+
+      if (!scanner) {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ Scanner is not ready yet.</strong>",
+        );
+        return;
+      }
+
+      const successMessage =
+        "<strong>🔄 Scanner reset.</strong> Ready to scan a new QR code.";
+
+      try {
+        const resumeResult =
+          typeof scanner.resume === "function"
+            ? scanner.resume()
+            : typeof scanner.start === "function"
+            ? scanner.start()
+            : null;
+
+        if (resumeResult && typeof resumeResult.then === "function") {
+          resumeResult
+            .then(() => {
+              setScanResult(scanResult, "success", successMessage);
+            })
+            .catch((error) => {
+              console.error(
+                "Unable to reset dashboard scanner",
+                error,
+              );
+              setScanResult(
+                scanResult,
+                "error",
+                `<strong>❌ Unable to reset scanner.</strong> ${escapeHtml(
+                  error && error.message ? error.message : String(error),
+                )}`,
+              );
+            });
+        } else {
+          setScanResult(scanResult, "success", successMessage);
+        }
+      } catch (error) {
+        console.error("Unable to reset dashboard scanner", error);
+        setScanResult(
+          scanResult,
+          "error",
+          `<strong>❌ Unable to reset scanner.</strong> ${escapeHtml(
+            error && error.message ? error.message : String(error),
+          )}`,
+        );
+      }
+    });
   }
 
   if (scannerEnabled && readerEl) {
@@ -237,6 +448,8 @@ function initDashboardScanner() {
 
     const onScanSuccess = (decodedText) => {
       pauseActiveScanner();
+      lastScannedCode = decodedText || "";
+      updateAddButtonState();
       const safeCode = escapeHtml(decodedText || "");
       setScanResult(
         scanResult,

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -95,6 +95,10 @@ class DashboardPage
         $scanner_enabled  = (bool) get_option('kerbcycle_qr_enable_scanner', 1);
         ?>
                 <?php if ($scanner_enabled) : ?>
+                    <div class="qr-scanner-actions">
+                        <button id="dashboard-add-qr-btn" class="button button-primary"><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></button>
+                        <button id="dashboard-reset-scan-btn" class="button"><?php esc_html_e('Scan Reset', 'kerbcycle'); ?></button>
+                    </div>
                     <div id="reader" class="qr-reader"></div>
                 <?php else : ?>
                     <div class="notice notice-warning qr-warning">


### PR DESCRIPTION
## Summary
- add "Add QR Code" and "Scan Reset" controls above the dashboard scanner feed and style them for side-by-side layout
- expose a reusable add-QR-code helper in the admin script so scanner-triggered additions share the same logic and events
- extend the dashboard scanner script to track scans, add codes via the shared helper, and reset/resume scanning on demand

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cef50087a4832d8e56d67f9bba21b3