### PR TITLE
Add helper to render and log admin notices

### DIFF
--- a/includes/Admin/Notices.php
+++ b/includes/Admin/Notices.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Kerbcycle\QrCode\Admin;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+use Kerbcycle\QrCode\Data\Repositories\ErrorLogRepository;
+
+/**
+ * Helper for rendering admin notices and logging them to the Kerbcycle log table.
+ */
+class Notices
+{
+    /**
+     * Render an admin notice and persist it to the error log repository.
+     *
+     * @param string $notice_type WordPress notice type (success, error, warning, info).
+     * @param string $message     The HTML message to display inside the notice.
+     * @param array  $args        Optional arguments.
+     *
+     * @return string Rendered HTML for the notice.
+     */
+    public static function add($notice_type, $message, array $args = [])
+    {
+        $defaults = [
+            'dismissible'   => false,
+            'log_type'      => '',
+            'page'          => '',
+            'status'        => null,
+            'echo'          => true,
+            'extra_classes' => [],
+        ];
+
+        $args = \wp_parse_args($args, $defaults);
+
+        $notice_type = is_string($notice_type) ? strtolower($notice_type) : 'info';
+        $classes = ['notice', 'notice-' . $notice_type];
+        if (!empty($args['dismissible'])) {
+            $classes[] = 'is-dismissible';
+        }
+
+        $extra_classes = $args['extra_classes'];
+        if (!is_array($extra_classes)) {
+            $extra_classes = $extra_classes ? [$extra_classes] : [];
+        }
+        foreach ($extra_classes as $extra_class) {
+            if (is_string($extra_class) && $extra_class !== '') {
+                $classes[] = \sanitize_html_class($extra_class);
+            }
+        }
+
+        $sanitized_message = \wp_kses_post($message);
+        $page = $args['page'];
+        if ($page === '' && isset($_GET['page'])) {
+            $page = \sanitize_text_field(\wp_unslash($_GET['page']));
+        }
+
+        $status = $args['status'];
+        if ($status === null) {
+            $status = ($notice_type === 'success') ? 'success' : 'failure';
+        }
+
+        $log_type = $args['log_type'] !== '' ? $args['log_type'] : $notice_type;
+
+        ErrorLogRepository::log([
+            'type'    => $log_type,
+            'message' => $sanitized_message,
+            'page'    => $page,
+            'status'  => $status,
+        ]);
+
+        $html = \sprintf(
+            '<div class="%1$s"><p>%2$s</p></div>',
+            \esc_attr(\implode(' ', \array_filter($classes))),
+            $sanitized_message
+        );
+
+        if (!empty($args['echo'])) {
+            echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
+
+        return $html;
+    }
+}

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -6,6 +6,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+use Kerbcycle\QrCode\Admin\Notices;
+
 /**
  * The dashboard page.
  *
@@ -53,9 +55,17 @@ class DashboardPage
         ?>
         <div class="wrap">
             <h1>KerbCycle QR Code Manager</h1>
-            <div class="notice notice-info">
-                <p><?php esc_html_e('Select a customer and scan or choose a QR code to assign.', 'kerbcycle'); ?></p>
-            </div>
+            <?php
+            Notices::add(
+                'info',
+                esc_html__('Select a customer and scan or choose a QR code to assign.', 'kerbcycle'),
+                [
+                    'log_type' => 'dashboard_instruction',
+                    'page'     => 'kerbcycle-qr-manager',
+                    'status'   => 'success',
+                ]
+            );
+            ?>
             <div id="qr-scanner-container">
                 <?php
                 $email_enabled    = (bool) get_option('kerbcycle_qr_enable_email', 1);
@@ -85,9 +95,18 @@ class DashboardPage
                     </div>
                     <div id="reader" class="qr-reader"></div>
                 <?php else : ?>
-                    <div class="notice notice-warning qr-warning">
-                        <p><?php esc_html_e('QR code scanner camera is disabled in settings.', 'kerbcycle'); ?></p>
-                    </div>
+                    <?php
+                    Notices::add(
+                        'warning',
+                        esc_html__('QR code scanner camera is disabled in settings.', 'kerbcycle'),
+                        [
+                            'extra_classes' => 'qr-warning',
+                            'log_type'      => 'dashboard_scanner_disabled',
+                            'page'          => 'kerbcycle-qr-manager',
+                            'status'        => 'failure',
+                        ]
+                    );
+                    ?>
                 <?php endif; ?>
                 <div id="scan-result" class="updated"></div>
                 <h2><?php esc_html_e('Manual QR Code Tasks', 'kerbcycle'); ?></h2>

--- a/includes/Admin/Pages/MessagesHistoryPage.php
+++ b/includes/Admin/Pages/MessagesHistoryPage.php
@@ -6,6 +6,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+use Kerbcycle\QrCode\Admin\Notices;
 use Kerbcycle\QrCode\Data\Repositories\MessageLogRepository;
 use Kerbcycle\QrCode\Helpers\Nonces;
 
@@ -233,14 +234,21 @@ class MessagesHistoryPage
                 <h1><?php esc_html_e('Messages History', 'kerbcycle'); ?></h1>
 
                 <?php if (!$table_ok) : ?>
-                    <div class="notice notice-error">
-                        <p>
-                            <?php esc_html_e('The message logs table is missing or incomplete. Click “Repair Table” to (re)create the correct structure.', 'kerbcycle'); ?>
-                            <?php if (!empty($this->last_error)) : ?>
-                                <br><strong><?php esc_html_e('Last DB error:', 'kerbcycle'); ?></strong> <?php echo esc_html($this->last_error); ?>
-                            <?php endif; ?>
-                        </p>
-                    </div>
+                    <?php
+                    $missing_message = esc_html__('The message logs table is missing or incomplete. Click “Repair Table” to (re)create the correct structure.', 'kerbcycle');
+                    if (!empty($this->last_error)) {
+                        $missing_message .= '<br><strong>' . esc_html__('Last DB error:', 'kerbcycle') . '</strong> ' . esc_html($this->last_error);
+                    }
+                    Notices::add(
+                        'error',
+                        $missing_message,
+                        [
+                            'log_type' => 'messages_history_table',
+                            'page'     => $this->page_slug,
+                            'status'   => 'failure',
+                        ]
+                    );
+                    ?>
                     <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="margin:8px 0;">
                         <?php wp_nonce_field('kerbcycle_repair_logs'); ?>
                         <input type="hidden" name="action" value="kerbcycle_repair_logs" />
@@ -249,31 +257,64 @@ class MessagesHistoryPage
                 <?php endif; ?>
 
                 <?php if (!empty($_GET['repaired'])) : ?>
-                    <div class="notice notice-success is-dismissible">
-                        <p><?php esc_html_e('Logs table repaired.', 'kerbcycle'); ?></p>
-                    </div>
+                    <?php
+                    Notices::add(
+                        'success',
+                        esc_html__('Logs table repaired.', 'kerbcycle'),
+                        [
+                            'dismissible' => true,
+                            'log_type'    => 'messages_history_repair',
+                            'page'        => $this->page_slug,
+                            'status'      => 'success',
+                        ]
+                    );
+                    ?>
                 <?php endif; ?>
 
                 <?php if (!empty($_GET['repair_failed'])) : ?>
-                    <div class="notice notice-error is-dismissible">
-                        <p><?php esc_html_e('Repair failed. Check server error logs or DB permissions.', 'kerbcycle'); ?></p>
-                    </div>
+                    <?php
+                    Notices::add(
+                        'error',
+                        esc_html__('Repair failed. Check server error logs or DB permissions.', 'kerbcycle'),
+                        [
+                            'dismissible' => true,
+                            'log_type'    => 'messages_history_repair',
+                            'page'        => $this->page_slug,
+                            'status'      => 'failure',
+                        ]
+                    );
+                    ?>
                 <?php endif; ?>
 
                 <?php if (!empty($_GET['deleted'])) : ?>
-                    <div class="notice notice-success is-dismissible">
-                        <p>
-                            <?php printf(esc_html__('%d log(s) deleted.', 'kerbcycle'), absint($_GET['deleted'])); ?>
-                        </p>
-                    </div>
+                    <?php
+                    $deleted = absint($_GET['deleted']);
+                    Notices::add(
+                        'success',
+                        sprintf(esc_html__('%d log(s) deleted.', 'kerbcycle'), $deleted),
+                        [
+                            'dismissible' => true,
+                            'log_type'    => 'messages_history_deleted',
+                            'page'        => $this->page_slug,
+                            'status'      => 'success',
+                        ]
+                    );
+                    ?>
                 <?php endif; ?>
 
                 <?php if (!empty($_GET['cleared'])) : ?>
-                    <div class="notice notice-success is-dismissible">
-                        <p>
-                            <?php esc_html_e('All logs cleared.', 'kerbcycle'); ?>
-                        </p>
-                    </div>
+                    <?php
+                    Notices::add(
+                        'success',
+                        esc_html__('All logs cleared.', 'kerbcycle'),
+                        [
+                            'dismissible' => true,
+                            'log_type'    => 'messages_history_cleared',
+                            'page'        => $this->page_slug,
+                            'status'      => 'success',
+                        ]
+                    );
+                    ?>
                 <?php endif; ?>
 
                 <h2 class="nav-tab-wrapper" style="margin-top:12px;">

--- a/includes/Services/MessagesService.php
+++ b/includes/Services/MessagesService.php
@@ -2,6 +2,7 @@
 
 namespace Kerbcycle\QrCode\Services;
 
+use Kerbcycle\QrCode\Admin\Notices;
 use Kerbcycle\QrCode\Helpers\Nonces;
 
 if (!defined('ABSPATH')) {
@@ -99,7 +100,16 @@ class MessagesService
             $messages[$sel]['email'] = wp_strip_all_tags($email, true);
 
             update_option(self::OPT, $messages, false);
-            echo '<div class="notice notice-success is-dismissible"><p>Messages saved for <strong>'.esc_html(self::label_for($sel)).'</strong>.</p></div>';
+            Notices::add(
+                'success',
+                'Messages saved for <strong>' . esc_html(self::label_for($sel)) . '</strong>.',
+                [
+                    'dismissible' => true,
+                    'log_type'    => 'messages_save',
+                    'page'        => 'kerbcycle-messages',
+                    'status'      => 'success',
+                ]
+            );
             $tab = 'edit';
         }
 
@@ -143,21 +153,55 @@ class MessagesService
                 $r = \Kerbcycle\QrCode\Services\SmsService::send($t_to_sms, $test_preview_sms);
                 if (is_wp_error($r)) {
                     $d = $r->get_error_data();
-                    $http = (is_array($d) && isset($d['http'])) ? ' HTTP='.$d['http'] : '';
-                    $body = (is_array($d) && isset($d['body'])) ? ' Body='.substr(is_string($d['body']) ? $d['body'] : json_encode($d['body']), 0, 300) : '';
-                    echo '<div class="notice notice-error"><p><strong>Test SMS failed:</strong> '.esc_html($r->get_error_message().$http.$body).'</p></div>';
+                    $http = (is_array($d) && isset($d['http'])) ? ' HTTP=' . $d['http'] : '';
+                    $body = (is_array($d) && isset($d['body'])) ? ' Body=' . substr(is_string($d['body']) ? $d['body'] : json_encode($d['body']), 0, 300) : '';
+                    Notices::add(
+                        'error',
+                        '<strong>Test SMS failed:</strong> ' . esc_html($r->get_error_message() . $http . $body),
+                        [
+                            'log_type' => 'test_sms',
+                            'page'     => 'kerbcycle-messages',
+                            'status'   => 'failure',
+                        ]
+                    );
                 } else {
-                    echo '<div class="notice notice-success is-dismissible"><p><strong>Test SMS sent.</strong> '.esc_html(json_encode($r)).'</p></div>';
+                    Notices::add(
+                        'success',
+                        '<strong>Test SMS sent.</strong> ' . esc_html(json_encode($r)),
+                        [
+                            'dismissible' => true,
+                            'log_type'    => 'test_sms',
+                            'page'        => 'kerbcycle-messages',
+                            'status'      => 'success',
+                        ]
+                    );
                 }
             }
 
             // Email send (optional)
             if ($do_send_email && $t_to_email) {
-                $sent = wp_mail($t_to_email, 'KerbCycle Test: '.self::label_for($t_type), $test_preview_email);
+                $sent = wp_mail($t_to_email, 'KerbCycle Test: ' . self::label_for($t_type), $test_preview_email);
                 if ($sent) {
-                    echo '<div class="notice notice-success is-dismissible"><p><strong>Test Email sent</strong> to '.esc_html($t_to_email).'.</p></div>';
+                    Notices::add(
+                        'success',
+                        '<strong>Test Email sent</strong> to ' . esc_html($t_to_email) . '.',
+                        [
+                            'dismissible' => true,
+                            'log_type'    => 'test_email',
+                            'page'        => 'kerbcycle-messages',
+                            'status'      => 'success',
+                        ]
+                    );
                 } else {
-                    echo '<div class="notice notice-error"><p><strong>Test Email failed</strong> (check site mail configuration).</p></div>';
+                    Notices::add(
+                        'error',
+                        '<strong>Test Email failed</strong> (check site mail configuration).',
+                        [
+                            'log_type' => 'test_email',
+                            'page'     => 'kerbcycle-messages',
+                            'status'   => 'failure',
+                        ]
+                    );
                 }
             }
             $tab = 'test';


### PR DESCRIPTION
## Summary
- add a shared `Kerbcycle\QrCode\Admin\Notices` helper that renders admin notices and records them via the error log repository
- refactor dashboard, message history, and message settings notices to use the helper so all alerts are captured consistently

## Testing
- php -l includes/Admin/Notices.php
- php -l includes/Admin/Pages/DashboardPage.php
- php -l includes/Admin/Pages/MessagesHistoryPage.php
- php -l includes/Services/MessagesService.php

------
https://chatgpt.com/codex/tasks/task_e_68d31df525dc832dad3ef7a81e5c5863