### PR TITLE
Add minimal AI Assistant panel to Dashboard and wire Option B AI REST endpoint

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -222,3 +222,17 @@
   gap: 20px;
   margin: 10px 0;
 }
+
+
+#kerbcycle-ai-panel {
+  margin: 16px 0;
+  max-width: 900px;
+}
+
+#kerbcycle-ai-panel .inside {
+  padding-top: 12px;
+}
+
+#kerbcycle-ai-result ul {
+  margin: 8px 0 0 18px;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -624,6 +624,137 @@ function initKerbcycleAdmin() {
   });
   updateSortIndicators();
 
+  const aiFromDate = document.getElementById("kerbcycle-ai-from-date");
+  const aiQrExceptionsBtn = document.getElementById(
+    "kerbcycle-ai-qr-exceptions-btn",
+  );
+  const aiDraftTemplateBtn = document.getElementById(
+    "kerbcycle-ai-draft-template-btn",
+  );
+  const aiStatus = document.getElementById("kerbcycle-ai-status");
+  const aiResult = document.getElementById("kerbcycle-ai-result");
+
+  function renderAiList(items) {
+    if (!Array.isArray(items) || !items.length) {
+      return "";
+    }
+    const lis = items
+      .slice(0, 5)
+      .map((item) => `<li>${escapeHtml(String(item))}</li>`)
+      .join("");
+    return `<ul>${lis}</ul>`;
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll("\"", "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function setAiResult(html, statusClass = "notice-info") {
+    if (!aiResult) {
+      return;
+    }
+    aiResult.className = `notice inline ${statusClass}`;
+    aiResult.innerHTML = html;
+    aiResult.style.display = "block";
+  }
+
+  function callAiAction(action) {
+    if (!kerbcycle_ajax.rest_url || !kerbcycle_ajax.rest_nonce) {
+      setAiResult("<p>AI endpoint is not configured in admin assets.</p>", "notice-error");
+      return;
+    }
+
+    const fromDate = aiFromDate ? aiFromDate.value : "";
+    const body = { action };
+    if (fromDate) {
+      body.from_date = fromDate;
+      body.to_date = new Date().toISOString().slice(0, 10);
+    }
+
+    if (aiStatus) {
+      aiStatus.textContent = "Loading AI response...";
+    }
+
+    setAiResult("<p>Loading...</p>", "notice-info");
+
+    return fetch(kerbcycle_ajax.rest_url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-WP-Nonce": kerbcycle_ajax.rest_nonce,
+      },
+      body: JSON.stringify(body),
+    })
+      .then((res) => res.json().then((data) => ({ ok: res.ok, data })))
+      .then(({ ok, data }) => {
+        if (!ok || !data || data.success !== true) {
+          const message =
+            (data && data.message) ||
+            (data && data.code) ||
+            "Unable to load AI response.";
+          throw new Error(message);
+        }
+
+        if (action === "qr_exceptions") {
+          const aiData = data.data || {};
+          const priorities = Array.isArray(aiData.priority_exceptions)
+            ? aiData.priority_exceptions
+                .slice(0, 5)
+                .map(
+                  (item) =>
+                    `${item.type || "Issue"}: ${item.count || 0} (${item.reason || "No reason provided"})`,
+                )
+            : [];
+          const totalExceptions = Array.isArray(data.source?.groups)
+            ? data.source.groups.reduce((sum, group) => sum + (group.count || 0), 0)
+            : 0;
+
+          setAiResult(
+            `<p><strong>Summary:</strong> ${escapeHtml(aiData.overview || "No summary returned.")}</p>` +
+              `<p><strong>Total exceptions scanned:</strong> ${escapeHtml(totalExceptions)}</p>` +
+              `<p><strong>Top issues:</strong></p>${renderAiList(priorities)}`,
+            "notice-success",
+          );
+        } else {
+          const aiData = data.data || {};
+          setAiResult(
+            `<p><strong>Title:</strong> ${escapeHtml(aiData.title || "Untitled")}</p>` +
+              `<p><strong>Audience:</strong> ${escapeHtml(aiData.audience || "General")}</p>` +
+              `<p><strong>Draft:</strong> ${escapeHtml(aiData.message || "No draft returned.")}</p>`,
+            "notice-success",
+          );
+        }
+
+        if (aiStatus) {
+          aiStatus.textContent = "AI response loaded.";
+        }
+      })
+      .catch((error) => {
+        console.error("AI request failed:", error);
+        setAiResult(`<p>${escapeHtml(error.message || "AI request failed.")}</p>`, "notice-error");
+        if (aiStatus) {
+          aiStatus.textContent = "AI request failed.";
+        }
+      });
+  }
+
+  if (aiQrExceptionsBtn) {
+    aiQrExceptionsBtn.addEventListener("click", function () {
+      callAiAction("qr_exceptions");
+    });
+  }
+
+  if (aiDraftTemplateBtn) {
+    aiDraftTemplateBtn.addEventListener("click", function () {
+      callAiAction("draft_template");
+    });
+  }
+
   if (userField && assignedSelect) {
     userField.addEventListener("change", function () {
       const userId = userField.value;

--- a/includes/Admin/Assets/AdminAssets.php
+++ b/includes/Admin/Assets/AdminAssets.php
@@ -86,6 +86,8 @@ class AdminAssets
         wp_localize_script('kerbcycle-qr-admin-js', 'kerbcycle_ajax', [
             'ajax_url'          => admin_url('admin-ajax.php'),
             'nonce'             => wp_create_nonce('kerbcycle_qr_nonce'),
+            'rest_url'          => rest_url('kerbcycle/v1/ai'),
+            'rest_nonce'        => wp_create_nonce('wp_rest'),
             'scanner_enabled'   => $scanner_enabled,
             'drag_drop_disabled' => $drag_drop_disabled,
         ]);

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -109,6 +109,18 @@ class DashboardPage
                     ?>
                 <?php endif; ?>
                 <div id="scan-result" class="updated"></div>
+                <div id="kerbcycle-ai-panel" class="postbox">
+                    <h2 class="hndle"><?php esc_html_e('AI Assistant (Beta)', 'kerbcycle'); ?></h2>
+                    <div class="inside">
+                        <div class="qr-select-group">
+                            <input type="date" id="kerbcycle-ai-from-date" />
+                            <button id="kerbcycle-ai-qr-exceptions-btn" class="button"><?php esc_html_e('AI: QR Exceptions', 'kerbcycle'); ?></button>
+                            <button id="kerbcycle-ai-draft-template-btn" class="button"><?php esc_html_e('AI: Draft Template', 'kerbcycle'); ?></button>
+                        </div>
+                        <p id="kerbcycle-ai-status" class="description" aria-live="polite"></p>
+                        <div id="kerbcycle-ai-result" class="notice inline" style="display:none;"></div>
+                    </div>
+                </div>
                 <h2><?php esc_html_e('Manual QR Code Tasks', 'kerbcycle'); ?></h2>
                 <div id="qr-task-options">
                     <label><input type="checkbox" id="send-email" <?php checked($email_enabled); ?> <?php disabled(!$email_enabled); ?>> <?php esc_html_e('Send notification email', 'kerbcycle'); ?></label>


### PR DESCRIPTION
### Motivation
- Provide a minimal admin-side control so an authorized admin can trigger the Option B AI endpoint and view results in-place without building a new admin UI.
- Keep the change surgical and consistent with existing KerbCycle admin patterns by wiring into the current Dashboard page and existing asset pipeline.

### Description
- Added a small `AI Assistant (Beta)` panel to the existing dashboard view in `includes/Admin/Pages/DashboardPage.php` containing a date input (`#kerbcycle-ai-from-date`), `AI: QR Exceptions` and `AI: Draft Template` buttons, a status line (`#kerbcycle-ai-status`) and an inline result container (`#kerbcycle-ai-result`).
- Localized the AI REST endpoint and nonce in `includes/Admin/Assets/AdminAssets.php` via `wp_localize_script` keys `rest_url` (set to `rest_url('kerbcycle/v1/ai')`) and `rest_nonce` (set to `wp_create_nonce('wp_rest')`) so the existing `kerbcycle-qr-admin-js` can call the REST API.
- Implemented the admin-side JS in `assets/js/admin.js` to: call the AI REST endpoint using `fetch(kerbcycle_ajax.rest_url)` with header `X-WP-Nonce: kerbcycle_ajax.rest_nonce` and JSON body `{ action, from_date?, to_date? }`, show a loading state, render results (summary, counts and top issues for `qr_exceptions`, or title/audience/draft for `draft_template`), and show a clean error state; outputs are escaped with `escapeHtml` for admin-safe rendering.
- Added minimal admin styles in `assets/css/admin.css` to keep the panel visually consistent with existing UI.

### Testing
- Ran `node --check assets/js/admin.js` to validate injected JS syntax; it succeeded.
- Ran `php -l includes/Admin/Pages/DashboardPage.php` and `php -l includes/Admin/Assets/AdminAssets.php` to lint PHP files; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4a02b254832db3e123c5871c7351)