### PR TITLE
Add dashboard customer assignment controls

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -60,6 +60,32 @@
   margin-top: 20px;
 }
 
+.qr-scanner-actions {
+  margin-top: 20px;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.qr-scanner-customer {
+  margin-top: 10px;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  max-width: 400px;
+}
+
+.qr-scanner-customer-select {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.qr-scanner-customer-select .kc-search-input {
+  width: 100%;
+}
+
 .qr-warning {
   margin-top: 20px;
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -130,6 +130,176 @@ function initKerbcycleAdmin() {
     userField.dispatchEvent(new Event("change"));
   }
 
+  const cssEscape = (value) =>
+    typeof CSS !== "undefined" && typeof CSS.escape === "function"
+      ? CSS.escape(value)
+      : value;
+
+  function assignQrCodeToCustomer(rawQrCode, rawUserId, options = {}) {
+    const {
+      sendEmail = false,
+      sendSms = false,
+      sendReminder = false,
+      showAlertOnMissing = false,
+      source = "manual",
+      customerName = "",
+    } = options;
+
+    const qrCode = rawQrCode ? rawQrCode.trim() : "";
+    const userId = rawUserId ? String(rawUserId).trim() : "";
+
+    if (!userId) {
+      if (showAlertOnMissing) {
+        alert("Please select a user.");
+      }
+      const detail = { code: qrCode, userId, source, reason: "missing-user" };
+      document.dispatchEvent(
+        new CustomEvent("kerbcycle-qr-code-assignment-failed", { detail }),
+      );
+      return Promise.resolve({ success: false, reason: "missing-user" });
+    }
+
+    if (!qrCode) {
+      if (showAlertOnMissing) {
+        alert("Please choose a QR code.");
+      }
+      const detail = { code: qrCode, userId, source, reason: "missing-code" };
+      document.dispatchEvent(
+        new CustomEvent("kerbcycle-qr-code-assignment-failed", { detail }),
+      );
+      return Promise.resolve({ success: false, reason: "missing-code" });
+    }
+
+    const body = `action=assign_qr_code&qr_code=${encodeURIComponent(
+      qrCode,
+    )}&customer_id=${encodeURIComponent(
+      userId,
+    )}&send_email=${sendEmail ? 1 : 0}&send_sms=${sendSms ? 1 : 0}&send_reminder=${
+      sendReminder ? 1 : 0
+    }&security=${kerbcycle_ajax.nonce}`;
+
+    return fetch(kerbcycle_ajax.ajax_url, {
+      method: "POST",
+      headers: {
+        "Content-Type":
+          "application/x-www-form-urlencoded; charset=UTF-8",
+      },
+      body,
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.success) {
+          let msg = "QR code assigned successfully.";
+          if (data.data && typeof data.data.sms_sent !== "undefined") {
+            if (data.data.sms_sent) {
+              msg += " SMS notification sent.";
+            } else {
+              msg +=
+                " SMS failed: " +
+                (data.data.sms_error || "Unknown error") +
+                ".";
+            }
+          }
+          showToast(msg);
+          try {
+            localStorage.setItem(
+              "kerbcycleAssignment",
+              Date.now().toString(),
+            );
+          } catch (e) {
+            console.warn("LocalStorage unavailable", e);
+          }
+          const escapedCode = cssEscape(qrCode);
+          const li = document.querySelector(
+            `#qr-code-list .qr-item[data-code="${escapedCode}"]`,
+          );
+          if (li) {
+            li.querySelector(".qr-user").textContent = userId;
+            const displayName =
+              customerName ||
+              (userField &&
+                userField.options[userField.selectedIndex] &&
+                userField.options[userField.selectedIndex].text) ||
+              "—";
+            li.querySelector(".qr-name").textContent = displayName;
+            li.querySelector(".qr-status").textContent = "Assigned";
+            li.querySelector(".qr-assigned").textContent = new Date()
+              .toISOString()
+              .slice(0, 19)
+              .replace("T", " ");
+          }
+          if (qrSelect) {
+            const opt = qrSelect.querySelector(
+              `option[value="${cssEscape(qrCode)}"]`,
+            );
+            if (opt) {
+              opt.remove();
+            }
+            qrSelect.value = "";
+            if (qrSelect._searchable) {
+              qrSelect._searchable.updateOptions();
+              qrSelect._searchable.input.value = "";
+            }
+          }
+          if (assignedSelect && userField && userField.value === userId) {
+            const exists = assignedSelect.querySelector(
+              `option[value="${cssEscape(qrCode)}"]`,
+            );
+            if (!exists) {
+              const opt2 = document.createElement("option");
+              opt2.value = qrCode;
+              opt2.textContent = qrCode;
+              assignedSelect.appendChild(opt2);
+            }
+            if (assignedSelect._searchable) {
+              assignedSelect._searchable.updateOptions();
+            }
+          }
+          adjustCounts(-1, 1);
+          document.dispatchEvent(
+            new CustomEvent("kerbcycle-qr-code-assigned", {
+              detail: { code: qrCode, userId, data, source, customerName },
+            }),
+          );
+          return { success: true, data };
+        }
+        const err =
+          (data.data && data.data.message)
+            ? data.data.message
+            : "Failed to assign QR code.";
+        showToast(err, true);
+        const result = {
+          success: false,
+          data,
+          reason: "request-failed",
+          message: err,
+        };
+        document.dispatchEvent(
+          new CustomEvent("kerbcycle-qr-code-assignment-failed", {
+            detail: { code: qrCode, userId, data, source, message: err },
+          }),
+        );
+        return result;
+      })
+      .catch((error) => {
+        console.error("Error:", error);
+        const message = "An error occurred while assigning the QR code.";
+        showToast(message, true);
+        const result = {
+          success: false,
+          error,
+          reason: "network-error",
+          message,
+        };
+        document.dispatchEvent(
+          new CustomEvent("kerbcycle-qr-code-assignment-error", {
+            detail: { code: qrCode, userId, error, source },
+          }),
+        );
+        return result;
+      });
+  }
+
   if (assignBtn) {
     assignBtn.addEventListener("click", function () {
       const userId = userField ? userField.value : "";
@@ -139,92 +309,21 @@ function initKerbcycleAdmin() {
       const sendReminder = sendReminderCheckbox
         ? sendReminderCheckbox.checked
         : false;
+      const customerName =
+        userField && userField.selectedIndex >= 0
+          ? userField.options[userField.selectedIndex].text
+          : "";
 
-      if (!userId || !qrCode) {
-        alert("Please select a user and choose a QR code.");
-        return;
-      }
-
-      fetch(kerbcycle_ajax.ajax_url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-        },
-        body: `action=assign_qr_code&qr_code=${encodeURIComponent(qrCode)}&customer_id=${encodeURIComponent(userId)}&send_email=${sendEmail ? 1 : 0}&send_sms=${sendSms ? 1 : 0}&send_reminder=${sendReminder ? 1 : 0}&security=${kerbcycle_ajax.nonce}`,
-      })
-        .then((response) => response.json())
-        .then((data) => {
-          if (data.success) {
-            let msg = "QR code assigned successfully.";
-            if (data.data && typeof data.data.sms_sent !== "undefined") {
-              if (data.data.sms_sent) {
-                msg += " SMS notification sent.";
-              } else {
-                msg +=
-                  " SMS failed: " +
-                  (data.data.sms_error || "Unknown error") +
-                  ".";
-              }
-            }
-            showToast(msg);
-            try {
-              localStorage.setItem(
-                "kerbcycleAssignment",
-                Date.now().toString(),
-              );
-            } catch (e) {
-              console.warn("LocalStorage unavailable", e);
-            }
-            const li = document.querySelector(
-              `#qr-code-list .qr-item[data-code="${qrCode}"]`,
-            );
-            if (li) {
-              li.querySelector(".qr-user").textContent = userId;
-              const userName =
-                userField.options[userField.selectedIndex].text || "—";
-              li.querySelector(".qr-name").textContent = userName;
-              li.querySelector(".qr-status").textContent = "Assigned";
-              li.querySelector(".qr-assigned").textContent = new Date()
-                .toISOString()
-                .slice(0, 19)
-                .replace("T", " ");
-            }
-            const opt = qrSelect
-              ? qrSelect.querySelector(`option[value="${qrCode}"]`)
-              : null;
-            if (opt) opt.remove();
-            if (qrSelect) {
-              qrSelect.value = "";
-              if (qrSelect._searchable) {
-                qrSelect._searchable.updateOptions();
-                qrSelect._searchable.input.value = "";
-              }
-            }
-            if (assignedSelect && userField && userField.value === userId) {
-              const opt2 = document.createElement("option");
-              opt2.value = qrCode;
-              opt2.textContent = qrCode;
-              assignedSelect.appendChild(opt2);
-              if (assignedSelect._searchable) {
-                assignedSelect._searchable.updateOptions();
-              }
-            }
-            adjustCounts(-1, 1);
-          } else {
-            const err =
-              data.data && data.data.message
-                ? data.data.message
-                : "Failed to assign QR code.";
-            showToast(err, true);
-          }
-        })
-        .catch((error) => {
-          console.error("Error:", error);
-          showToast("An error occurred while assigning the QR code.", true);
-        });
+      assignQrCodeToCustomer(qrCode, userId, {
+        sendEmail,
+        sendSms,
+        sendReminder,
+        showAlertOnMissing: true,
+        source: "manual",
+        customerName,
+      });
     });
   }
-
   if (releaseBtn) {
     releaseBtn.addEventListener("click", function () {
       const qrCode = assignedSelect ? assignedSelect.value : "";
@@ -301,52 +400,66 @@ function initKerbcycleAdmin() {
     });
   }
 
-  if (addBtn) {
-    addBtn.addEventListener("click", function () {
-      const qrCode = newCodeInput ? newCodeInput.value.trim() : "";
-      if (!qrCode) {
-        alert("Please enter a QR code.");
-        return;
-      }
+  function addQrCodeToRepository(rawQrCode, options = {}) {
+    const {
+      showAlertOnEmpty = false,
+      clearInput = false,
+      source = "manual",
+    } = options;
 
-      fetch(kerbcycle_ajax.ajax_url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-        },
-        body: `action=add_qr_code&qr_code=${encodeURIComponent(qrCode)}&security=${kerbcycle_ajax.nonce}`,
-      })
-        .then((response) => response.json())
-        .then((data) => {
-          if (data.success) {
-            const msg =
-              data.data && data.data.message
-                ? data.data.message
-                : "QR code added successfully.";
-            showToast(msg);
-            if (
-              qrSelect &&
-              !qrSelect.querySelector(`option[value="${qrCode}"]`)
-            ) {
-              const opt = document.createElement("option");
-              opt.value = qrCode;
-              opt.textContent = qrCode;
-              qrSelect.appendChild(opt);
-              if (qrSelect._searchable) {
-                qrSelect._searchable.updateOptions();
-              }
+    const qrCode = rawQrCode ? rawQrCode.trim() : "";
+
+    if (!qrCode) {
+      if (showAlertOnEmpty) {
+        alert("Please enter a QR code.");
+      }
+      document.dispatchEvent(
+        new CustomEvent("kerbcycle-qr-code-add-failed", {
+          detail: { code: qrCode, source, reason: "empty" },
+        }),
+      );
+      return Promise.resolve({ success: false, reason: "empty" });
+    }
+
+    const payload = `action=add_qr_code&qr_code=${encodeURIComponent(qrCode)}&security=${kerbcycle_ajax.nonce}`;
+
+    return fetch(kerbcycle_ajax.ajax_url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+      },
+      body: payload,
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.success) {
+          const msg =
+            data.data && data.data.message
+              ? data.data.message
+              : "QR code added successfully.";
+          showToast(msg);
+          if (qrSelect && !qrSelect.querySelector(`option[value="${qrCode}"]`)) {
+            const opt = document.createElement("option");
+            opt.value = qrCode;
+            opt.textContent = qrCode;
+            qrSelect.appendChild(opt);
+            if (qrSelect._searchable) {
+              qrSelect._searchable.updateOptions();
             }
+          }
+          if (clearInput && newCodeInput) {
             newCodeInput.value = "";
-            adjustCounts(1, 0);
-            if (data.data && data.data.row) {
-              const row = data.data.row;
-              const list = document.getElementById("qr-code-list");
-              if (list) {
-                const li = document.createElement("li");
-                li.className = "qr-item";
-                li.dataset.code = row.qr_code;
-                li.dataset.id = row.id;
-                li.innerHTML = `
+          }
+          adjustCounts(1, 0);
+          if (data.data && data.data.row) {
+            const row = data.data.row;
+            const list = document.getElementById("qr-code-list");
+            if (list) {
+              const li = document.createElement("li");
+              li.className = "qr-item";
+              li.dataset.code = row.qr_code;
+              li.dataset.id = row.id;
+              li.innerHTML = `
 <input type="checkbox" class="qr-select" />
 <span class="qr-id">${row.id}</span>
 <span class="qr-text" contenteditable="true">${row.qr_code}</span>
@@ -354,83 +467,109 @@ function initKerbcycleAdmin() {
 <span class="qr-name">—</span>
 <span class="qr-status">Available</span>
 <span class="qr-assigned">—</span>`;
-                const header = list.querySelector(".qr-header");
-                if (header && header.nextSibling) {
-                  list.insertBefore(li, header.nextSibling);
-                } else {
-                  list.appendChild(li);
-                }
-                const checkbox = li.querySelector(".qr-select");
-                if (checkbox) {
-                  checkbox.addEventListener("change", function () {
-                    const items = document.querySelectorAll(
-                      "#qr-code-list .qr-item .qr-select",
-                    );
-                    const allChecked = Array.from(items).every(
-                      (cb) => cb.checked,
-                    );
-                    const anyChecked = Array.from(items).some(
-                      (cb) => cb.checked,
-                    );
-                    const selectAll = document.getElementById("qr-select-all");
-                    if (selectAll) {
-                      selectAll.checked = allChecked;
-                      selectAll.indeterminate = !allChecked && anyChecked;
-                    }
-                  });
-                }
-                const span = li.querySelector(".qr-text");
-                if (span) {
-                  span.addEventListener("blur", function () {
-                    const liElem = span.closest("li");
-                    const oldCode = liElem.dataset.code;
-                    const newCode = span.textContent.trim();
-                    if (oldCode === newCode) {
-                      return;
-                    }
-                    fetch(kerbcycle_ajax.ajax_url, {
-                      method: "POST",
-                      headers: {
-                        "Content-Type":
-                          "application/x-www-form-urlencoded; charset=UTF-8",
-                      },
-                      body: `action=update_qr_code&old_code=${encodeURIComponent(oldCode)}&new_code=${encodeURIComponent(newCode)}&security=${kerbcycle_ajax.nonce}`,
-                    })
-                      .then((res) => res.json())
-                      .then((data) => {
-                        if (data.success) {
-                          liElem.dataset.code = newCode;
-                          const msg =
-                            data.data && data.data.message
-                              ? data.data.message
-                              : "QR code updated";
-                          showToast(msg);
-                          refreshDropdowns(oldCode, newCode);
-                        } else {
-                          const err =
-                            data.data && data.data.message
-                              ? data.data.message
-                              : "Failed to update QR code";
-                          showToast(err, true);
-                          span.textContent = oldCode;
-                        }
-                      });
-                  });
-                }
+              const header = list.querySelector(".qr-header");
+              if (header && header.nextSibling) {
+                list.insertBefore(li, header.nextSibling);
+              } else {
+                list.appendChild(li);
+              }
+              const checkbox = li.querySelector(".qr-select");
+              if (checkbox) {
+                checkbox.addEventListener("change", function () {
+                  const items = document.querySelectorAll(
+                    "#qr-code-list .qr-item .qr-select",
+                  );
+                  const allChecked = Array.from(items).every((cb) => cb.checked);
+                  const anyChecked = Array.from(items).some((cb) => cb.checked);
+                  const selectAll = document.getElementById("qr-select-all");
+                  if (selectAll) {
+                    selectAll.checked = allChecked;
+                    selectAll.indeterminate = !allChecked && anyChecked;
+                  }
+                });
+              }
+              const span = li.querySelector(".qr-text");
+              if (span) {
+                span.addEventListener("blur", function () {
+                  const liElem = span.closest("li");
+                  const oldCode = liElem.dataset.code;
+                  const newCode = span.textContent.trim();
+                  if (oldCode === newCode) {
+                    return;
+                  }
+                  fetch(kerbcycle_ajax.ajax_url, {
+                    method: "POST",
+                    headers: {
+                      "Content-Type":
+                        "application/x-www-form-urlencoded; charset=UTF-8",
+                    },
+                    body: `action=update_qr_code&old_code=${encodeURIComponent(oldCode)}&new_code=${encodeURIComponent(newCode)}&security=${kerbcycle_ajax.nonce}`,
+                  })
+                    .then((res) => res.json())
+                    .then((updateData) => {
+                      if (updateData.success) {
+                        liElem.dataset.code = newCode;
+                        const msg =
+                          updateData.data && updateData.data.message
+                            ? updateData.data.message
+                            : "QR code updated";
+                        showToast(msg);
+                        refreshDropdowns(oldCode, newCode);
+                      } else {
+                        const err =
+                          updateData.data && updateData.data.message
+                            ? updateData.data.message
+                            : "Failed to update QR code";
+                        showToast(err, true);
+                        span.textContent = oldCode;
+                      }
+                    });
+                });
               }
             }
-          } else {
-            const err =
-              data.data && data.data.message
-                ? data.data.message
-                : "Failed to add QR code.";
-            showToast(err, true);
           }
-        })
-        .catch((error) => {
-          console.error("Error:", error);
-          showToast("An error occurred while adding the QR code.", true);
-        });
+          document.dispatchEvent(
+            new CustomEvent("kerbcycle-qr-code-added", {
+              detail: { code: qrCode, data, source },
+            }),
+          );
+          return { success: true, data };
+        }
+
+        const err =
+          data.data && data.data.message
+            ? data.data.message
+            : "Failed to add QR code.";
+        showToast(err, true);
+        document.dispatchEvent(
+          new CustomEvent("kerbcycle-qr-code-add-failed", {
+            detail: { code: qrCode, data, source },
+          }),
+        );
+        return { success: false, data };
+      })
+      .catch((error) => {
+        console.error("Error:", error);
+        showToast("An error occurred while adding the QR code.", true);
+        document.dispatchEvent(
+          new CustomEvent("kerbcycle-qr-code-add-error", {
+            detail: { code: qrCode, error, source },
+          }),
+        );
+        return { success: false, error };
+      });
+  }
+
+  window.kerbcycleAssignQrCodeToCustomer = assignQrCodeToCustomer;
+  window.kerbcycleAddQrCodeToRepository = addQrCodeToRepository;
+
+  if (addBtn) {
+    addBtn.addEventListener("click", function () {
+      addQrCodeToRepository(newCodeInput ? newCodeInput.value : "", {
+        showAlertOnEmpty: true,
+        clearInput: true,
+        source: "manual",
+      });
     });
   }
 

--- a/assets/js/dashboard-scanner.js
+++ b/assets/js/dashboard-scanner.js
@@ -215,7 +215,85 @@ function initDashboardScanner() {
   const readerEl = document.getElementById("reader");
   const scanResult = document.getElementById("scan-result");
   const scannerEnabled = kerbcycle_ajax.scanner_enabled;
+  const addFromScannerBtn = document.getElementById("dashboard-add-qr-btn");
+  const resetScannerBtn = document.getElementById("dashboard-reset-scan-btn");
+  const dashboardCustomerField = document.getElementById(
+    "dashboard-customer-id",
+  );
+  const assignToCustomerBtn = document.getElementById(
+    "dashboard-assign-qr-btn",
+  );
+  const sendEmailCheckbox = document.getElementById("send-email");
+  const sendSmsCheckbox = document.getElementById("send-sms");
+  const sendReminderCheckbox = document.getElementById("send-reminder");
   let scanner = null;
+  let lastScannedCode = "";
+  let addInProgress = false;
+  let assignInProgress = false;
+
+  function updateAddButtonState() {
+    if (!addFromScannerBtn) {
+      return;
+    }
+    const shouldDisable =
+      addInProgress || !scannerEnabled || !lastScannedCode;
+    addFromScannerBtn.disabled = shouldDisable;
+  }
+
+  function getDashboardCustomerName() {
+    if (!dashboardCustomerField) {
+      return "";
+    }
+    const option =
+      dashboardCustomerField.options[dashboardCustomerField.selectedIndex];
+    if (option) {
+      return option.textContent || option.text || "";
+    }
+    if (
+      dashboardCustomerField._searchable &&
+      dashboardCustomerField._searchable.input
+    ) {
+      return dashboardCustomerField._searchable.input.value || "";
+    }
+    return "";
+  }
+
+  function updateAssignButtonState() {
+    if (!assignToCustomerBtn) {
+      return;
+    }
+    const hasCustomer =
+      dashboardCustomerField && dashboardCustomerField.value;
+    const shouldDisable =
+      assignInProgress || !scannerEnabled || !lastScannedCode || !hasCustomer;
+    assignToCustomerBtn.disabled = shouldDisable;
+  }
+
+  updateAddButtonState();
+  updateAssignButtonState();
+
+  if (resetScannerBtn && !scannerEnabled) {
+    resetScannerBtn.disabled = true;
+  }
+
+  if (assignToCustomerBtn && !scannerEnabled) {
+    assignToCustomerBtn.disabled = true;
+  }
+
+  if (dashboardCustomerField) {
+    dashboardCustomerField.addEventListener("change", () => {
+      updateAssignButtonState();
+    });
+    if (
+      dashboardCustomerField._searchable &&
+      dashboardCustomerField._searchable.input
+    ) {
+      dashboardCustomerField._searchable.input.addEventListener(
+        "input",
+        updateAssignButtonState,
+      );
+    }
+  }
 
   function pauseActiveScanner() {
     if (scanner && typeof scanner.pause === "function") {
@@ -225,6 +303,354 @@ function initDashboardScanner() {
         console.warn("Unable to pause dashboard scanner", e);
       }
     }
+  }
+
+  if (addFromScannerBtn) {
+    addFromScannerBtn.addEventListener("click", () => {
+      if (!scannerEnabled) {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ QR code scanner is disabled in settings.</strong>",
+        );
+        return;
+      }
+
+      if (addInProgress) {
+        return;
+      }
+
+      if (!lastScannedCode) {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ Please scan a QR code before adding.</strong>",
+        );
+        return;
+      }
+
+      const addHandler = window.kerbcycleAddQrCodeToRepository;
+      if (typeof addHandler !== "function") {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ Unable to add QR code.</strong> Please use the manual form below.",
+        );
+        return;
+      }
+
+      const safeCode = escapeHtml(lastScannedCode);
+      addInProgress = true;
+      addFromScannerBtn.setAttribute("aria-busy", "true");
+      updateAddButtonState();
+      updateAssignButtonState();
+
+      setScanResult(
+        scanResult,
+        "success",
+        `<strong>⏳ Adding QR Code...</strong><br>Code: <code>${safeCode}</code>`,
+      );
+
+      let addPromise;
+      try {
+        addPromise = addHandler(lastScannedCode, {
+          source: "dashboard-scanner",
+          showAlertOnEmpty: false,
+          clearInput: false,
+        });
+      } catch (error) {
+        addInProgress = false;
+        addFromScannerBtn.removeAttribute("aria-busy");
+        updateAddButtonState();
+        console.error("Unable to add QR code from dashboard scanner", error);
+        setScanResult(
+          scanResult,
+          "error",
+          `<strong>❌ Unable to add QR code.</strong> ${escapeHtml(
+            error && error.message ? error.message : String(error),
+          )}`,
+        );
+        return;
+      }
+
+      Promise.resolve(addPromise)
+        .then((result) => {
+          if (result && result.success) {
+            lastScannedCode = "";
+            updateAssignButtonState();
+            setScanResult(
+              scanResult,
+              "success",
+              `<strong>✅ QR Code added to repository.</strong><br>Code: <code>${safeCode}</code><br>Use "Scan Reset" to scan another code.`,
+            );
+            return;
+          }
+
+          if (result && result.reason === "empty") {
+            setScanResult(
+              scanResult,
+              "error",
+              "<strong>❌ Please scan a QR code before adding.</strong>",
+            );
+            return;
+          }
+
+          const errMessage =
+            (result &&
+              result.data &&
+              result.data.data &&
+              result.data.data.message) ||
+            (result && result.data && result.data.message) ||
+            (result && result.error && result.error.message) ||
+            (result &&
+              typeof result.error === "string" &&
+              result.error) ||
+            "Failed to add QR code.";
+
+          setScanResult(
+            scanResult,
+            "error",
+            `<strong>❌ ${escapeHtml(errMessage)}</strong>`,
+          );
+        })
+        .catch((error) => {
+          console.error("Unable to add QR code from dashboard scanner", error);
+          setScanResult(
+            scanResult,
+            "error",
+            `<strong>❌ Unable to add QR code.</strong> ${escapeHtml(
+              error && error.message ? error.message : String(error),
+            )}`,
+          );
+        })
+        .finally(() => {
+          addInProgress = false;
+          addFromScannerBtn.removeAttribute("aria-busy");
+          updateAddButtonState();
+          updateAssignButtonState();
+        });
+    });
+  }
+
+  if (assignToCustomerBtn) {
+    assignToCustomerBtn.addEventListener("click", () => {
+      if (!scannerEnabled) {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ QR code scanner is disabled in settings.</strong>",
+        );
+        return;
+      }
+
+      if (assignInProgress) {
+        return;
+      }
+
+      const userId = dashboardCustomerField ? dashboardCustomerField.value : "";
+      if (!userId) {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ Please select a customer before assigning.</strong>",
+        );
+        return;
+      }
+
+      if (!lastScannedCode) {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ Please scan a QR code before assigning.</strong>",
+        );
+        return;
+      }
+
+      const assignHandler = window.kerbcycleAssignQrCodeToCustomer;
+      if (typeof assignHandler !== "function") {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ Unable to assign QR code.</strong> Please use the manual form below.",
+        );
+        return;
+      }
+
+      assignInProgress = true;
+      assignToCustomerBtn.setAttribute("aria-busy", "true");
+      updateAssignButtonState();
+
+      const customerName = getDashboardCustomerName();
+      const safeCode = escapeHtml(lastScannedCode);
+      const safeName = escapeHtml(customerName || "");
+      const pendingCustomerLine = customerName
+        ? `<br>Customer: <strong>${safeName}</strong>`
+        : "";
+
+      setScanResult(
+        scanResult,
+        "success",
+        `<strong>⏳ Assigning QR Code...</strong><br>Code: <code>${safeCode}</code>${pendingCustomerLine}`,
+      );
+
+      let assignPromise;
+      try {
+        assignPromise = assignHandler(lastScannedCode, userId, {
+          sendEmail: sendEmailCheckbox ? sendEmailCheckbox.checked : false,
+          sendSms: sendSmsCheckbox ? sendSmsCheckbox.checked : false,
+          sendReminder: sendReminderCheckbox
+            ? sendReminderCheckbox.checked
+            : false,
+          showAlertOnMissing: false,
+          source: "dashboard-scanner",
+          customerName,
+        });
+      } catch (error) {
+        assignInProgress = false;
+        assignToCustomerBtn.removeAttribute("aria-busy");
+        updateAssignButtonState();
+        console.error("Unable to assign QR code from dashboard scanner", error);
+        setScanResult(
+          scanResult,
+          "error",
+          `<strong>❌ Unable to assign QR code.</strong> ${escapeHtml(
+            error && error.message ? error.message : String(error),
+          )}`,
+        );
+        return;
+      }
+
+      Promise.resolve(assignPromise)
+        .then((result) => {
+          if (result && result.success) {
+            lastScannedCode = "";
+            updateAddButtonState();
+            updateAssignButtonState();
+            const successCustomerLine = customerName
+              ? `<br>Customer: <strong>${safeName}</strong>`
+              : "";
+            setScanResult(
+              scanResult,
+              "success",
+              `<strong>✅ QR Code assigned to customer.</strong><br>Code: <code>${safeCode}</code>${successCustomerLine}`,
+            );
+            return;
+          }
+
+          if (result && result.reason === "missing-user") {
+            setScanResult(
+              scanResult,
+              "error",
+              "<strong>❌ Please select a customer before assigning.</strong>",
+            );
+            return;
+          }
+
+          if (result && result.reason === "missing-code") {
+            setScanResult(
+              scanResult,
+              "error",
+              "<strong>❌ Please scan a QR code before assigning.</strong>",
+            );
+            return;
+          }
+
+          const errMessage =
+            (result && result.message) ||
+            (result && result.error && result.error.message) ||
+            "Unable to assign QR code.";
+
+          setScanResult(
+            scanResult,
+            "error",
+            `<strong>❌ ${escapeHtml(errMessage)}</strong>`,
+          );
+        })
+        .catch((error) => {
+          console.error("Unable to assign QR code from dashboard scanner", error);
+          setScanResult(
+            scanResult,
+            "error",
+            `<strong>❌ Unable to assign QR code.</strong> ${escapeHtml(
+              error && error.message ? error.message : String(error),
+            )}`,
+          );
+        })
+        .finally(() => {
+          assignInProgress = false;
+          assignToCustomerBtn.removeAttribute("aria-busy");
+          updateAssignButtonState();
+        });
+    });
+  }
+
+  if (resetScannerBtn) {
+    resetScannerBtn.addEventListener("click", () => {
+      if (!scannerEnabled) {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ QR code scanner is disabled in settings.</strong>",
+        );
+        return;
+      }
+
+      lastScannedCode = "";
+      updateAddButtonState();
+      updateAssignButtonState();
+
+      if (!scanner) {
+        setScanResult(
+          scanResult,
+          "error",
+          "<strong>❌ Scanner is not ready yet.</strong>",
+        );
+        return;
+      }
+
+      const successMessage =
+        "<strong>🔄 Scanner reset.</strong> Ready to scan a new QR code.";
+
+      try {
+        const resumeResult =
+          typeof scanner.resume === "function"
+            ? scanner.resume()
+            : typeof scanner.start === "function"
+            ? scanner.start()
+            : null;
+
+        if (resumeResult && typeof resumeResult.then === "function") {
+          resumeResult
+            .then(() => {
+              setScanResult(scanResult, "success", successMessage);
+            })
+            .catch((error) => {
+              console.error(
+                "Unable to reset dashboard scanner",
+                error,
+              );
+              setScanResult(
+                scanResult,
+                "error",
+                `<strong>❌ Unable to reset scanner.</strong> ${escapeHtml(
+                  error && error.message ? error.message : String(error),
+                )}`,
+              );
+            });
+        } else {
+          setScanResult(scanResult, "success", successMessage);
+        }
+      } catch (error) {
+        console.error("Unable to reset dashboard scanner", error);
+        setScanResult(
+          scanResult,
+          "error",
+          `<strong>❌ Unable to reset scanner.</strong> ${escapeHtml(
+            error && error.message ? error.message : String(error),
+          )}`,
+        );
+      }
+    });
   }
 
   if (scannerEnabled && readerEl) {
@@ -237,6 +663,9 @@ function initDashboardScanner() {
 
     const onScanSuccess = (decodedText) => {
       pauseActiveScanner();
+      lastScannedCode = decodedText || "";
+      updateAddButtonState();
+      updateAssignButtonState();
       const safeCode = escapeHtml(decodedText || "");
       setScanResult(
         scanResult,

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -95,6 +95,25 @@ class DashboardPage
         $scanner_enabled  = (bool) get_option('kerbcycle_qr_enable_scanner', 1);
         ?>
                 <?php if ($scanner_enabled) : ?>
+                    <div class="qr-scanner-actions">
+                        <button id="dashboard-add-qr-btn" class="button button-primary"><?php esc_html_e('Add QR Code', 'kerbcycle'); ?></button>
+                        <button id="dashboard-reset-scan-btn" class="button"><?php esc_html_e('Scan Reset', 'kerbcycle'); ?></button>
+                    </div>
+                    <div class="qr-scanner-customer">
+                        <div class="qr-scanner-customer-select">
+                            <?php
+                            wp_dropdown_users(array(
+                                'name'              => 'dashboard_customer_id',
+                                'id'                => 'dashboard-customer-id',
+                                'class'             => 'kc-searchable',
+                                'show_option_none'  => __('Select Customer', 'kerbcycle'),
+                                'option_none_value' => ''
+                            ));
+                            ?>
+                            <p class="description"><?php esc_html_e('Customer Search', 'kerbcycle'); ?></p>
+                        </div>
+                        <button id="dashboard-assign-qr-btn" class="button button-primary"><?php esc_html_e('Assign QR Code', 'kerbcycle'); ?></button>
+                    </div>
                     <div id="reader" class="qr-reader"></div>
                 <?php else : ?>
                     <div class="notice notice-warning qr-warning">


### PR DESCRIPTION
## Summary
- add a customer search select and assign button above the dashboard scanner feed so staff can pick a recipient alongside the add/reset actions
- style the scanner action area to keep the new search input and assign button aligned with the camera controls
- refactor assignment logic into a reusable helper that updates admin lists/counts and wire the scanner button to call it with the current scan and customer selection

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cef50087a4832d8e56d67f9bba21b3