### PR TITLE
Handle success notice types when logging admin notices

### DIFF
--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -170,12 +170,43 @@ class Admin
         }
 
         foreach ($errors as $err) {
+            $notice_type = $err['type'] ?? '';
+
             ErrorLogRepository::log([
                 'type'   => $err['code'] ?? '',
                 'message' => $err['message'] ?? '',
                 'page'   => $page,
-                'status' => ($err['type'] ?? '') === 'updated' ? 'success' : 'failure',
+                'status' => $this->determine_status_from_notice_type($notice_type),
             ]);
         }
+    }
+
+    /**
+     * Map a WordPress notice type to a Kerbcycle log status value.
+     *
+     * WordPress historically uses both "updated" and "success" to represent
+     * successful outcomes, so treat either (and any variant that contains the
+     * keyword) as a success in the log. All other types are treated as
+     * failures by default so they remain prominent in the Errors view.
+     *
+     * @param string $notice_type WordPress notice type (e.g. success, updated, error).
+     * @return string
+     */
+    private function determine_status_from_notice_type($notice_type)
+    {
+        if (!is_string($notice_type)) {
+            return 'failure';
+        }
+
+        $normalized = strtolower(trim($notice_type));
+        $success_keywords = ['success', 'updated'];
+
+        foreach ($success_keywords as $keyword) {
+            if ($normalized === $keyword || strpos($normalized, $keyword) !== false) {
+                return 'success';
+            }
+        }
+
+        return 'failure';
     }
 }

--- a/tests/capture_admin_notices_test.php
+++ b/tests/capture_admin_notices_test.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+// Stub the handful of WordPress functions that Admin::capture_admin_notices uses.
+namespace {
+    if (!function_exists('add_action')) {
+        function add_action($hook, $callback, $priority = 10, $accepted_args = 1)
+        {
+            // No-op stub for testing.
+        }
+    }
+
+    if (!function_exists('get_settings_errors')) {
+        function get_settings_errors()
+        {
+            return $GLOBALS['mock_settings_errors'] ?? [];
+        }
+    }
+
+    if (!function_exists('sanitize_text_field')) {
+        function sanitize_text_field($value)
+        {
+            return is_string($value) ? trim($value) : $value;
+        }
+    }
+
+    if (!function_exists('wp_unslash')) {
+        function wp_unslash($value)
+        {
+            return $value;
+        }
+    }
+}
+
+// Provide a minimal ErrorLogRepository double that records log entries in memory.
+namespace Kerbcycle\QrCode\Data\Repositories {
+    class ErrorLogRepository
+    {
+        public static $logged = [];
+
+        public static function log($args)
+        {
+            self::$logged[] = $args;
+        }
+
+        public static function reset()
+        {
+            self::$logged = [];
+        }
+    }
+}
+
+namespace {
+    require_once __DIR__ . '/../includes/Admin/Admin.php';
+
+    use Kerbcycle\QrCode\Admin\Admin;
+    use Kerbcycle\QrCode\Data\Repositories\ErrorLogRepository;
+
+    function assert_equals($expected, $actual, $message)
+    {
+        if ($expected !== $actual) {
+            throw new \RuntimeException(
+                sprintf("Assertion failed: %s. Expected %s but got %s", $message, var_export($expected, true), var_export($actual, true))
+            );
+        }
+    }
+
+    $admin_reflection = new \ReflectionClass(Admin::class);
+    /** @var Admin $admin */
+    $admin = $admin_reflection->newInstanceWithoutConstructor();
+
+    $_GET['page'] = 'kerbcycle-qr-settings';
+
+    // Success notices should be logged as success regardless of whether WordPress
+    // uses "success" or the legacy "updated" type.
+    $scenarios = [
+        ['type' => 'success', 'expected_status' => 'success'],
+        ['type' => 'updated', 'expected_status' => 'success'],
+        ['type' => 'notice-success', 'expected_status' => 'success'],
+        ['type' => 'error', 'expected_status' => 'failure'],
+    ];
+
+    foreach ($scenarios as $scenario) {
+        ErrorLogRepository::reset();
+        $GLOBALS['mock_settings_errors'] = [
+            [
+                'code'    => 'settings_updated',
+                'message' => 'Settings saved',
+                'type'    => $scenario['type'],
+            ],
+        ];
+
+        $admin->capture_admin_notices();
+
+        assert_equals(1, count(ErrorLogRepository::$logged), 'One log entry should be recorded');
+        $log = ErrorLogRepository::$logged[0];
+        assert_equals('settings_updated', $log['type'], 'Log type should match the settings notice code');
+        assert_equals($scenario['expected_status'], $log['status'], 'Log status should reflect the notice type');
+    }
+
+    echo "capture_admin_notices tests passed\n";
+}


### PR DESCRIPTION
## Summary
- treat WordPress `success` notices (including legacy `updated`) as successful when logging captured admin notices
- add a lightweight test harness covering `capture_admin_notices` to ensure success notices record a success status

## Testing
- php tests/capture_admin_notices_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d325174170832da3a59bc40aadc198