### PR TITLE
Add Render provider adapter to AiProviderService

### DIFF
--- a/includes/Services/AiProviderService.php
+++ b/includes/Services/AiProviderService.php
@@ -25,6 +25,10 @@ class AiProviderService
     {
         $provider = $this->get_provider();
 
+        if ($provider === 'render') {
+            return $this->call_render_endpoint($action, $payload);
+        }
+
         if ($provider !== 'ollama') {
             return new \WP_Error('kerbcycle_ai_provider_unsupported', __('Unsupported AI provider configured.', 'kerbcycle'), ['status' => 500]);
         }
@@ -127,6 +131,75 @@ class AiProviderService
             'model'    => $model,
             'latency_ms' => $elapsed_ms,
             'output'   => $parsed_output,
+        ];
+    }
+
+    /**
+     * @param string $action
+     * @param array<string,mixed> $payload
+     *
+     * @return array<string,mixed>|\WP_Error
+     */
+    private function call_render_endpoint($action, array $payload)
+    {
+        $endpoint = defined('KERBCYCLE_AI_RENDER_ENDPOINT') ? KERBCYCLE_AI_RENDER_ENDPOINT : get_option('kerbcycle_ai_render_endpoint', '');
+        $api_key  = defined('KERBCYCLE_AI_RENDER_API_KEY') ? KERBCYCLE_AI_RENDER_API_KEY : get_option('kerbcycle_ai_render_api_key', '');
+
+        $endpoint = is_string($endpoint) ? trim($endpoint) : '';
+        $api_key  = is_string($api_key) ? trim($api_key) : '';
+
+        if ($endpoint === '' || $api_key === '') {
+            return new \WP_Error('kerbcycle_ai_provider_misconfigured', __('AI provider configuration is incomplete.', 'kerbcycle'), ['status' => 500]);
+        }
+
+        $started = microtime(true);
+        $response = wp_remote_post($endpoint, [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'x-api-key'    => $api_key,
+            ],
+            'body'    => wp_json_encode([
+                'task' => $action,
+                'data' => $payload,
+            ]),
+            'timeout' => 20,
+        ]);
+        $elapsed_ms = (int) round((microtime(true) - $started) * 1000);
+
+        if (is_wp_error($response)) {
+            ErrorLogRepository::log([
+                'type'    => 'ai_provider',
+                'message' => sprintf('AI request failed (%s): %s', $action, $response->get_error_message()),
+                'page'    => 'api-ai',
+                'status'  => 'failure',
+            ]);
+
+            return new \WP_Error('kerbcycle_ai_provider_unreachable', __('AI provider is unreachable.', 'kerbcycle'), ['status' => 502]);
+        }
+
+        $status_code = (int) wp_remote_retrieve_response_code($response);
+        $body        = (string) wp_remote_retrieve_body($response);
+
+        if ($status_code < 200 || $status_code >= 300) {
+            ErrorLogRepository::log([
+                'type'    => 'ai_provider',
+                'message' => sprintf('AI provider HTTP %d (%s).', $status_code, $action),
+                'page'    => 'api-ai',
+                'status'  => 'failure',
+            ]);
+
+            return new \WP_Error('kerbcycle_ai_provider_http_error', __('AI provider returned an unexpected response.', 'kerbcycle'), ['status' => 502]);
+        }
+
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded) || !isset($decoded['result']) || !is_array($decoded['result'])) {
+            return new \WP_Error('kerbcycle_ai_provider_invalid_response', __('AI provider response could not be parsed.', 'kerbcycle'), ['status' => 502]);
+        }
+
+        return [
+            'provider'   => 'render',
+            'latency_ms' => $elapsed_ms,
+            'output'     => $decoded['result'],
         ];
     }
 


### PR DESCRIPTION
### Motivation
- No Codex skills were required or used for this change. 
- Enable `AiProviderService` to call an alternative AI provider named `render` while preserving the existing `ollama` flow. 
- Keep the change surgical and confined to the service so REST controllers, admin UI, and the prompt builder remain untouched. 

### Description
- Insertion point: added a branch in `AiProviderService::generate()` to check `if ($provider === 'render')` and call a new `call_render_endpoint($action, $payload)` before the existing unsupported-provider check. 
- Implemented `private function call_render_endpoint($action, array $payload)` which uses the WordPress HTTP API (`wp_remote_post`) to `POST` JSON to the configured endpoint with headers `Content-Type: application/json` and `x-api-key: <key>`, and body `{ "task": <action>, "data": <payload> }`. 
- Provider configuration lookup uses `KERBCYCLE_AI_RENDER_ENDPOINT` (fallback option `kerbcycle_ai_render_endpoint`) and `KERBCYCLE_AI_RENDER_API_KEY` (fallback option `kerbcycle_ai_render_api_key`). 
- Normalized successful return shape to an array with `'provider' => 'render'`, `'latency_ms' => <int>`, and `'output' => <decoded result>` and preserved the existing `ollama` return format. 
- Error handling added to mirror existing conventions for misconfiguration, network failure, non-2xx responses, and invalid JSON: `kerbcycle_ai_provider_misconfigured`, `kerbcycle_ai_provider_unreachable`, `kerbcycle_ai_provider_http_error`, and `kerbcycle_ai_provider_invalid_response`. 
- Files changed: `includes/Services/AiProviderService.php` only. 

### Testing
- Ran `php -l includes/Services/AiProviderService.php` and it reported no syntax errors. 
- No other automated tests were modified or run as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07f740b1c832d88f8860243e6ff56)