### PR TITLE
Ensure OSRM map waits for Leaflet before init

### DIFF
--- a/assets/js/kc-osrm.js
+++ b/assets/js/kc-osrm.js
@@ -3,9 +3,68 @@
         window.KC_OSRM = {};
     }
 
+    var callbacks = [];
+    var isReady = false;
+    var pollTimer = null;
+
+    function flushCallbacks() {
+        var callback;
+
+        while ((callback = callbacks.shift())) {
+            try {
+                callback(window.KC_OSRM);
+            } catch (error) {
+                if (window.console && typeof window.console.error === 'function') {
+                    window.console.error('KC_OSRM.ready callback failed', error);
+                }
+            }
+        }
+    }
+
+    function checkReady() {
+        if (isReady) {
+            return;
+        }
+
+        if (window.L && window.L.Routing) {
+            isReady = true;
+
+            if (pollTimer) {
+                window.clearInterval(pollTimer);
+                pollTimer = null;
+            }
+
+            flushCallbacks();
+        }
+    }
+
+    function ensurePolling() {
+        if (isReady || pollTimer) {
+            checkReady();
+            return;
+        }
+
+        pollTimer = window.setInterval(checkReady, 50);
+        checkReady();
+    }
+
     window.KC_OSRM.ready = function (callback) {
-        if (typeof callback === 'function') {
-            callback(window.KC_OSRM);
+        if (typeof callback !== 'function') {
+            return;
+        }
+
+        callbacks.push(callback);
+
+        if (isReady) {
+            flushCallbacks();
+        } else {
+            ensurePolling();
         }
     };
+
+    if (document.readyState === 'complete') {
+        ensurePolling();
+    } else {
+        window.addEventListener('load', ensurePolling);
+    }
 })(window);

--- a/includes/Admin/Pages/RoutingPage.php
+++ b/includes/Admin/Pages/RoutingPage.php
@@ -432,10 +432,7 @@ class RoutingPage
         ?>
         <div id="<?php echo esc_attr($element_id); ?>" style="height:<?php echo esc_attr($atts['height']); ?>;"></div>
         <script>
-        (function(){
-            if (!window.L || !window.L.Routing || !window.KC_OSRM) {
-                return;
-            }
+        KC_OSRM.ready(function(){
             var map = L.map('<?php echo esc_js($element_id); ?>').setView([
                 <?php echo esc_js($atts['start']); ?>
             ].reverse(), <?php echo (int) $atts['zoom']; ?>);
@@ -446,7 +443,7 @@ class RoutingPage
                 waypoints: [wp1, wp2],
                 router: L.Routing.osrmv1({ serviceUrl: KC_OSRM.endpoint.replace(/\/route\/v1\/.*$/, '/route/v1') })
             }).addTo(map);
-        })();
+        });
         </script>
         <?php
         return ob_get_clean();


### PR DESCRIPTION
## Summary
- update KC_OSRM.ready to queue callbacks until Leaflet and the routing plug-in are available
- wrap the map shortcode initialisation in KC_OSRM.ready so it runs after deferred assets load

## Testing
- php -l includes/Admin/Pages/RoutingPage.php

------
https://chatgpt.com/codex/tasks/task_e_68d5c7b388f4832d985e93eb772b5a97