### PR TITLE
Add admin-only KerbCycle AI REST endpoint skeleton

### DIFF
--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -17,9 +17,10 @@ if (!defined('KERBCYCLE_QR_URL')) {
 }
 
 // Main plugin class
-class KerbCycle_QR_Manager {
-
-    public function __construct() {
+class KerbCycle_QR_Manager
+{
+    public function __construct()
+    {
         // Admin hooks
         add_action('admin_menu', array($this, 'register_admin_menu'));
         add_action('admin_enqueue_scripts', array($this, 'enqueue_admin_scripts'));
@@ -37,7 +38,8 @@ class KerbCycle_QR_Manager {
     }
 
     // Plugin activation
-    public static function activate() {
+    public static function activate()
+    {
         global $wpdb;
         $table = $wpdb->prefix . 'kerbcycle_qr_codes';
         $charset = $wpdb->get_charset_collate();
@@ -57,12 +59,14 @@ class KerbCycle_QR_Manager {
     }
 
     // Plugin deactivation
-    public static function deactivate() {
+    public static function deactivate()
+    {
         // Optional cleanup
     }
 
     // Register admin menu
-    public function register_admin_menu() {
+    public function register_admin_menu()
+    {
         add_menu_page(
             'QR Code Manager',
             'QR Codes',
@@ -84,7 +88,8 @@ class KerbCycle_QR_Manager {
     }
 
     // Enqueue admin scripts
-    public function enqueue_admin_scripts($hook) {
+    public function enqueue_admin_scripts($hook)
+    {
         if (!in_array($hook, ['toplevel_page_kerbcycle-qr-manager', 'kerbcycle-qr-manager_page_kerbcycle-qr-history'])) {
             return;
         }
@@ -105,7 +110,8 @@ class KerbCycle_QR_Manager {
     }
 
     // Admin dashboard page
-    public function admin_page() {
+    public function admin_page()
+    {
         ?>
         <div class="wrap">
             <h1>KerbCycle QR Code Manager</h1>
@@ -123,7 +129,8 @@ class KerbCycle_QR_Manager {
     }
 
     // QR code history page
-    public function history_page() {
+    public function history_page()
+    {
         global $wpdb;
         $table_name = $wpdb->prefix . 'kerbcycle_qr_codes';
 
@@ -165,7 +172,8 @@ class KerbCycle_QR_Manager {
     }
 
     // Shortcode to render scanner on any page
-    public function generate_frontend_scanner() {
+    public function generate_frontend_scanner()
+    {
         ob_start();
         ?>
         <div class="kerbcycle-qr-scanner-container">
@@ -181,7 +189,8 @@ class KerbCycle_QR_Manager {
     }
 
     // Enqueue frontend scripts only when shortcode is used
-    public function enqueue_frontend_scripts() {
+    public function enqueue_frontend_scripts()
+    {
         global $post;
 
         if (is_a($post, 'WP_Post') && has_shortcode($post->post_content, 'kerbcycle_scanner')) {
@@ -202,7 +211,8 @@ class KerbCycle_QR_Manager {
     }
 
     // AJAX: Assign QR code
-    public function assign_qr_code() {
+    public function assign_qr_code()
+    {
         check_ajax_referer('kerbcycle_qr_nonce', 'security');
 
         global $wpdb;
@@ -235,7 +245,8 @@ class KerbCycle_QR_Manager {
     }
 
     // AJAX: Release QR code
-    public function release_qr_code() {
+    public function release_qr_code()
+    {
         check_ajax_referer('kerbcycle_qr_nonce', 'security');
 
         global $wpdb;
@@ -262,7 +273,8 @@ class KerbCycle_QR_Manager {
     }
 
     // REST API: Handle QR code scan
-    public function register_rest_endpoints() {
+    public function register_rest_endpoints()
+    {
         register_rest_route('qrmgmt2/v1', '/qr-code/scanned', array(
             'methods' => 'POST',
             'callback' => array($this, 'handle_qr_code_scan'),
@@ -276,7 +288,8 @@ class KerbCycle_QR_Manager {
         ));
     }
 
-    public function check_ai_permissions(WP_REST_Request $request) {
+    public function check_ai_permissions(WP_REST_Request $request)
+    {
         if (!current_user_can('manage_options')) {
             return new WP_Error('kerbcycle_ai_forbidden', 'Sorry, you are not allowed to access this endpoint.', array('status' => 403));
         }
@@ -293,7 +306,8 @@ class KerbCycle_QR_Manager {
         return true;
     }
 
-    public function handle_ai_dispatch(WP_REST_Request $request) {
+    public function handle_ai_dispatch(WP_REST_Request $request)
+    {
         $action = sanitize_text_field($request->get_param('action'));
         $allowed_actions = array('pickup_summary', 'qr_exceptions', 'draft_template');
 
@@ -328,7 +342,8 @@ class KerbCycle_QR_Manager {
         ), 200);
     }
 
-    public function handle_qr_code_scan(WP_REST_Request $request) {
+    public function handle_qr_code_scan(WP_REST_Request $request)
+    {
         $qr_code = sanitize_text_field($request->get_param('qr_code'));
         $user_id = intval($request->get_param('user_id'));
 
@@ -356,7 +371,8 @@ class KerbCycle_QR_Manager {
     }
 
     // Helper: Send email notification
-    private function send_notification_email($user_id, $qr_code) {
+    private function send_notification_email($user_id, $qr_code)
+    {
         $admin_email = get_option('admin_email');
         $subject = 'QR Code Assignment Notification';
         $message = sprintf(

--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -268,6 +268,64 @@ class KerbCycle_QR_Manager {
             'callback' => array($this, 'handle_qr_code_scan'),
             'permission_callback' => '__return_true'
         ));
+
+        register_rest_route('kerbcycle/v1', '/ai', array(
+            'methods' => 'POST',
+            'callback' => array($this, 'handle_ai_dispatch'),
+            'permission_callback' => array($this, 'check_ai_permissions')
+        ));
+    }
+
+    public function check_ai_permissions(WP_REST_Request $request) {
+        if (!current_user_can('manage_options')) {
+            return new WP_Error('kerbcycle_ai_forbidden', 'Sorry, you are not allowed to access this endpoint.', array('status' => 403));
+        }
+
+        $nonce = $request->get_header('x_wp_nonce');
+        if (empty($nonce)) {
+            $nonce = $request->get_param('_wpnonce');
+        }
+
+        if (empty($nonce) || !wp_verify_nonce($nonce, 'wp_rest')) {
+            return new WP_Error('kerbcycle_ai_invalid_nonce', 'Invalid REST nonce.', array('status' => 403));
+        }
+
+        return true;
+    }
+
+    public function handle_ai_dispatch(WP_REST_Request $request) {
+        $action = sanitize_text_field($request->get_param('action'));
+        $allowed_actions = array('pickup_summary', 'qr_exceptions', 'draft_template');
+
+        if (empty($action)) {
+            return new WP_Error('kerbcycle_ai_missing_action', 'Missing required action parameter.', array('status' => 400));
+        }
+
+        if (!in_array($action, $allowed_actions, true)) {
+            return new WP_Error('kerbcycle_ai_invalid_action', 'Invalid action value.', array('status' => 400));
+        }
+
+        $mock_data = array(
+            'pickup_summary' => array(
+                'action' => 'pickup_summary',
+                'summary' => 'Mock pickup summary response.'
+            ),
+            'qr_exceptions' => array(
+                'action' => 'qr_exceptions',
+                'exceptions' => array(
+                    array('code' => 'QR-001', 'reason' => 'Mock exception item')
+                )
+            ),
+            'draft_template' => array(
+                'action' => 'draft_template',
+                'template' => 'Mock draft template response.'
+            )
+        );
+
+        return new WP_REST_Response(array(
+            'success' => true,
+            'data' => $mock_data[$action]
+        ), 200);
     }
 
     public function handle_qr_code_scan(WP_REST_Request $request) {


### PR DESCRIPTION
### Motivation
- Add an initial, admin-only KerbCycle AI endpoint under the plugin's existing REST registration flow to prepare for future Option B AI features while keeping changes minimal.  
- The existing main plugin file was the best surgical target because it already bootstraps REST routes via `rest_api_init` so no new files or directories were required.

### Description
- Registered a new POST route `kerbcycle/v1/ai` in `kerbcycle-qr-code-manager.php` using the plugin's existing `register_rest_endpoints()` method.  
- Implemented `check_ai_permissions()` which requires `current_user_can('manage_options')` and validates a WP REST nonce via the `X-WP-Nonce` header or `_wpnonce` param using `wp_verify_nonce(..., 'wp_rest')`.  
- Added `handle_ai_dispatch()` that only accepts the allowed `action` values `pickup_summary`, `qr_exceptions`, and `draft_template`, returns mock JSON payloads for each action, and returns clean `WP_Error` responses for missing or invalid actions.  
- Kept changes surgical in a single file; no DB queries, no external API calls, no new directories, and followed existing plugin bootstrapping conventions.

### Testing
- Ran PHP lint on the modified file with `php -l kerbcycle-qr-code-manager.php` which reported no syntax errors.  
- Confirmed the patch applied and committed successfully (git commit completed) as part of the automated edit workflow.

Files changed: `kerbcycle-qr-code-manager.php` only.  
What was added: admin-only REST route `kerbcycle/v1/ai`, permission checks, action dispatcher for the three allowed actions, mock responses, and error handling.  
Assumptions: admin access is represented by `manage_options` and REST clients will provide the WP nonce via `X-WP-Nonce` or `_wpnonce`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af37ede428832d8f9a3b04a45a81a5)