### PR TITLE
Order QR listings by latest assignment

### DIFF
--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -242,7 +242,10 @@ class QrCodeRepository
     public function list_all()
     {
         global $wpdb;
-        return $wpdb->get_results("SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $this->table ORDER BY id DESC");
+        return $wpdb->get_results(
+            "SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $this->table"
+            . " ORDER BY assigned_at DESC, id DESC"
+        );
     }
 
     public function recent_history($limit)

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -79,7 +79,10 @@ class Shortcodes
     {
         global $wpdb;
         $table = $wpdb->prefix . 'kerbcycle_qr_codes';
-        $codes = $wpdb->get_results("SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $table ORDER BY id DESC");
+        $codes = $wpdb->get_results(
+            "SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $table"
+            . " ORDER BY assigned_at DESC, id DESC"
+        );
 
         ob_start();
         ?>


### PR DESCRIPTION
## Summary
- order the QR shortcode table by most recent assignment first so reassigned codes stay on top
- align the repository list_all query with the shortcode ordering for consistent consumers

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf267b04c8832d8fbe98942c7f0a56