### PR TITLE
Add reset default option and adjust roundtrip toggle

### DIFF
--- a/assets/js/kc-osrm.js
+++ b/assets/js/kc-osrm.js
@@ -120,10 +120,11 @@
     var addStopBtn = makeButton("Add stop");
     var pasteBtn = makeButton("Paste list");
     var optimizeBtn = makeButton("Optimize", "primary");
-    var roundtripToggle = makeToggle("Roundtrip", true);
+    var roundtripToggle = makeToggle("Roundtrip", false);
     var fixStartToggle = makeToggle("Fix start", true);
     var fixEndToggle = makeToggle("Fix finish", true);
     var saveDefaultBtn = makeButton("Set current as default Start");
+    var resetDefaultBtn = makeButton("Reset defaults");
     var clearBtn = makeButton("Clear");
     var exportBtn = makeButton("Export");
     // Follow / unfollow button
@@ -138,6 +139,7 @@
     toolbar.appendChild(fixStartToggle.label);
     toolbar.appendChild(fixEndToggle.label);
     toolbar.appendChild(saveDefaultBtn);
+    toolbar.appendChild(resetDefaultBtn);
     toolbar.appendChild(clearBtn);
     toolbar.appendChild(exportBtn);
     toolbar.appendChild(followBtn);
@@ -1040,6 +1042,25 @@
         }
         if (saved) {
           setStatus("Saved default start for this browser.", "success");
+        } else {
+          setStatus("Unable to access browser storage.", "error");
+        }
+      });
+      resetDefaultBtn.addEventListener("click", function () {
+        var cleared = false;
+        try {
+          if (typeof window !== "undefined" && window.localStorage) {
+            window.localStorage.removeItem("kc_default_start");
+            cleared = true;
+          }
+        } catch (error) {
+          console.warn("Unable to clear default start", error);
+        }
+        if (cleared) {
+          setStatus(
+            "Per-user default cleared. Reload to use shortcode/site default.",
+            ""
+          );
         } else {
           setStatus("Unable to access browser storage.", "error");
         }


### PR DESCRIPTION
## Summary
- add a reset defaults button that clears the stored per-user start and reports the status
- default the roundtrip toggle to off for one-way routing workflows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e03e095ef4832dad19c0bd7739e33d