### PR TITLE
Align OSRM toolbar buttons with WordPress styling

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -40,6 +40,13 @@
   padding-bottom: 0;
 }
 
+.kc-osrm-toolbar .button {
+  font-size: 14px;
+  line-height: 1.2;
+  padding: 0.35rem 0.75rem;
+  border-radius: 4px;
+}
+
 .kc-combobox-list {
   position: absolute;
   z-index: 10000;

--- a/assets/js/kc-osrm.js
+++ b/assets/js/kc-osrm.js
@@ -54,26 +54,12 @@
     toolbar.style.alignItems = "center";
     toolbar.style.marginBottom = "0.5rem";
 
-    var buttonStyle = {
-      padding: "0.35rem 0.75rem",
-      border: "1px solid #ccc",
-      background: "#f8f8f8",
-      borderRadius: "4px",
-      cursor: "pointer",
-      font: "14px/1.2 system-ui, Arial, sans-serif",
-    };
-
-    function makeButton(label) {
+    function makeButton(label, priority) {
       var btn = document.createElement("button");
       btn.type = "button";
       btn.textContent = label;
-      Object.assign(btn.style, buttonStyle);
-      btn.addEventListener("focus", function () {
-        btn.style.outline = "2px solid #2684ff";
-      });
-      btn.addEventListener("blur", function () {
-        btn.style.outline = "";
-      });
+      btn.className =
+        "button " + (priority === "primary" ? "button-primary" : "button-secondary");
       return btn;
     }
 
@@ -95,7 +81,7 @@
 
     var addStopBtn = makeButton("Add stop");
     var pasteBtn = makeButton("Paste list");
-    var optimizeBtn = makeButton("Optimize");
+    var optimizeBtn = makeButton("Optimize", "primary");
     var roundtripToggle = makeToggle("Roundtrip", true);
     var fixStartToggle = makeToggle("Fix start", true);
     var fixEndToggle = makeToggle("Fix finish", true);


### PR DESCRIPTION
## Summary
- swap the OSRM toolbar buttons to use WordPress button classes so they inherit the active theme palette
- add neutral spacing and typography rules for toolbar buttons in public CSS to retain the intended layout

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dadb43beb4832da736670f49619d3d