### PR TITLE
Display settings success notice

### DIFF
--- a/includes/Admin/Pages/SettingsPage.php
+++ b/includes/Admin/Pages/SettingsPage.php
@@ -35,6 +35,7 @@ class SettingsPage
         ?>
         <div class="wrap">
             <h1><?php esc_html_e('KerbCycle QR Settings', 'kerbcycle'); ?></h1>
+            <?php settings_errors('kerbcycle_qr_settings'); ?>
             <form method="post" action="options.php">
                 <?php
                 settings_fields('kerbcycle_qr_settings');


### PR DESCRIPTION
## Summary
- show WordPress settings notices on the KerbCycle QR settings page so successful saves display a banner

## Testing
- php tests/capture_admin_notices_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d46e3493d4832da903a7a58bb8cbb3