### PR TITLE
Support Render provider and validate AI provider selection

### DIFF
--- a/includes/Services/AiProviderService.php
+++ b/includes/Services/AiProviderService.php
@@ -25,26 +25,31 @@ class AiProviderService
     {
         $provider = $this->get_provider();
 
-        if ($provider === 'render') {
-            return $this->call_render_endpoint($action, $payload);
+        if (is_wp_error($provider)) {
+            return $provider;
         }
 
-        if ($provider !== 'ollama') {
-            return new \WP_Error('kerbcycle_ai_provider_unsupported', __('Unsupported AI provider configured.', 'kerbcycle'), ['status' => 500]);
+        if ($provider === 'render') {
+            return $this->call_render_endpoint($action, $payload);
         }
 
         return $this->call_ollama($action, $payload);
     }
 
     /**
-     * @return string
+     * @return string|\WP_Error
      */
     private function get_provider()
     {
         $provider = defined('KERBCYCLE_AI_PROVIDER') ? KERBCYCLE_AI_PROVIDER : get_option('kerbcycle_ai_provider', 'ollama');
         $provider = is_string($provider) ? strtolower(trim($provider)) : 'ollama';
+        $provider = $provider !== '' ? $provider : 'ollama';
 
-        return $provider !== '' ? $provider : 'ollama';
+        if (!in_array($provider, ['ollama', 'render'], true)) {
+            return new \WP_Error('kerbcycle_ai_provider_unsupported', __('Unsupported AI provider configured.', 'kerbcycle'), ['status' => 500]);
+        }
+
+        return $provider;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Allow switching between `ollama` and `render` providers via the `KERBCYCLE_AI_PROVIDER` constant or the `kerbcycle_ai_provider` option while preserving existing behaviour and failing fast for unsupported values.

### Description
- Update `AiProviderService::get_provider()` to prefer the `KERBCYCLE_AI_PROVIDER` constant, then the `kerbcycle_ai_provider` option, normalize the value, default to `ollama`, and return a `WP_Error` for any provider not in `['ollama','render']`, and update `AiProviderService::generate()` to return early on provider resolution errors and route `render` to `call_render_endpoint()` otherwise call `call_ollama()`.

### Testing
- Ran `php -l includes/Services/AiProviderService.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b081bdd930832da19252d6e127c294)