### PR TITLE
Add minimal Tools page for KerbCycle AI endpoint testing

### DIFF
--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -35,6 +35,14 @@ class Admin
      */
     public function register_admin_menu()
     {
+        add_management_page(
+            'KerbCycle AI Test',
+            'KerbCycle AI Test',
+            'manage_options',
+            'kerbcycle-ai-test',
+            [$this, 'render_ai_test_page']
+        );
+
         add_menu_page(
             'QR Code Manager',
             'QR Codes',
@@ -161,6 +169,56 @@ class Admin
             'kerbcycle-plugin-integrations',
             [new Pages\IntegrationsPage(), 'render']
         );
+    }
+
+    /**
+     * Render a minimal Tools page to test the AI endpoint.
+     */
+    public function render_ai_test_page()
+    {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        $customer_name = '';
+        $result        = null;
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            check_admin_referer('kerbcycle_ai_test_action', 'kerbcycle_ai_test_nonce');
+
+            $customer_name = isset($_POST['customer_name']) ? sanitize_text_field(wp_unslash($_POST['customer_name'])) : '';
+
+            $result = \kc_call_ai_endpoint(
+                'draft_sms',
+                array(
+                    'customer_name' => $customer_name,
+                )
+            );
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php echo esc_html__('KerbCycle AI Test', 'kerbcycle'); ?></h1>
+            <form method="post">
+                <?php wp_nonce_field('kerbcycle_ai_test_action', 'kerbcycle_ai_test_nonce'); ?>
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row">
+                            <label for="customer_name"><?php echo esc_html__('Customer Name', 'kerbcycle'); ?></label>
+                        </th>
+                        <td>
+                            <input type="text" id="customer_name" name="customer_name" class="regular-text" value="<?php echo esc_attr($customer_name); ?>" />
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button(__('Test AI Endpoint', 'kerbcycle')); ?>
+            </form>
+
+            <?php if (null !== $result) : ?>
+                <h2><?php echo esc_html__('Response', 'kerbcycle'); ?></h2>
+                <pre><?php echo esc_html(wp_json_encode($result, JSON_PRETTY_PRINT)); ?></pre>
+            <?php endif; ?>
+        </div>
+        <?php
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Provide a tiny internal admin-only page to manually test the existing AI endpoint from inside WordPress while keeping changes surgical and reusing the existing AI helper.
- The best place for this is `includes/Admin/Admin.php` inside `Kerbcycle\QrCode\Admin\Admin::register_admin_menu` because that class already registers admin menus and is responsible for admin callbacks.

### Description
- Register a Tools page via `add_management_page` titled `KerbCycle AI Test` and implement the page callback `render_ai_test_page` in the same `Admin` class.
- The page renders a minimal form with a `customer_name` text input and a submit button, and on submit it enforces `manage_options`, verifies the nonce with `check_admin_referer`, sanitizes `customer_name` using `sanitize_text_field(wp_unslash(...))`, calls `kc_call_ai_endpoint('draft_sms', ['customer_name' => $customer_name])`, and prints the returned result escaped via `esc_html(wp_json_encode(..., JSON_PRETTY_PRINT))` inside a `<pre>` block.
- This is a single-file, surgical change with no refactors or unrelated UI changes; the only file modified is `includes/Admin/Admin.php`.
- Patch summary: files changed — `includes/Admin/Admin.php`; form fields added — `customer_name` and submit button; security checks added — `manage_options` capability gate, nonce generation/verification, input sanitization, and escaped output.

### Testing
- Ran `php -l includes/Admin/Admin.php` which passed with `No syntax errors detected`.
- Attempted a headless browser navigation to `http://localhost:8080/wp-admin/tools.php?page=kerbcycle-ai-test`, which failed with `net::ERR_EMPTY_RESPONSE` because the local WordPress site was not reachable in this environment.
- No additional automated unit tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b076d82b6c832daf1443ad20771369)