### PR TITLE
Display settings errors on settings page

### DIFF
--- a/includes/Admin/Pages/SettingsPage.php
+++ b/includes/Admin/Pages/SettingsPage.php
@@ -35,6 +35,7 @@ class SettingsPage
         ?>
         <div class="wrap">
             <h1><?php esc_html_e('KerbCycle QR Settings', 'kerbcycle'); ?></h1>
+            <?php settings_errors('kerbcycle_qr_settings'); ?>
             <form method="post" action="options.php">
                 <?php
                 settings_fields('kerbcycle_qr_settings');


### PR DESCRIPTION
## Summary
- display stored settings notices on the settings page by invoking `settings_errors`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5b2524ba0832dbdb57676cba3a6a0