### PR TITLE
Enforce strict JSON contracts for Render AI /ai endpoint

### DIFF
--- a/render_service/main.py
+++ b/render_service/main.py
@@ -1,0 +1,154 @@
+import json
+import logging
+import os
+from typing import Any, Dict, List
+
+import httpx
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel
+
+app = FastAPI()
+logger = logging.getLogger("kerbcycle_render_ai")
+
+
+class AiRequest(BaseModel):
+    task: str
+    data: Dict[str, Any]
+
+
+def _build_prompt(task: str, payload: Dict[str, Any]) -> str:
+    contracts: Dict[str, Dict[str, Any]] = {
+        "pickup_summary": {
+            "summary": "string",
+            "highlights": ["string"],
+            "issues": ["string"],
+        },
+        "qr_exceptions": {
+            "exceptions": [
+                {
+                    "code": "string",
+                    "reason": "string",
+                    "severity": "low|medium|high",
+                }
+            ]
+        },
+        "draft_template": {
+            "subject": "string",
+            "message": "string",
+        },
+    }
+    return (
+        "You are a municipal operations assistant. "
+        "Return ONLY valid JSON. Do not include markdown, code fences, explanations, or extra keys.\n"
+        f"Task: {task}\n"
+        f"Required JSON schema: {json.dumps(contracts[task])}\n"
+        f"Input payload: {json.dumps(payload)}"
+    )
+
+
+def _validate_contract(task: str, value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+
+    if task == "pickup_summary":
+        return (
+            isinstance(value.get("summary"), str)
+            and isinstance(value.get("highlights"), list)
+            and all(isinstance(item, str) for item in value.get("highlights", []))
+            and isinstance(value.get("issues"), list)
+            and all(isinstance(item, str) for item in value.get("issues", []))
+        )
+
+    if task == "qr_exceptions":
+        exceptions = value.get("exceptions")
+        if not isinstance(exceptions, list):
+            return False
+        for item in exceptions:
+            if not isinstance(item, dict):
+                return False
+            if not isinstance(item.get("code"), str) or not isinstance(item.get("reason"), str):
+                return False
+            if item.get("severity") not in {"low", "medium", "high"}:
+                return False
+        return True
+
+    if task == "draft_template":
+        return isinstance(value.get("subject"), str) and isinstance(value.get("message"), str)
+
+    return False
+
+
+def _call_provider(prompt: str) -> str:
+    provider_url = os.getenv("AI_PROVIDER_URL", "")
+    model = os.getenv("AI_PROVIDER_MODEL", "")
+    api_key = os.getenv("AI_PROVIDER_API_KEY", "")
+    if not provider_url or not model:
+        raise RuntimeError("AI provider is not configured")
+
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+    }
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    response = httpx.post(provider_url, json=payload, headers=headers, timeout=30)
+    response.raise_for_status()
+    body = response.json()
+
+    choices: List[Dict[str, Any]] = body.get("choices", []) if isinstance(body, dict) else []
+    if choices and isinstance(choices[0], dict):
+        message = choices[0].get("message", {})
+        if isinstance(message, dict) and isinstance(message.get("content"), str):
+            return message["content"]
+
+    if isinstance(body, dict) and isinstance(body.get("output"), str):
+        return body["output"]
+
+    raise RuntimeError("AI provider response did not contain model output")
+
+
+@app.post("/ai")
+def handle_ai_request(request: AiRequest, x_api_key: str = Header(default="")) -> Dict[str, Any]:
+    expected_key = os.getenv("RENDER_API_KEY", "")
+    if not expected_key or x_api_key != expected_key:
+        raise HTTPException(status_code=401, detail={"error": "Unauthorized"})
+
+    task = request.task
+    if task not in {"pickup_summary", "qr_exceptions", "draft_template"}:
+        raise HTTPException(status_code=400, detail={"error": "Unsupported task", "task": task})
+
+    try:
+        prompt = _build_prompt(task, request.data)
+        raw_output = _call_provider(prompt)
+        parsed = json.loads(raw_output)
+    except json.JSONDecodeError:
+        logger.warning("ai task=%s status=failure reason=invalid_json", task)
+        raise HTTPException(
+            status_code=422,
+            detail={"error": "Invalid model JSON output", "meta": {"task": task, "valid_json": False}},
+        )
+    except Exception as exc:
+        logger.warning("ai task=%s status=failure reason=%s", task, str(exc))
+        raise HTTPException(
+            status_code=502,
+            detail={"error": "AI provider call failed", "meta": {"task": task, "valid_json": False}},
+        )
+
+    if not _validate_contract(task, parsed):
+        logger.warning("ai task=%s status=failure reason=invalid_shape", task)
+        raise HTTPException(
+            status_code=422,
+            detail={"error": "Model JSON did not match expected schema", "meta": {"task": task, "valid_json": False}},
+        )
+
+    logger.info("ai task=%s status=success", task)
+    return {
+        "result": parsed,
+        "meta": {
+            "task": task,
+            "valid_json": True,
+        },
+    }


### PR DESCRIPTION
### Motivation
- Ensure the Render AI endpoint returns strict JSON that matches the KerbCycle plugin's AiProviderService expectations so the plugin can normalize responses without any WordPress-side changes. 
- Provide deterministic contracts and graceful JSON error responses for the three tasks `pickup_summary`, `qr_exceptions`, and `draft_template` to avoid parsing/shape failures in the plugin.

### Description
- Added a FastAPI handler `POST /ai` implemented in `render_service/main.py` that gates requests with `x-api-key` against `RENDER_API_KEY` and accepts only the tasks `pickup_summary`, `qr_exceptions`, and `draft_template`.
- Constructs strict JSON-only prompts specific to each task, forwards the prompt to the configured AI provider, parses the provider output as JSON, and validates the top-level structure against task contracts.
- On success returns the standardized wrapper `{"result": <validated task JSON>, "meta": {"task": "task_name", "valid_json": true}}` and on failure returns controlled JSON error responses with appropriate HTTP status codes and logging; raw model text is never returned.
- Minimal logging was added for `task`, `success`/`failure`, `invalid_json`, and `invalid_shape` outcomes, and the patch is isolated to the Render endpoint implementation.

### Testing
- Compiled the new endpoint module with `python -m py_compile render_service/main.py` which succeeded.
- No existing automated unit tests were changed in this patch and no WordPress-side tests were executed as part of this change.

Patch summary: files changed: `render_service/main.py`; JSON schemas enforced: `pickup_summary` (`summary`, `highlights[]`, `issues[]`), `qr_exceptions` (`exceptions[]` with `code`, `reason`, `severity` in `low|medium|high`), `draft_template` (`subject`, `message`); validation/error handling added: JSON parsing, shape validation, controlled error responses, and minimal logging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08603606c832d8882697a79f063b5)