### PR TITLE
Configure KerbCycle to use Render AI provider via wp-config constants

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * KerbCycle AI provider overrides.
+ */
+define('KERBCYCLE_AI_PROVIDER', 'render');
+define('KERBCYCLE_AI_RENDER_URL', 'https://YOUR-RENDER-SERVICE.onrender.com/ask');
+define('KERBCYCLE_AI_RENDER_API_KEY', 'YOUR_RENDER_API_KEY');
+define('KERBCYCLE_AI_RENDER_MODEL', 'endpoint');
+
+/* That's all, stop editing! Happy publishing. */


### PR DESCRIPTION
### Motivation
- Force the plugin to use the Render AI provider (so requests go to the Render endpoint instead of Ollama at 127.0.0.1:11434) by adding configuration-only overrides in the WordPress bootstrap.

### Description
- Add a `wp-config.php` configuration block placed before the "/* That's all, stop editing! Happy publishing. */" marker that defines `KERBCYCLE_AI_PROVIDER` as `render` and provides `KERBCYCLE_AI_RENDER_URL`, `KERBCYCLE_AI_RENDER_API_KEY`, and `KERBCYCLE_AI_RENDER_MODEL`; these constants are read by `AiProviderService` via `defined(...)` before falling back to `get_option(...)`, so they override database options without changing plugin code.

### Testing
- Ran `php -l wp-config.php` to validate syntax and committed the new `wp-config.php` file, and the linter returned no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b09760a578832db90e05ceebb5314f)