### PR TITLE
Ensure combobox buttons retain glyph color

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -27,6 +27,7 @@
   border-radius: 4px;
   background: #f6f7f7;
   cursor: pointer;
+  color: var(--wp-admin-theme-color-darker-10, #1d2327);
 }
 
 .kc-combobox-reset {
@@ -41,11 +42,18 @@
   white-space: nowrap;
   display: inline-flex;
   align-items: center;
+  color: var(--wp-admin-theme-color-darker-10, #1d2327);
 }
 
 .kc-combobox-reset:hover,
 .kc-combobox-reset:focus {
   background: #e0e0e0;
+  color: var(--wp-admin-theme-color-darker-10, #1d2327);
+}
+
+.kc-combobox-toggle:hover,
+.kc-combobox-toggle:focus {
+  color: var(--wp-admin-theme-color-darker-10, #1d2327);
 }
 
 .kc-combobox-list {


### PR DESCRIPTION
## Summary
- assign the WordPress admin theme text color to the combobox toggle and reset controls so their icons remain legible against customized button themes
- mirror the same color on hover and focus states to prevent theme overrides from obscuring the controls during interaction

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1cd4c0ee8832dacf1c7f2ea499562