### PR TITLE
Improve OSRM itinerary initial state on mobile

### DIFF
--- a/assets/js/kc-osrm.js
+++ b/assets/js/kc-osrm.js
@@ -1483,9 +1483,11 @@
       })
         .on("routingstart", function () {
           setStatus("Routing…", "");
+          clearItinerary();
         })
         .on("routesfound", function (e) {
           setStatus("", "");
+          clearItinerary();
           if (e && e.routes && e.routes[0]) {
             buildSteps(e.routes[0]);
             if (posMarker && typeof posMarker.getLatLng === "function") {
@@ -1493,14 +1495,96 @@
               onPosition(current.lat, current.lng);
             }
           }
+          if (isMobile) {
+            collapseItinerary();
+          }
         })
         .addTo(map);
 
-      setTimeout(function () {
-        if (routingControl && routingControl._container) {
-          routingControl._container.classList.add("leaflet-routing-collapsed");
+      function collapseItinerary() {
+        var container = routingControl && routingControl._container;
+        if (!container) {
+          return;
         }
-      }, 0);
+        container.classList.add("leaflet-routing-collapsed");
+        container.classList.add("leaflet-routing-container-hide");
+      }
+
+      function clearItinerary() {
+        var container = routingControl && routingControl._container;
+        if (!container) {
+          return;
+        }
+
+        var altWrap = container.querySelector(
+          ".leaflet-routing-alternatives-container"
+        );
+        if (altWrap) {
+          altWrap.innerHTML = "";
+        }
+
+        var altNodes = container.querySelectorAll(".leaflet-routing-alt");
+        Array.prototype.forEach.call(altNodes, function (node) {
+          node.innerHTML = "";
+        });
+
+        var summary = container.querySelector(".leaflet-routing-summary");
+        if (summary) {
+          summary.innerHTML = "";
+        }
+
+        var errors = container.querySelector(".leaflet-routing-error");
+        if (errors) {
+          errors.innerHTML = "";
+        }
+
+        var customHost = document.querySelector(
+          ".kc-steps, #kc-steps, .kc-steps-list"
+        );
+        if (customHost) {
+          customHost.innerHTML = "";
+        }
+      }
+
+      var isMobile = false;
+      if (typeof window !== "undefined" && window.matchMedia) {
+        isMobile = window.matchMedia("(max-width: 768px)").matches;
+      }
+
+      clearItinerary();
+
+      if (typeof requestAnimationFrame === "function") {
+        requestAnimationFrame(clearItinerary);
+      } else {
+        setTimeout(clearItinerary, 0);
+      }
+
+      (function ensureClearedForAMoment() {
+        if (typeof window === "undefined" || !window.MutationObserver) {
+          return;
+        }
+        var container = routingControl && routingControl._container;
+        if (!container) {
+          return;
+        }
+        var observer = new MutationObserver(function () {
+          clearItinerary();
+        });
+        observer.observe(container, { childList: true, subtree: true });
+        setTimeout(function () {
+          try {
+            observer.disconnect();
+          } catch (error) {}
+        }, 1000);
+      })();
+
+      if (isMobile) {
+        if (typeof requestAnimationFrame === "function") {
+          requestAnimationFrame(collapseItinerary);
+        } else {
+          setTimeout(collapseItinerary, 0);
+        }
+      }
 
       registerEvents();
 


### PR DESCRIPTION
## Summary
- broaden itinerary clearing so all Leaflet Routing Machine panels and custom step hosts reset before rebuilding steps
- collapse the itinerary panel by default on mobile and keep it minimized after routing events
- guard the initial render with requestAnimationFrame and a short-lived mutation observer to ensure the itinerary remains empty while loading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15d3cb9dc832db0847d963abfc339