### PR TITLE
Order QR code listings by assignment timestamp

### DIFF
--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -242,7 +242,9 @@ class QrCodeRepository
     public function list_all()
     {
         global $wpdb;
-        return $wpdb->get_results("SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $this->table ORDER BY id DESC");
+        return $wpdb->get_results(
+            "SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $this->table ORDER BY assigned_at DESC, id DESC"
+        );
     }
 
     public function recent_history($limit)

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -79,7 +79,9 @@ class Shortcodes
     {
         global $wpdb;
         $table = $wpdb->prefix . 'kerbcycle_qr_codes';
-        $codes = $wpdb->get_results("SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $table ORDER BY id DESC");
+        $codes = $wpdb->get_results(
+            "SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $table ORDER BY assigned_at DESC, id DESC"
+        );
 
         ob_start();
         ?>


### PR DESCRIPTION
## Summary
- order the shortcode table query by assigned_at DESC, id DESC so freshly assigned codes stay at the top
- update the QR code repository list_all helper to match the new ordering for consistent consumers

## Testing
- php -l includes/Public/Shortcodes.php
- php -l includes/Data/Repositories/QrCodeRepository.php

------
https://chatgpt.com/codex/tasks/task_e_68cf2441f7a0832da78e2895e0afa250