### PR TITLE
Support Render endpoint config via constants or WP options in AiProviderService

### DIFF
--- a/includes/Services/AiProviderService.php
+++ b/includes/Services/AiProviderService.php
@@ -142,11 +142,8 @@ class AiProviderService
      */
     private function call_render_endpoint($action, array $payload)
     {
-        $endpoint = defined('KERBCYCLE_AI_RENDER_ENDPOINT') ? KERBCYCLE_AI_RENDER_ENDPOINT : get_option('kerbcycle_ai_render_endpoint', '');
-        $api_key  = defined('KERBCYCLE_AI_RENDER_API_KEY') ? KERBCYCLE_AI_RENDER_API_KEY : get_option('kerbcycle_ai_render_api_key', '');
-
-        $endpoint = is_string($endpoint) ? trim($endpoint) : '';
-        $api_key  = is_string($api_key) ? trim($api_key) : '';
+        $endpoint = $this->get_render_endpoint();
+        $api_key  = $this->get_render_api_key();
 
         if ($endpoint === '' || $api_key === '') {
             return new \WP_Error('kerbcycle_ai_provider_misconfigured', __('AI provider configuration is incomplete.', 'kerbcycle'), ['status' => 500]);
@@ -201,6 +198,26 @@ class AiProviderService
             'latency_ms' => $elapsed_ms,
             'output'     => $decoded['result'],
         ];
+    }
+
+    /**
+     * @return string
+     */
+    private function get_render_endpoint()
+    {
+        $endpoint = defined('KERBCYCLE_AI_RENDER_URL') ? KERBCYCLE_AI_RENDER_URL : get_option('kerbcycle_ai_render_endpoint', '');
+
+        return is_string($endpoint) ? trim($endpoint) : '';
+    }
+
+    /**
+     * @return string
+     */
+    private function get_render_api_key()
+    {
+        $api_key = defined('KERBCYCLE_AI_RENDER_API_KEY') ? KERBCYCLE_AI_RENDER_API_KEY : get_option('kerbcycle_ai_render_api_key', '');
+
+        return is_string($api_key) ? trim($api_key) : '';
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Allow the plugin to configure the Render AI endpoint and API key via constants or WordPress options while keeping existing Ollama behavior unchanged.
- Provide a predictable priority: prefer constants, fallback to options, and fail cleanly if configuration is missing.

### Description
- Added `get_render_endpoint()` which prefers `KERBCYCLE_AI_RENDER_URL` and falls back to `get_option('kerbcycle_ai_render_endpoint')`, returning a trimmed string or empty default. 
- Added `get_render_api_key()` which prefers `KERBCYCLE_AI_RENDER_API_KEY` and falls back to `get_option('kerbcycle_ai_render_api_key')`, returning a trimmed string or empty default. 
- Updated `call_render_endpoint()` to use these helpers and preserved the existing `WP_Error` misconfiguration response when endpoint or API key are missing.

### Testing
- Ran `php -l includes/Services/AiProviderService.php` to verify there are no PHP syntax errors, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0808240ac832da41065fa66d86e87)