### PR TITLE
Add admin-only Option B AI REST endpoint skeleton

### DIFF
--- a/includes/Api/Controllers/AiController.php
+++ b/includes/Api/Controllers/AiController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Kerbcycle\QrCode\Api\Controllers;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Option B AI endpoint controller.
+ *
+ * @since      1.0.0
+ * @package    Kerbcycle\QrCode
+ * @subpackage Kerbcycle\QrCode\Api\Controllers
+ */
+class AiController
+{
+    /**
+     * Validate endpoint permissions for admin-only access.
+     *
+     * @param WP_REST_Request $request The request object.
+     *
+     * @return true|\WP_Error
+     */
+    public function permissions(WP_REST_Request $request)
+    {
+        if (!current_user_can('manage_options')) {
+            return new \WP_Error('rest_forbidden', __('Unauthorized', 'kerbcycle'), ['status' => 403]);
+        }
+
+        $nonce = sanitize_text_field($request->get_header('X-WP-Nonce'));
+        if (!wp_verify_nonce($nonce, 'wp_rest')) {
+            return new \WP_Error('rest_nonce_invalid', __('Security check failed', 'kerbcycle'), ['status' => 403]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Dispatch Option B AI actions.
+     *
+     * @param WP_REST_Request $request The request object.
+     *
+     * @return WP_REST_Response|\WP_Error
+     */
+    public function dispatch_action(WP_REST_Request $request)
+    {
+        $action = sanitize_key($request->get_param('action'));
+
+        if (empty($action)) {
+            return new \WP_Error('kerbcycle_ai_action_missing', __('Missing action parameter.', 'kerbcycle'), ['status' => 400]);
+        }
+
+        switch ($action) {
+            case 'pickup_summary':
+                return new WP_REST_Response([
+                    'success' => true,
+                    'action'  => $action,
+                    'data'    => [
+                        'summary' => __('Mock pickup summary response.', 'kerbcycle'),
+                    ],
+                ], 200);
+            case 'qr_exceptions':
+                return new WP_REST_Response([
+                    'success' => true,
+                    'action'  => $action,
+                    'data'    => [
+                        'exceptions' => [],
+                        'message'    => __('Mock QR exceptions response.', 'kerbcycle'),
+                    ],
+                ], 200);
+            case 'draft_template':
+                return new WP_REST_Response([
+                    'success'  => true,
+                    'action'   => $action,
+                    'data'     => [
+                        'template' => __('Mock draft template response.', 'kerbcycle'),
+                    ],
+                ], 200);
+            default:
+                return new \WP_Error('kerbcycle_ai_action_invalid', __('Invalid action parameter.', 'kerbcycle'), ['status' => 400]);
+        }
+    }
+}

--- a/includes/Api/RestService.php
+++ b/includes/Api/RestService.php
@@ -32,6 +32,8 @@ class RestService
      */
     public function register_routes()
     {
+        $ai_controller = new Controllers\AiController();
+
         register_rest_route('kerbcycle/v1', '/qr-code/scanned', [
             'methods'  => 'POST',
             'callback' => [new Controllers\QrController(), 'handle_qr_code_scan'],
@@ -46,6 +48,12 @@ class RestService
             'permission_callback' => function () {
                 return is_user_logged_in();
             },
+        ]);
+
+        register_rest_route('kerbcycle/v1', '/ai', [
+            'methods'  => 'POST',
+            'callback' => [$ai_controller, 'dispatch_action'],
+            'permission_callback' => [$ai_controller, 'permissions'],
         ]);
     }
 }


### PR DESCRIPTION
### Motivation
- `includes/Api/RestService.php` is the existing central place for registering plugin REST routes, so it was the correct minimal touchpoint to expose the new Option B AI endpoint.
- Provide an admin-only skeleton endpoint for future AI actions (`pickup_summary`, `qr_exceptions`, `draft_template`) without wiring to external providers or changing existing plugin conventions.

### Description
- Added `includes/Api/Controllers/AiController.php` implementing an admin-only permission callback and an action dispatcher that accepts `action` and returns mock JSON responses.
- Registered a new `POST /kerbcycle/v1/ai` route in `includes/Api/RestService.php` wired to the controller's `dispatch_action` and `permissions` methods.
- Permission checks use `current_user_can('manage_options')` and WP REST nonce verification via the `X-WP-Nonce` header against the `wp_rest` action.
- Dispatcher only allows `pickup_summary`, `qr_exceptions`, and `draft_template`, and returns `WP_Error` responses for missing or invalid `action` values.

### Testing
- Ran `php -l includes/Api/Controllers/AiController.php` and `php -l includes/Api/RestService.php` and both reported no syntax errors.
- Verified the route registration change via repository diff and committed the changes; no integration tests were run against a running WP instance in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af468f0f98832daba00c15c4443e93)