### PR TITLE
Normalize Render AI responses to AiProviderService format

### DIFF
--- a/includes/Services/AiProviderService.php
+++ b/includes/Services/AiProviderService.php
@@ -144,6 +144,7 @@ class AiProviderService
     {
         $endpoint = $this->get_render_endpoint();
         $api_key  = $this->get_render_api_key();
+        $model    = $this->get_render_model();
 
         if ($endpoint === '' || $api_key === '') {
             return new \WP_Error('kerbcycle_ai_provider_misconfigured', __('AI provider configuration is incomplete.', 'kerbcycle'), ['status' => 500]);
@@ -189,15 +190,59 @@ class AiProviderService
         }
 
         $decoded = json_decode($body, true);
-        if (!is_array($decoded) || !isset($decoded['result']) || !is_array($decoded['result'])) {
+        if (!is_array($decoded)) {
             return new \WP_Error('kerbcycle_ai_provider_invalid_response', __('AI provider response could not be parsed.', 'kerbcycle'), ['status' => 502]);
+        }
+
+        $raw_output = null;
+        foreach (['result', 'output', 'response', 'data'] as $candidate_key) {
+            if (array_key_exists($candidate_key, $decoded)) {
+                $raw_output = $decoded[$candidate_key];
+                break;
+            }
+        }
+
+        if ($raw_output === null) {
+            $raw_output = $decoded;
+        }
+
+        if (is_string($raw_output)) {
+            $raw_output = json_decode(trim($raw_output), true);
+        }
+
+        if (!is_array($raw_output)) {
+            ErrorLogRepository::log([
+                'type'    => 'ai_provider',
+                'message' => sprintf('AI returned non-JSON output (%s).', $action),
+                'page'    => 'api-ai',
+                'status'  => 'failure',
+            ]);
+
+            return new \WP_Error('kerbcycle_ai_output_invalid_json', __('AI output was not valid JSON.', 'kerbcycle'), ['status' => 422]);
         }
 
         return [
             'provider'   => 'render',
+            'model'      => $model,
             'latency_ms' => $elapsed_ms,
-            'output'     => $decoded['result'],
+            'output'     => $raw_output,
         ];
+    }
+
+    /**
+     * @return string|null
+     */
+    private function get_render_model()
+    {
+        $model = defined('KERBCYCLE_AI_RENDER_MODEL') ? KERBCYCLE_AI_RENDER_MODEL : get_option('kerbcycle_ai_render_model', '');
+
+        if (!is_string($model)) {
+            return null;
+        }
+
+        $model = trim($model);
+
+        return $model !== '' ? $model : null;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Ensure the `AiProviderService` always returns the same normalized contract so REST controllers and the admin UI remain provider-agnostic when switching to Render.
- Render responses can vary in structure and sometimes return JSON payloads nested under different keys or as a JSON-encoded string, so the service must extract and normalize that output.
- Preserve existing Ollama behavior while mapping Render to the existing output shape to avoid schema, controller, or UI changes.

### Description
- Updated `AiProviderService::call_render_endpoint()` to parse the HTTP response body, extract the response payload, and map it into the normalized shape used by Ollama: `provider`, `model`, `latency_ms`, and `output`.
- Added payload extraction rules that look for keys in this priority order: `result`, `output`, `response`, `data`, and fall back to the full decoded body if none match, then JSON-decode string payloads into structured arrays.
- When extracted payload is not structured JSON, the method logs the failure and returns `WP_Error('kerbcycle_ai_output_invalid_json', ...)` with status `422` to match existing error handling.
- Added `get_render_model()` and include `model` (string|null) in the normalized output; touched file: `includes/Services/AiProviderService.php`.

### Testing
- Ran PHP syntax check `php -l includes/Services/AiProviderService.php`, which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0811c2f28832d8f669f35d3889790)