### PR TITLE
Make routing control collapsible by default

### DIFF
--- a/assets/js/kc-osrm.js
+++ b/assets/js/kc-osrm.js
@@ -477,6 +477,7 @@
         draggableWaypoints: true,
         routeWhileDragging: true,
         showAlternatives: false,
+        collapsible: true,
       })
         .on("routingstart", function () {
           setStatus("Routing…", "");
@@ -485,6 +486,12 @@
           setStatus("", "");
         })
         .addTo(map);
+
+      setTimeout(function () {
+        if (routingControl && routingControl._container) {
+          routingControl._container.classList.add("leaflet-routing-collapsed");
+        }
+      }, 0);
 
       registerEvents();
 


### PR DESCRIPTION
## Summary
- enable the Leaflet Routing Machine control to render with the collapsible toggle
- collapse the routing panel by default once the control container is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d85a4dca8c832d88b02ce452f4fc0a