### PR TITLE
Add AJAX pagination for QR code dashboard

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -54,12 +54,17 @@ function initKerbcycleAdmin() {
   const newCodeInput = document.getElementById("new-qr-code");
   const importBtn = document.getElementById("import-qr-btn");
   const importFile = document.getElementById("import-qr-file");
+  const listingWrapper = document.getElementById("qr-listing");
+  const paginationWrappers = listingWrapper
+    ? Array.from(listingWrapper.querySelectorAll(".qr-pagination"))
+    : [];
   const listContainer = document.getElementById("qr-code-list");
   const sortButtons = listContainer
     ? Array.from(
         listContainer.querySelectorAll(".qr-header .qr-sort-control"),
       )
     : [];
+  let isPaginating = false;
   let currentSortKey = null;
   let currentSortDirection = "asc";
 
@@ -114,6 +119,308 @@ function initKerbcycleAdmin() {
     const anyChecked = Array.from(checkboxes).some((cb) => cb.checked);
     selectAll.checked = allChecked;
     selectAll.indeterminate = !allChecked && anyChecked;
+  }
+
+  function getListingState() {
+    if (!listingWrapper) {
+      return null;
+    }
+    const parseNumber = (value, fallback) => {
+      const parsed = parseInt(value, 10);
+      return Number.isNaN(parsed) ? fallback : parsed;
+    };
+    const currentPage = parseNumber(listingWrapper.dataset.currentPage, 1);
+    const totalPages = parseNumber(listingWrapper.dataset.totalPages, 0);
+    const totalItems = parseNumber(listingWrapper.dataset.totalItems, 0);
+    let perPage = parseNumber(listingWrapper.dataset.perPage, 20);
+    if (perPage < 1) {
+      perPage = 20;
+    }
+    return {
+      currentPage,
+      totalPages,
+      totalItems,
+      perPage,
+      filters: {
+        status_filter: listingWrapper.dataset.statusFilter || "",
+        start_date: listingWrapper.dataset.startDate || "",
+        end_date: listingWrapper.dataset.endDate || "",
+        search: listingWrapper.dataset.search || "",
+      },
+    };
+  }
+
+  function updatePaginationUI(pagination) {
+    if (!listingWrapper || !pagination) {
+      return;
+    }
+
+    const filters = pagination.filters || {};
+
+    if (
+      typeof pagination.current_page !== "undefined" &&
+      pagination.current_page !== null
+    ) {
+      listingWrapper.dataset.currentPage = String(pagination.current_page);
+    }
+
+    if (
+      typeof pagination.total_pages !== "undefined" &&
+      pagination.total_pages !== null
+    ) {
+      listingWrapper.dataset.totalPages = String(pagination.total_pages);
+    }
+
+    if (
+      typeof pagination.total_items !== "undefined" &&
+      pagination.total_items !== null
+    ) {
+      listingWrapper.dataset.totalItems = String(pagination.total_items);
+    }
+
+    if (
+      typeof pagination.per_page !== "undefined" &&
+      pagination.per_page !== null
+    ) {
+      listingWrapper.dataset.perPage = String(pagination.per_page);
+    }
+
+    if (
+      typeof filters.status_filter !== "undefined" &&
+      filters.status_filter !== null
+    ) {
+      listingWrapper.dataset.statusFilter = filters.status_filter;
+    }
+
+    if (
+      typeof filters.start_date !== "undefined" &&
+      filters.start_date !== null
+    ) {
+      listingWrapper.dataset.startDate = filters.start_date;
+    }
+
+    if (
+      typeof filters.end_date !== "undefined" &&
+      filters.end_date !== null
+    ) {
+      listingWrapper.dataset.endDate = filters.end_date;
+    }
+
+    if (
+      typeof filters.search !== "undefined" &&
+      filters.search !== null
+    ) {
+      listingWrapper.dataset.search = filters.search;
+    }
+
+    paginationWrappers.forEach((wrapper) => {
+      const controls = wrapper.querySelector(".qr-pagination-controls");
+      if (controls) {
+        controls.innerHTML = pagination.links || "";
+      }
+
+      const fallback = wrapper.querySelector(".qr-pagination-fallback");
+      if (fallback) {
+        const pages = fallback.querySelector(".tablenav-pages");
+        if (pages) {
+          pages.innerHTML = pagination.links || "";
+        }
+        if (
+          listingWrapper.classList.contains("qr-pagination-enhanced") ||
+          pagination.links
+        ) {
+          fallback.style.display = "none";
+        } else {
+          fallback.style.display = "";
+        }
+      }
+    });
+  }
+
+  function updateCountsFromServer(counts) {
+    if (!counts) {
+      return;
+    }
+    if (typeof counts.available !== "undefined") {
+      document.querySelectorAll(".qr-available-count").forEach((el) => {
+        el.textContent = counts.available;
+      });
+    }
+    if (typeof counts.assigned !== "undefined") {
+      document.querySelectorAll(".qr-assigned-count").forEach((el) => {
+        el.textContent = counts.assigned;
+      });
+    }
+  }
+
+  function replaceQrItems(html) {
+    if (!listContainer) {
+      return;
+    }
+    listContainer
+      .querySelectorAll(".qr-item")
+      .forEach((item) => item.remove());
+    if (html) {
+      listContainer.insertAdjacentHTML("beforeend", html);
+    }
+    listContainer
+      .querySelectorAll(".qr-item")
+      .forEach((item) => wireQrItem(item));
+  }
+
+  function getPageFromLink(link) {
+    if (!link) {
+      return null;
+    }
+    const pageAttr = link.getAttribute("data-page");
+    if (pageAttr) {
+      const parsedPage = parseInt(pageAttr, 10);
+      if (!Number.isNaN(parsedPage)) {
+        return parsedPage;
+      }
+    }
+    const href = link.getAttribute("href");
+    if (href) {
+      try {
+        const url = new URL(href, window.location.href);
+        const pagedParam = url.searchParams.get("paged");
+        if (pagedParam) {
+          const parsed = parseInt(pagedParam, 10);
+          if (!Number.isNaN(parsed)) {
+            return parsed;
+          }
+        }
+      } catch (error) {
+        // ignore malformed URLs
+      }
+    }
+    const state = getListingState();
+    if (!state) {
+      return null;
+    }
+    if (link.classList.contains("prev")) {
+      return Math.max(1, state.currentPage - 1);
+    }
+    if (link.classList.contains("next")) {
+      const total = state.totalPages || state.currentPage;
+      return Math.min(total, state.currentPage + 1);
+    }
+    return null;
+  }
+
+  function requestPage(targetPage) {
+    if (!listingWrapper || !listContainer) {
+      return Promise.resolve();
+    }
+    const state = getListingState();
+    if (!state) {
+      return Promise.resolve();
+    }
+    isPaginating = true;
+    listingWrapper.classList.add("is-loading");
+
+    const params = new URLSearchParams();
+    params.append("action", "kerbcycle_paginate_qr_codes");
+    params.append("security", kerbcycle_ajax.nonce);
+    params.append("paged", targetPage);
+    if (state.perPage > 0) {
+      params.append("per_page", state.perPage);
+    }
+    if (state.filters.status_filter) {
+      params.append("status_filter", state.filters.status_filter);
+    }
+    if (state.filters.start_date) {
+      params.append("start_date", state.filters.start_date);
+    }
+    if (state.filters.end_date) {
+      params.append("end_date", state.filters.end_date);
+    }
+    if (state.filters.search) {
+      params.append("search", state.filters.search);
+    }
+
+    return fetch(kerbcycle_ajax.ajax_url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+      },
+      body: params.toString(),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((data) => {
+        if (!data || !data.success) {
+          const message =
+            data && data.data && data.data.message
+              ? data.data.message
+              : "Unable to load QR codes.";
+          showToast(message, true);
+          return;
+        }
+        const payload = data.data || {};
+        replaceQrItems(payload.items_html || "");
+        updatePaginationUI(payload.pagination || {});
+        updateCountsFromServer(payload.counts || null);
+        applyCurrentSort();
+        updateSelectAllState();
+      })
+      .catch((error) => {
+        console.error("Error loading paginated QR codes:", error);
+        showToast("Failed to load QR codes. Please try again.", true);
+      })
+      .finally(() => {
+        isPaginating = false;
+        listingWrapper.classList.remove("is-loading");
+      });
+  }
+
+  function handlePaginationClick(event) {
+    const link = event.target.closest("a.page-numbers");
+    if (!link) {
+      return;
+    }
+    const state = getListingState();
+    if (!state) {
+      return;
+    }
+    const targetPage = getPageFromLink(link);
+    if (targetPage === null || targetPage === state.currentPage) {
+      return;
+    }
+    event.preventDefault();
+    if (isPaginating) {
+      return;
+    }
+    requestPage(targetPage);
+  }
+
+  function enhancePagination() {
+    if (!listingWrapper) {
+      return;
+    }
+    const state = getListingState();
+    let initialLinks = "";
+    paginationWrappers.forEach((wrapper) => {
+      const fallbackPages = wrapper.querySelector(
+        ".qr-pagination-fallback .tablenav-pages",
+      );
+      if (fallbackPages && !initialLinks) {
+        initialLinks = fallbackPages.innerHTML;
+      }
+    });
+    updatePaginationUI({
+      links: initialLinks,
+      current_page: state ? state.currentPage : undefined,
+      total_pages: state ? state.totalPages : undefined,
+      total_items: state ? state.totalItems : undefined,
+      per_page: state ? state.perPage : undefined,
+      filters: state ? state.filters : undefined,
+    });
+    listingWrapper.classList.add("qr-pagination-enhanced");
   }
 
   const normalizeDateValue = (value) => {
@@ -298,6 +605,13 @@ function initKerbcycleAdmin() {
   document
     .querySelectorAll("select.kc-searchable")
     .forEach(makeSearchableSelect);
+
+  if (listingWrapper) {
+    enhancePagination();
+    paginationWrappers.forEach((wrapper) => {
+      wrapper.addEventListener("click", handlePaginationClick);
+    });
+  }
 
   sortButtons.forEach((button) => {
     button.addEventListener("click", () => {

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -10,6 +10,7 @@ use Kerbcycle\QrCode\Services\ReportService;
 use Kerbcycle\QrCode\Services\QrService;
 use Kerbcycle\QrCode\Helpers\Nonces;
 use Kerbcycle\QrCode\Data\Repositories\MessageLogRepository;
+use Kerbcycle\QrCode\Admin\Pages\DashboardPage;
 
 /**
  * The admin ajax.
@@ -39,6 +40,7 @@ class AdminAjax
         add_action('wp_ajax_add_qr_code', [$this, 'add_qr_code']);
         add_action('wp_ajax_get_assigned_qr_codes', [$this, 'get_assigned_qr_codes']);
         add_action('wp_ajax_import_qr_codes', [$this, 'import_qr_codes']);
+        add_action('wp_ajax_kerbcycle_paginate_qr_codes', [$this, 'paginate_qr_codes']);
         add_action('wp_ajax_kerbcycle_qr_report_data', [$this, 'ajax_report_data']);
         add_action('wp_ajax_kerbcycle_delete_logs', [$this, 'delete_logs']);
     }
@@ -323,6 +325,48 @@ class AdminAjax
         } else {
             wp_send_json_error(['message' => __('No QR codes were imported.', 'kerbcycle')]);
         }
+    }
+
+    public function paginate_qr_codes()
+    {
+        Nonces::verify('kerbcycle_qr_nonce', 'security');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
+        }
+
+        $args = [
+            'status_filter' => isset($_POST['status_filter']) ? wp_unslash($_POST['status_filter']) : '',
+            'start_date'    => isset($_POST['start_date']) ? wp_unslash($_POST['start_date']) : '',
+            'end_date'      => isset($_POST['end_date']) ? wp_unslash($_POST['end_date']) : '',
+            'search'        => isset($_POST['search']) ? wp_unslash($_POST['search']) : '',
+            's'             => isset($_POST['s']) ? wp_unslash($_POST['s']) : '',
+            'per_page'      => isset($_POST['per_page']) ? wp_unslash($_POST['per_page']) : '',
+            'paged'         => isset($_POST['paged']) ? wp_unslash($_POST['paged']) : 1,
+        ];
+
+        $listing = DashboardPage::get_listing_data($args);
+
+        $pagination_links = DashboardPage::build_pagination_links(
+            $listing['current_page'],
+            $listing['total_pages'],
+            $listing['filters']
+        );
+
+        wp_send_json_success([
+            'items_html' => DashboardPage::render_qr_items($listing['codes']),
+            'pagination' => [
+                'links'        => $pagination_links,
+                'current_page' => $listing['current_page'],
+                'total_pages'  => $listing['total_pages'],
+                'total_items'  => $listing['total_items'],
+                'per_page'     => $listing['per_page'],
+                'filters'      => $listing['filters'],
+            ],
+            'counts'      => [
+                'available' => $listing['available_count'],
+                'assigned'  => $listing['assigned_count'],
+            ],
+        ]);
     }
 
     public function ajax_report_data()

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -23,64 +23,33 @@ class DashboardPage
     public function render()
     {
         global $wpdb;
-        $table        = $wpdb->prefix . 'kerbcycle_qr_codes';
-        $per_page     = (int) get_option('kerbcycle_qr_codes_per_page', 20);
-        $current_page = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
-        $offset       = ($current_page - 1) * $per_page;
 
-        $status_filter = isset($_GET['status_filter']) ? sanitize_text_field(wp_unslash($_GET['status_filter'])) : '';
-        $start_date    = isset($_GET['start_date']) ? sanitize_text_field(wp_unslash($_GET['start_date'])) : '';
-        $end_date      = isset($_GET['end_date']) ? sanitize_text_field(wp_unslash($_GET['end_date'])) : '';
-        $search        = isset($_GET['s']) ? sanitize_text_field(wp_unslash($_GET['s'])) : '';
+        $request_args = [
+            'status_filter' => isset($_GET['status_filter']) ? wp_unslash($_GET['status_filter']) : '',
+            'start_date'    => isset($_GET['start_date']) ? wp_unslash($_GET['start_date']) : '',
+            'end_date'      => isset($_GET['end_date']) ? wp_unslash($_GET['end_date']) : '',
+            'search'        => isset($_GET['s']) ? wp_unslash($_GET['s']) : '',
+            'paged'         => isset($_GET['paged']) ? wp_unslash($_GET['paged']) : 1,
+        ];
 
-        $where  = '1=1';
-        $params = [];
+        $listing_data = self::get_listing_data($request_args);
 
-        if ($status_filter) {
-            $where   .= ' AND status = %s';
-            $params[] = $status_filter;
-        }
+        $status_filter   = $listing_data['filters']['status_filter'];
+        $start_date      = $listing_data['filters']['start_date'];
+        $end_date        = $listing_data['filters']['end_date'];
+        $search          = $listing_data['filters']['search'];
+        $per_page        = $listing_data['per_page'];
+        $current_page    = $listing_data['current_page'];
+        $total_pages     = $listing_data['total_pages'];
+        $total_items     = $listing_data['total_items'];
+        $available_count = $listing_data['available_count'];
+        $assigned_count  = $listing_data['assigned_count'];
+        $all_codes       = $listing_data['codes'];
 
-        if ($start_date) {
-            $where   .= ' AND DATE(assigned_at) >= %s';
-            $params[] = $start_date;
-        }
+        $pagination_links = self::build_pagination_links($current_page, $total_pages, $listing_data['filters']);
 
-        if ($end_date) {
-            $where   .= ' AND DATE(assigned_at) <= %s';
-            $params[] = $end_date;
-        }
-
-        if ($search) {
-            $like     = '%' . $wpdb->esc_like($search) . '%';
-            $where   .= ' AND (CAST(id AS CHAR) LIKE %s OR qr_code LIKE %s OR CAST(user_id AS CHAR) LIKE %s OR display_name LIKE %s OR CAST(assigned_at AS CHAR) LIKE %s)';
-            $params[] = $like;
-            $params[] = $like;
-            $params[] = $like;
-            $params[] = $like;
-            $params[] = $like;
-        }
-
-        $count_sql   = "SELECT COUNT(*) FROM $table WHERE $where";
-        $total_items = (int) ($params ? $wpdb->get_var($wpdb->prepare($count_sql, $params)) : $wpdb->get_var($count_sql));
-        $total_pages = (int) ceil($total_items / $per_page);
-
-        $pagination_links = $total_pages > 1 ? paginate_links([
-            'base'      => add_query_arg('paged', '%#%'),
-            'format'    => '',
-            'prev_text' => '&laquo;',
-            'next_text' => '&raquo;',
-            'total'     => $total_pages,
-            'current'   => $current_page,
-        ]) : '';
-
+        $table           = $wpdb->prefix . 'kerbcycle_qr_codes';
         $available_codes = $wpdb->get_results("SELECT qr_code FROM $table WHERE status = 'available' ORDER BY id DESC");
-        $available_count = count($available_codes);
-        $assigned_count  = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE status = 'assigned'");
-
-        $select_sql = "SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $table WHERE $where ORDER BY assigned_at DESC, id DESC LIMIT %d OFFSET %d";
-        $query_args = array_merge($params, [$per_page, $offset]);
-        $all_codes  = $wpdb->get_results($wpdb->prepare($select_sql, $query_args));
         ?>
         <div class="wrap">
             <h1>KerbCycle QR Code Manager</h1>
@@ -202,105 +171,108 @@ class DashboardPage
                 </select>
                 <button id="apply-bulk-top" class="button" data-target="bulk-action-top"><?php esc_html_e('Apply', 'kerbcycle'); ?></button>
                 <p class="qr-code-counts">QR Codes: <span class="qr-available-count"><?= esc_html($available_count); ?></span> Available <span class="qr-assigned-count"><?= esc_html($assigned_count); ?></span> Assigned</p>
-                <?php if ($pagination_links) : ?>
-                    <div class="tablenav">
-                        <div class="tablenav-pages">
-                            <?= $pagination_links; ?>
+                <div
+                    id="qr-listing"
+                    class="qr-listing"
+                    data-current-page="<?= esc_attr($current_page); ?>"
+                    data-total-pages="<?= esc_attr($total_pages); ?>"
+                    data-total-items="<?= esc_attr($total_items); ?>"
+                    data-per-page="<?= esc_attr($per_page); ?>"
+                    data-status-filter="<?= esc_attr($status_filter); ?>"
+                    data-start-date="<?= esc_attr($start_date); ?>"
+                    data-end-date="<?= esc_attr($end_date); ?>"
+                    data-search="<?= esc_attr($search); ?>"
+                >
+                    <?php if ($pagination_links) : ?>
+                        <div class="qr-pagination" data-pagination-position="top">
+                            <div class="qr-pagination-controls" aria-live="polite"></div>
+                            <div class="tablenav qr-pagination-fallback">
+                                <div class="tablenav-pages">
+                                    <?= $pagination_links; ?>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                <?php endif; ?>
-                <ul id="qr-code-list">
-                    <li class="qr-header">
-                        <input type="checkbox" class="qr-select" id="qr-select-all" title="<?php esc_attr_e('Select all', 'kerbcycle'); ?>" />
-                        <?php
-                        $id_label        = __('ID', 'kerbcycle');
-                        $code_label      = __('QR Code', 'kerbcycle');
-                        $user_label      = __('User ID', 'kerbcycle');
-                        $customer_label  = __('Customer', 'kerbcycle');
-                        $status_label    = __('Status', 'kerbcycle');
-                        $assigned_label  = __('Assigned At', 'kerbcycle');
-                        $sort_label_text = __('Sort by %s', 'kerbcycle');
-                        ?>
-                        <span class="qr-id">
-                            <button type="button" class="qr-sort-control" data-sort-key="id" data-sort-type="number" data-sort-label="<?= esc_attr($id_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $id_label)); ?>">
-                                <span class="qr-sort-label"><?= esc_html($id_label); ?></span>
-                                <span class="sort-indicator" aria-hidden="true">
-                                    <span class="sort-arrow sort-arrow-asc"></span>
-                                    <span class="sort-arrow sort-arrow-desc"></span>
-                                </span>
-                            </button>
-                        </span>
-                        <span class="qr-text">
-                            <button type="button" class="qr-sort-control" data-sort-key="code" data-sort-type="text" data-sort-label="<?= esc_attr($code_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $code_label)); ?>">
-                                <span class="qr-sort-label"><?= esc_html($code_label); ?></span>
-                                <span class="sort-indicator" aria-hidden="true">
-                                    <span class="sort-arrow sort-arrow-asc"></span>
-                                    <span class="sort-arrow sort-arrow-desc"></span>
-                                </span>
-                            </button>
-                        </span>
-                        <span class="qr-user">
-                            <button type="button" class="qr-sort-control" data-sort-key="userId" data-sort-type="number" data-sort-label="<?= esc_attr($user_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $user_label)); ?>">
-                                <span class="qr-sort-label"><?= esc_html($user_label); ?></span>
-                                <span class="sort-indicator" aria-hidden="true">
-                                    <span class="sort-arrow sort-arrow-asc"></span>
-                                    <span class="sort-arrow sort-arrow-desc"></span>
-                                </span>
-                            </button>
-                        </span>
-                        <span class="qr-name">
-                            <button type="button" class="qr-sort-control" data-sort-key="displayName" data-sort-type="text" data-sort-label="<?= esc_attr($customer_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $customer_label)); ?>">
-                                <span class="qr-sort-label"><?= esc_html($customer_label); ?></span>
-                                <span class="sort-indicator" aria-hidden="true">
-                                    <span class="sort-arrow sort-arrow-asc"></span>
-                                    <span class="sort-arrow sort-arrow-desc"></span>
-                                </span>
-                            </button>
-                        </span>
-                        <span class="qr-status">
-                            <button type="button" class="qr-sort-control" data-sort-key="status" data-sort-type="text" data-sort-label="<?= esc_attr($status_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $status_label)); ?>">
-                                <span class="qr-sort-label"><?= esc_html($status_label); ?></span>
-                                <span class="sort-indicator" aria-hidden="true">
-                                    <span class="sort-arrow sort-arrow-asc"></span>
-                                    <span class="sort-arrow sort-arrow-desc"></span>
-                                </span>
-                            </button>
-                        </span>
-                        <span class="qr-assigned">
-                            <button type="button" class="qr-sort-control" data-sort-key="assignedAt" data-sort-type="date" data-sort-label="<?= esc_attr($assigned_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $assigned_label)); ?>">
-                                <span class="qr-sort-label"><?= esc_html($assigned_label); ?></span>
-                                <span class="sort-indicator" aria-hidden="true">
-                                    <span class="sort-arrow sort-arrow-asc"></span>
-                                    <span class="sort-arrow sort-arrow-desc"></span>
-                                </span>
-                            </button>
-                        </span>
-                    </li>
-                    <?php foreach ($all_codes as $code) : ?>
-                        <li class="qr-item"
-                            data-code="<?= esc_attr($code->qr_code); ?>"
-                            data-id="<?= esc_attr($code->id); ?>"
-                            data-user-id="<?= esc_attr($code->user_id ? $code->user_id : ''); ?>"
-                            data-display-name="<?= esc_attr($code->display_name ? $code->display_name : ''); ?>"
-                            data-status="<?= esc_attr($code->status ? strtolower($code->status) : ''); ?>"
-                            data-assigned-at="<?= esc_attr($code->assigned_at ? $code->assigned_at : ''); ?>">
-                            <input type="checkbox" class="qr-select" />
-                            <span class="qr-id"><?= esc_html($code->id); ?></span>
-                            <span class="qr-text" contenteditable="true"><?= esc_html($code->qr_code); ?></span>
-                            <span class="qr-user"><?= $code->user_id ? esc_html($code->user_id) : '—'; ?></span>
-                            <span class="qr-name"><?= $code->display_name ? esc_html($code->display_name) : '—'; ?></span>
-                            <span class="qr-status"><?= esc_html(ucfirst($code->status)); ?></span>
-                            <span class="qr-assigned"><?= $code->assigned_at ? esc_html($code->assigned_at) : '—'; ?></span>
+                    <?php endif; ?>
+                    <ul id="qr-code-list">
+                        <li class="qr-header">
+                            <input type="checkbox" class="qr-select" id="qr-select-all" title="<?php esc_attr_e('Select all', 'kerbcycle'); ?>" />
+                            <?php
+                            $id_label        = __('ID', 'kerbcycle');
+                            $code_label      = __('QR Code', 'kerbcycle');
+                            $user_label      = __('User ID', 'kerbcycle');
+                            $customer_label  = __('Customer', 'kerbcycle');
+                            $status_label    = __('Status', 'kerbcycle');
+                            $assigned_label  = __('Assigned At', 'kerbcycle');
+                            $sort_label_text = __('Sort by %s', 'kerbcycle');
+                            ?>
+                            <span class="qr-id">
+                                <button type="button" class="qr-sort-control" data-sort-key="id" data-sort-type="number" data-sort-label="<?= esc_attr($id_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $id_label)); ?>">
+                                    <span class="qr-sort-label"><?= esc_html($id_label); ?></span>
+                                    <span class="sort-indicator" aria-hidden="true">
+                                        <span class="sort-arrow sort-arrow-asc"></span>
+                                        <span class="sort-arrow sort-arrow-desc"></span>
+                                    </span>
+                                </button>
+                            </span>
+                            <span class="qr-text">
+                                <button type="button" class="qr-sort-control" data-sort-key="code" data-sort-type="text" data-sort-label="<?= esc_attr($code_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $code_label)); ?>">
+                                    <span class="qr-sort-label"><?= esc_html($code_label); ?></span>
+                                    <span class="sort-indicator" aria-hidden="true">
+                                        <span class="sort-arrow sort-arrow-asc"></span>
+                                        <span class="sort-arrow sort-arrow-desc"></span>
+                                    </span>
+                                </button>
+                            </span>
+                            <span class="qr-user">
+                                <button type="button" class="qr-sort-control" data-sort-key="userId" data-sort-type="number" data-sort-label="<?= esc_attr($user_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $user_label)); ?>">
+                                    <span class="qr-sort-label"><?= esc_html($user_label); ?></span>
+                                    <span class="sort-indicator" aria-hidden="true">
+                                        <span class="sort-arrow sort-arrow-asc"></span>
+                                        <span class="sort-arrow sort-arrow-desc"></span>
+                                    </span>
+                                </button>
+                            </span>
+                            <span class="qr-name">
+                                <button type="button" class="qr-sort-control" data-sort-key="displayName" data-sort-type="text" data-sort-label="<?= esc_attr($customer_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $customer_label)); ?>">
+                                    <span class="qr-sort-label"><?= esc_html($customer_label); ?></span>
+                                    <span class="sort-indicator" aria-hidden="true">
+                                        <span class="sort-arrow sort-arrow-asc"></span>
+                                        <span class="sort-arrow sort-arrow-desc"></span>
+                                    </span>
+                                </button>
+                            </span>
+                            <span class="qr-status">
+                                <button type="button" class="qr-sort-control" data-sort-key="status" data-sort-type="text" data-sort-label="<?= esc_attr($status_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $status_label)); ?>">
+                                    <span class="qr-sort-label"><?= esc_html($status_label); ?></span>
+                                    <span class="sort-indicator" aria-hidden="true">
+                                        <span class="sort-arrow sort-arrow-asc"></span>
+                                        <span class="sort-arrow sort-arrow-desc"></span>
+                                    </span>
+                                </button>
+                            </span>
+                            <span class="qr-assigned">
+                                <button type="button" class="qr-sort-control" data-sort-key="assignedAt" data-sort-type="date" data-sort-label="<?= esc_attr($assigned_label); ?>" aria-pressed="false" title="<?= esc_attr(sprintf($sort_label_text, $assigned_label)); ?>">
+                                    <span class="qr-sort-label"><?= esc_html($assigned_label); ?></span>
+                                    <span class="sort-indicator" aria-hidden="true">
+                                        <span class="sort-arrow sort-arrow-asc"></span>
+                                        <span class="sort-arrow sort-arrow-desc"></span>
+                                    </span>
+                                </button>
+                            </span>
                         </li>
-                    <?php endforeach; ?>
-                </ul>
-                <?php if ($pagination_links) : ?>
-                    <div class="tablenav">
-                        <div class="tablenav-pages">
-                            <?= $pagination_links; ?>
+                        <?= self::render_qr_items($all_codes); ?>
+                    </ul>
+                    <?php if ($pagination_links) : ?>
+                        <div class="qr-pagination" data-pagination-position="bottom">
+                            <div class="qr-pagination-controls" aria-live="polite"></div>
+                            <div class="tablenav qr-pagination-fallback">
+                                <div class="tablenav-pages">
+                                    <?= $pagination_links; ?>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                <?php endif; ?>
+                    <?php endif; ?>
+                </div>
                 <p class="qr-code-counts">QR Codes: <span class="qr-available-count"><?= esc_html($available_count); ?></span> Available <span class="qr-assigned-count"><?= esc_html($assigned_count); ?></span> Assigned</p>
                 <select id="bulk-action">
                     <option value=""><?php esc_html_e('Bulk actions', 'kerbcycle'); ?></option>
@@ -311,5 +283,205 @@ class DashboardPage
             </form>
         </div>
         <?php
+    }
+
+    /**
+     * Retrieve QR code listing data for the dashboard.
+     *
+     * @param array $args Request arguments.
+     *
+     * @return array
+     */
+    public static function get_listing_data(array $args = [])
+    {
+        global $wpdb;
+
+        $table            = $wpdb->prefix . 'kerbcycle_qr_codes';
+        $per_page_default = (int) get_option('kerbcycle_qr_codes_per_page', 20);
+        $per_page         = isset($args['per_page']) ? absint($args['per_page']) : $per_page_default;
+
+        if ($per_page < 1) {
+            $per_page = $per_page_default > 0 ? $per_page_default : 20;
+        }
+
+        $raw_page     = isset($args['paged']) ? $args['paged'] : (isset($args['page']) ? $args['page'] : 1);
+        $current_page = max(1, absint($raw_page));
+        $offset       = ($current_page - 1) * $per_page;
+
+        $status_filter = '';
+        if (isset($args['status_filter'])) {
+            $status_filter = sanitize_text_field((string) $args['status_filter']);
+        }
+        if ($status_filter && !in_array($status_filter, ['assigned', 'available'], true)) {
+            $status_filter = '';
+        }
+
+        $start_date = '';
+        if (isset($args['start_date'])) {
+            $start_date = sanitize_text_field((string) $args['start_date']);
+        }
+
+        $end_date = '';
+        if (isset($args['end_date'])) {
+            $end_date = sanitize_text_field((string) $args['end_date']);
+        }
+
+        $search = '';
+        if (isset($args['search'])) {
+            $search = sanitize_text_field((string) $args['search']);
+        } elseif (isset($args['s'])) {
+            $search = sanitize_text_field((string) $args['s']);
+        }
+
+        $where  = '1=1';
+        $params = [];
+
+        if ($status_filter) {
+            $where   .= ' AND status = %s';
+            $params[] = $status_filter;
+        }
+
+        if ($start_date) {
+            $where   .= ' AND DATE(assigned_at) >= %s';
+            $params[] = $start_date;
+        }
+
+        if ($end_date) {
+            $where   .= ' AND DATE(assigned_at) <= %s';
+            $params[] = $end_date;
+        }
+
+        if ($search) {
+            $like     = '%' . $wpdb->esc_like($search) . '%';
+            $where   .= ' AND (CAST(id AS CHAR) LIKE %s OR qr_code LIKE %s OR CAST(user_id AS CHAR) LIKE %s OR display_name LIKE %s OR CAST(assigned_at AS CHAR) LIKE %s)';
+            $params[] = $like;
+            $params[] = $like;
+            $params[] = $like;
+            $params[] = $like;
+            $params[] = $like;
+        }
+
+        $count_sql   = "SELECT COUNT(*) FROM $table WHERE $where";
+        $total_items = (int) ($params ? $wpdb->get_var($wpdb->prepare($count_sql, $params)) : $wpdb->get_var($count_sql));
+        $total_pages = (int) ceil($total_items / $per_page);
+
+        $select_sql = "SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $table WHERE $where ORDER BY assigned_at DESC, id DESC LIMIT %d OFFSET %d";
+        $query_args = array_merge($params, [$per_page, $offset]);
+        $codes      = $wpdb->get_results($wpdb->prepare($select_sql, $query_args));
+
+        $available_count = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE status = 'available'");
+        $assigned_count  = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE status = 'assigned'");
+
+        return [
+            'codes'          => $codes,
+            'per_page'       => $per_page,
+            'current_page'   => $current_page,
+            'total_pages'    => $total_pages,
+            'total_items'    => $total_items,
+            'available_count' => $available_count,
+            'assigned_count' => $assigned_count,
+            'filters'        => [
+                'status_filter' => $status_filter,
+                'start_date'    => $start_date,
+                'end_date'      => $end_date,
+                'search'        => $search,
+            ],
+        ];
+    }
+
+    /**
+     * Render QR code list items.
+     *
+     * @param iterable $codes Codes to render.
+     *
+     * @return string
+     */
+    public static function render_qr_items($codes)
+    {
+        if (empty($codes)) {
+            return '';
+        }
+
+        ob_start();
+
+        foreach ($codes as $code) {
+            $id_value      = isset($code->id) ? (int) $code->id : 0;
+            $qr_code_value = isset($code->qr_code) ? (string) $code->qr_code : '';
+            $user_id_value = isset($code->user_id) && $code->user_id !== null ? (string) $code->user_id : '';
+            $name_value    = isset($code->display_name) && $code->display_name !== null ? (string) $code->display_name : '';
+            $status_raw    = isset($code->status) && $code->status !== null ? (string) $code->status : '';
+            $status_value  = $status_raw !== '' ? strtolower($status_raw) : '';
+            $assigned_at   = isset($code->assigned_at) && $code->assigned_at !== null ? (string) $code->assigned_at : '';
+            $status_label  = $status_raw !== '' ? ucfirst($status_raw) : '';
+            ?>
+            <li class="qr-item"
+                data-code="<?= esc_attr($qr_code_value); ?>"
+                data-id="<?= esc_attr($id_value); ?>"
+                data-user-id="<?= esc_attr($user_id_value); ?>"
+                data-display-name="<?= esc_attr($name_value); ?>"
+                data-status="<?= esc_attr($status_value); ?>"
+                data-assigned-at="<?= esc_attr($assigned_at); ?>">
+                <input type="checkbox" class="qr-select" />
+                <span class="qr-id"><?= esc_html($id_value); ?></span>
+                <span class="qr-text" contenteditable="true"><?= esc_html($qr_code_value); ?></span>
+                <span class="qr-user"><?= $user_id_value !== '' ? esc_html($user_id_value) : '—'; ?></span>
+                <span class="qr-name"><?= $name_value !== '' ? esc_html($name_value) : '—'; ?></span>
+                <span class="qr-status"><?= esc_html($status_label); ?></span>
+                <span class="qr-assigned"><?= $assigned_at !== '' ? esc_html($assigned_at) : '—'; ?></span>
+            </li>
+            <?php
+        }
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Build pagination links for the dashboard list.
+     *
+     * @param int   $current_page Current page number.
+     * @param int   $total_pages  Total number of pages.
+     * @param array $filters      Active filters.
+     *
+     * @return string
+     */
+    public static function build_pagination_links($current_page, $total_pages, array $filters = [])
+    {
+        $total_pages = (int) $total_pages;
+
+        if ($total_pages <= 1) {
+            return '';
+        }
+
+        $current_page = max(1, (int) $current_page);
+
+        $query_args = ['page' => 'kerbcycle-qr-manager'];
+
+        if (!empty($filters['status_filter'])) {
+            $query_args['status_filter'] = $filters['status_filter'];
+        }
+
+        if (!empty($filters['start_date'])) {
+            $query_args['start_date'] = $filters['start_date'];
+        }
+
+        if (!empty($filters['end_date'])) {
+            $query_args['end_date'] = $filters['end_date'];
+        }
+
+        if (!empty($filters['search'])) {
+            $query_args['s'] = $filters['search'];
+        }
+
+        $base_url = add_query_arg($query_args, admin_url('admin.php'));
+        $base     = add_query_arg('paged', '%#%', $base_url);
+
+        return paginate_links([
+            'base'      => $base,
+            'format'    => '',
+            'prev_text' => '&laquo;',
+            'next_text' => '&raquo;',
+            'total'     => $total_pages,
+            'current'   => $current_page,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- expose pagination metadata and dynamic controls around the QR code listing while reusing shared query helpers
- add a secured kerbcycle_paginate_qr_codes admin-ajax endpoint that returns list markup plus pagination counts
- enhance the admin script to drive AJAX pagination, rebuild controls, and keep list wiring intact with error handling

## Testing
- php -l includes/Admin/Pages/DashboardPage.php
- php -l includes/Admin/Ajax/AdminAjax.php

------
https://chatgpt.com/codex/tasks/task_e_68d3115b31ac832d9ffa530101924fcc