### PR TITLE
Send non-blocking pickup_exception webhook from QR release

### DIFF
--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -115,6 +115,15 @@ class QrService
             return new \WP_Error('db_error', 'Failed to release QR code in database.');
         }
 
+        // Non-blocking webhook call: local DB release remains the source of truth.
+        $this->send_pickup_exception_webhook([
+            'qr_code'     => $qr_code,
+            'customer_id' => isset($row->user_id) ? (int) $row->user_id : 0,
+            'issue'       => '',
+            'notes'       => '',
+            'timestamp'   => '',
+        ]);
+
         $sms_result   = null;
         $email_result = null;
         if ($row->user_id) {
@@ -130,6 +139,46 @@ class QrService
             'sms_result'   => $sms_result,
             'email_result' => $email_result,
         ];
+    }
+
+    private function send_pickup_exception_webhook(array $data)
+    {
+        $webhook_url = defined('KERBCYCLE_PICKUP_EXCEPTION_WEBHOOK_URL')
+            ? KERBCYCLE_PICKUP_EXCEPTION_WEBHOOK_URL
+            : get_option('kerbcycle_pickup_exception_webhook_url', '');
+
+        $webhook_url = is_string($webhook_url) ? trim($webhook_url) : '';
+        if ($webhook_url === '') {
+            return;
+        }
+
+        $payload = [
+            'event'       => 'pickup_exception',
+            'qr_code'     => isset($data['qr_code']) ? (string) $data['qr_code'] : '',
+            'customer_id' => isset($data['customer_id']) ? (int) $data['customer_id'] : 0,
+            'issue'       => isset($data['issue']) ? (string) $data['issue'] : '',
+            'notes'       => isset($data['notes']) ? (string) $data['notes'] : '',
+            'timestamp'   => !empty($data['timestamp']) ? (string) $data['timestamp'] : gmdate('c'),
+        ];
+
+        $response = wp_remote_post($webhook_url, [
+            'method'  => 'POST',
+            'timeout' => 20,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'body'    => wp_json_encode($payload),
+        ]);
+
+        if (is_wp_error($response)) {
+            error_log('KerbCycle pickup_exception webhook WP_Error: ' . $response->get_error_message());
+            return;
+        }
+
+        $status_code = (int) wp_remote_retrieve_response_code($response);
+        if ($status_code < 200 || $status_code >= 300) {
+            error_log('KerbCycle pickup_exception webhook HTTP ' . $status_code . ' Body: ' . wp_remote_retrieve_body($response));
+        }
     }
 
     public function bulk_release(array $codes)


### PR DESCRIPTION
### Motivation
- Send a minimal `pickup_exception` event to the production n8n webhook whenever a real pickup-related save occurs, without altering the local DB-first flow or blocking the release path.
- Keep the change surgical and reversible, preserving existing architecture, UX and QR/database logic.

### Description
- Added a small helper `send_pickup_exception_webhook(array $data)` to `includes/Services/QrService.php` that builds the required JSON payload and posts it to an n8n webhook via `wp_remote_post()`.
- Webhook URL resolution follows the plugin pattern: `KERBCYCLE_PICKUP_EXCEPTION_WEBHOOK_URL` constant if defined, else `get_option('kerbcycle_pickup_exception_webhook_url', '')`.
- Payload fields sent (via `wp_json_encode`): `event` ("pickup_exception"), `qr_code`, `customer_id`, `issue`, `notes`, and `timestamp` (ISO8601 UTC fallback via `gmdate('c')`); request uses `Content-Type: application/json` and a 20-second timeout.
- Wired the helper into exactly one save point: inside `QrService::release()` immediately after a successful `release_latest_assigned()` call so local DB release remains authoritative; failures are logged via `error_log()` and do not block or alter the core flow.

### Testing
- Ran PHP lint: `php -l includes/Services/QrService.php` which returned no syntax errors.
- No repository unit tests were modified; only a lightweight lint check was executed on the changed file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c72d0c6638832dafe0017986ef224d)