### PR TITLE
Add minimal protected AI endpoint client helper

### DIFF
--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -45,6 +45,88 @@ function kerbcycle_qr_code_manager()
     return \Kerbcycle\QrCode\Plugin::instance();
 }
 
+/**
+ * Call the configured AI endpoint with a protected JSON payload.
+ *
+ * @param string $task
+ * @param array  $data
+ *
+ * @return array<string,mixed>
+ */
+function kc_call_ai_endpoint($task, $data = array())
+{
+    $task = sanitize_text_field($task);
+    $data = is_array($data) ? $data : array();
+
+    if ($task === '') {
+        return array(
+            'success' => false,
+            'message' => __('AI task is required.', 'kerbcycle'),
+            'data'    => null,
+        );
+    }
+
+    $endpoint = defined('KERBCYCLE_AI_ENDPOINT') ? KERBCYCLE_AI_ENDPOINT : get_option('kerbcycle_ai_endpoint', '');
+    $api_key  = defined('KERBCYCLE_AI_API_KEY') ? KERBCYCLE_AI_API_KEY : get_option('kerbcycle_ai_api_key', '');
+
+    $endpoint = is_string($endpoint) ? trim($endpoint) : '';
+    $api_key  = is_string($api_key) ? trim($api_key) : '';
+
+    if ($endpoint === '' || $api_key === '') {
+        return array(
+            'success' => false,
+            'message' => __('AI endpoint is not configured.', 'kerbcycle'),
+            'data'    => null,
+        );
+    }
+
+    $response = wp_remote_post($endpoint, array(
+        'headers' => array(
+            'Content-Type' => 'application/json',
+            'x-api-key'    => $api_key,
+        ),
+        'body'    => wp_json_encode(array(
+            'task' => $task,
+            'data' => $data,
+        )),
+        'timeout' => 20,
+    ));
+
+    if (is_wp_error($response)) {
+        return array(
+            'success' => false,
+            'message' => $response->get_error_message(),
+            'data'    => null,
+        );
+    }
+
+    $status_code = (int) wp_remote_retrieve_response_code($response);
+    $raw_body    = wp_remote_retrieve_body($response);
+
+    if ($status_code !== 200) {
+        return array(
+            'success' => false,
+            'message' => sprintf(__('AI endpoint returned HTTP %d.', 'kerbcycle'), $status_code),
+            'data'    => $raw_body,
+        );
+    }
+
+    $json = json_decode($raw_body, true);
+    if (!is_array($json)) {
+        return array(
+            'success' => false,
+            'message' => __('AI endpoint returned invalid JSON.', 'kerbcycle'),
+            'data'    => $raw_body,
+        );
+    }
+
+    return array(
+        'success' => true,
+        'message' => '',
+        'data'    => $json,
+    );
+}
+
 // Run the plugin
 kerbcycle_qr_code_manager();
 


### PR DESCRIPTION
### Motivation
- Add a small, surgical helper to let the plugin call the external Render AI endpoint with a protected JSON POST without changing existing services or UI, and place it where it will always be available (`kerbcycle-qr-code-manager.php`).

### Description
- Added `kc_call_ai_endpoint($task, $data = array())` in `kerbcycle-qr-code-manager.php` that sanitizes `task` with `sanitize_text_field`, builds the payload `{'task':..., 'data':...}`, and sends it using `wp_remote_post` with `wp_json_encode`, `Content-Type: application/json`, and `x-api-key` headers. 
- The function reads configuration from constants first and falls back to options: `KERBCYCLE_AI_ENDPOINT` / `kerbcycle_ai_endpoint` and `KERBCYCLE_AI_API_KEY` / `kerbcycle_ai_api_key`, decodes the JSON response with `json_decode`, and returns the structured array shape required for success and failure cases. 
- Error handling covers `WP_Error` network failures, non-200 HTTP responses, missing config or task, and invalid JSON, and returns the specified structured failure arrays rather than fatalling. 
- Patch summary: files changed `kerbcycle-qr-code-manager.php`; endpoint config points used `KERBCYCLE_AI_ENDPOINT` / `kerbcycle_ai_endpoint` and `KERBCYCLE_AI_API_KEY` / `kerbcycle_ai_api_key`; added error handling for network/API, HTTP status, and JSON parse failures.

### Testing
- Ran `php -l kerbcycle-qr-code-manager.php` to validate syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b075ab6b58832d9606af245bd86c4c)