### PR TITLE
Capture email delivery results in QR workflows

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -274,6 +274,16 @@ function initKerbcycleAdmin() {
       .then((data) => {
         if (data.success) {
           let msg = "QR code assigned successfully.";
+          if (data.data && typeof data.data.email_sent !== "undefined") {
+            if (data.data.email_sent) {
+              msg += " Email notification sent.";
+            } else {
+              msg +=
+                " Email failed: " +
+                (data.data.email_error || "Unknown error") +
+                ".";
+            }
+          }
           if (data.data && typeof data.data.sms_sent !== "undefined") {
             if (data.data.sms_sent) {
               msg += " SMS notification sent.";
@@ -498,6 +508,16 @@ function initKerbcycleAdmin() {
         .then((data) => {
           if (data.success) {
             let msg = "QR code released successfully.";
+            if (data.data && typeof data.data.email_sent !== "undefined") {
+              if (data.data.email_sent) {
+                msg += " Email notification sent.";
+              } else {
+                msg +=
+                  " Email failed: " +
+                  (data.data.email_error || "Unknown error") +
+                  ".";
+              }
+            }
             if (data.data && typeof data.data.sms_sent !== "undefined") {
               if (data.data.sms_sent) {
                 msg += " SMS notification sent.";

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -66,6 +66,12 @@ class AdminAjax
                 'qr_code' => $qr_code,
                 'user_id' => $user_id,
             ];
+            if ($send_email) {
+                $response['email_sent'] = ($result['email_result'] === true);
+                if ($result['email_result'] !== true) {
+                    $response['email_error'] = is_wp_error($result['email_result']) ? $result['email_result']->get_error_message() : __('Unknown error', 'kerbcycle');
+                }
+            }
             if ($send_sms) {
                 $response['sms_sent'] = ($result['sms_result'] === true);
                 if ($result['sms_result'] !== true) {
@@ -115,6 +121,12 @@ class AdminAjax
             wp_send_json_error(['message' => $result->get_error_message()]);
         } else {
             $response = ['message' => 'QR code released successfully'];
+            if ($send_email) {
+                $response['email_sent'] = ($result['email_result'] === true);
+                if ($result['email_result'] !== true) {
+                    $response['email_error'] = is_wp_error($result['email_result']) ? $result['email_result']->get_error_message() : __('Unknown error', 'kerbcycle');
+                }
+            }
             if ($send_sms) {
                 $response['sms_sent'] = ($result['sms_result'] === true);
                 if ($result['sms_result'] !== true) {

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -84,9 +84,10 @@ class QrService
             return new \WP_Error('db_error', 'Failed to assign QR code in database.');
         }
 
-        $sms_result = null;
+        $sms_result   = null;
+        $email_result = null;
         if ($send_email) {
-            (new EmailService())->send_notification($user_id, $qr_code, 'assigned');
+            $email_result = (new EmailService())->send_notification($user_id, $qr_code, 'assigned');
         }
         if ($send_sms) {
             $sms_result = (new SmsService())->send_notification($user_id, $qr_code, 'assigned');
@@ -95,8 +96,9 @@ class QrService
         // if ($send_reminder) { ... }
 
         return [
-            'sms_result' => $sms_result,
-            'record'     => $this->repository->find_by_qr_code($qr_code),
+            'sms_result'   => $sms_result,
+            'email_result' => $email_result,
+            'record'       => $this->repository->find_by_qr_code($qr_code),
         ];
     }
 
@@ -113,17 +115,21 @@ class QrService
             return new \WP_Error('db_error', 'Failed to release QR code in database.');
         }
 
-        $sms_result = null;
+        $sms_result   = null;
+        $email_result = null;
         if ($row->user_id) {
             if ($send_email) {
-                (new EmailService())->send_notification($row->user_id, $qr_code, 'released');
+                $email_result = (new EmailService())->send_notification($row->user_id, $qr_code, 'released');
             }
             if ($send_sms) {
                 $sms_result = (new SmsService())->send_notification($row->user_id, $qr_code, 'released');
             }
         }
 
-        return ['sms_result' => $sms_result];
+        return [
+            'sms_result'   => $sms_result,
+            'email_result' => $email_result,
+        ];
     }
 
     public function bulk_release(array $codes)


### PR DESCRIPTION
## Summary
- capture the email notification result in QrService assign and release responses
- expose email status in the admin ajax assign/release responses so the UI can surface it
- show email notification success/failure details alongside SMS feedback in the admin notifications

## Testing
- php -l includes/Services/QrService.php
- php -l includes/Admin/Ajax/AdminAjax.php
- node -e "/* simulated notification message composition */"

------
https://chatgpt.com/codex/tasks/task_e_68d1c6cf58f4832d93022f202f17959f