### PR TITLE
Add temporary admin pickup-exception test hook to Dashboard

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -633,6 +633,12 @@ function initKerbcycleAdmin() {
   );
   const aiStatus = document.getElementById("kerbcycle-ai-status");
   const aiResult = document.getElementById("kerbcycle-ai-result");
+  const pickupExceptionTestBtn = document.getElementById(
+    "kerbcycle-test-pickup-exception",
+  );
+  const pickupExceptionTestResult = document.getElementById(
+    "kerbcycle-ai-test-result",
+  );
 
   function renderAiList(items) {
     if (!Array.isArray(items) || !items.length) {
@@ -752,6 +758,51 @@ function initKerbcycleAdmin() {
   if (aiDraftTemplateBtn) {
     aiDraftTemplateBtn.addEventListener("click", function () {
       callAiAction("draft_template");
+    });
+  }
+
+  if (pickupExceptionTestBtn) {
+    pickupExceptionTestBtn.addEventListener("click", function () {
+      const originalText = pickupExceptionTestBtn.textContent;
+      pickupExceptionTestBtn.disabled = true;
+      pickupExceptionTestBtn.textContent = "Testing...";
+      if (pickupExceptionTestResult) {
+        pickupExceptionTestResult.textContent = "Loading AI webhook response...";
+      }
+
+      const params = new URLSearchParams();
+      params.append("action", "kerbcycle_test_pickup_exception");
+      params.append("security", kerbcycle_ajax.nonce);
+
+      fetch(kerbcycle_ajax.ajax_url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        },
+        body: params.toString(),
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          if (pickupExceptionTestResult) {
+            pickupExceptionTestResult.textContent = JSON.stringify(data, null, 2);
+          }
+        })
+        .catch((error) => {
+          if (pickupExceptionTestResult) {
+            pickupExceptionTestResult.textContent = JSON.stringify(
+              {
+                success: false,
+                message: error.message || "Request failed.",
+              },
+              null,
+              2,
+            );
+          }
+        })
+        .finally(() => {
+          pickupExceptionTestBtn.disabled = false;
+          pickupExceptionTestBtn.textContent = originalText;
+        });
     });
   }
 

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -43,6 +43,7 @@ class AdminAjax
         add_action('wp_ajax_kerbcycle_paginate_qr_codes', [$this, 'paginate_qr_codes']);
         add_action('wp_ajax_kerbcycle_qr_report_data', [$this, 'ajax_report_data']);
         add_action('wp_ajax_kerbcycle_delete_logs', [$this, 'delete_logs']);
+        add_action('wp_ajax_kerbcycle_test_pickup_exception', [$this, 'test_pickup_exception']);
     }
 
     public function assign_qr_code()
@@ -396,5 +397,35 @@ class AdminAjax
         $deleted = $repo->delete_by_ids($ids);
 
         wp_send_json_success(['deleted' => (int) $deleted]);
+    }
+
+    public function test_pickup_exception()
+    {
+        // TEMPORARY ADMIN TEST HOOK FOR AI / n8n INTEGRATION
+        Nonces::verify('kerbcycle_qr_nonce', 'security');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
+        }
+
+        $result = $this->qr_service->send_pickup_exception_to_n8n([
+            'qr_code'     => 'KC-TEST-1001',
+            'customer_id' => get_current_user_id(),
+            'issue'       => 'bag damaged',
+            'notes'       => 'admin test trigger',
+            'timestamp'   => gmdate('c'),
+        ]);
+
+        if (is_wp_error($result)) {
+            wp_send_json_error([
+                'message' => $result->get_error_message(),
+                'code'    => $result->get_error_code(),
+            ]);
+        }
+
+        if (!empty($result['success'])) {
+            wp_send_json_success($result);
+        }
+
+        wp_send_json_error($result);
     }
 }

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -119,6 +119,14 @@ class DashboardPage
                         </div>
                         <p id="kerbcycle-ai-status" class="description" aria-live="polite"></p>
                         <div id="kerbcycle-ai-result" class="notice inline" style="display:none;"></div>
+                        <?php // TEMPORARY ADMIN TEST HOOK FOR AI / n8n INTEGRATION ?>
+                        <div class="kerbcycle-ai-test">
+                            <h3><?php esc_html_e('AI Test (Temporary)', 'kerbcycle'); ?></h3>
+                            <button id="kerbcycle-test-pickup-exception" class="button button-primary">
+                                <?php esc_html_e('Test Pickup Exception → n8n', 'kerbcycle'); ?>
+                            </button>
+                            <pre id="kerbcycle-ai-test-result" style="margin-top:10px;"></pre>
+                        </div>
                     </div>
                 </div>
                 <h2><?php esc_html_e('Manual QR Code Tasks', 'kerbcycle'); ?></h2>

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -141,6 +141,11 @@ class QrService
         ];
     }
 
+    public function send_pickup_exception_to_n8n(array $data)
+    {
+        return $this->send_pickup_exception_webhook($data);
+    }
+
     private function send_pickup_exception_webhook(array $data)
     {
         $webhook_url = defined('KERBCYCLE_PICKUP_EXCEPTION_WEBHOOK_URL')
@@ -149,7 +154,7 @@ class QrService
 
         $webhook_url = is_string($webhook_url) ? trim($webhook_url) : '';
         if ($webhook_url === '') {
-            return;
+            return new \WP_Error('pickup_exception_webhook_missing', __('Pickup exception webhook URL is not configured.', 'kerbcycle'));
         }
 
         $payload = [
@@ -172,13 +177,27 @@ class QrService
 
         if (is_wp_error($response)) {
             error_log('KerbCycle pickup_exception webhook WP_Error: ' . $response->get_error_message());
-            return;
+            return $response;
         }
 
         $status_code = (int) wp_remote_retrieve_response_code($response);
         if ($status_code < 200 || $status_code >= 300) {
-            error_log('KerbCycle pickup_exception webhook HTTP ' . $status_code . ' Body: ' . wp_remote_retrieve_body($response));
+            $body = wp_remote_retrieve_body($response);
+            error_log('KerbCycle pickup_exception webhook HTTP ' . $status_code . ' Body: ' . $body);
+            return [
+                'success'     => false,
+                'status_code' => $status_code,
+                'body'        => $body,
+                'payload'     => $payload,
+            ];
         }
+
+        return [
+            'success'     => true,
+            'status_code' => $status_code,
+            'body'        => wp_remote_retrieve_body($response),
+            'payload'     => $payload,
+        ];
     }
 
     public function bulk_release(array $codes)


### PR DESCRIPTION
### Motivation
- Provide an admin-only, nonce-protected way to manually trigger the existing pickup_exception → n8n → AI flow and inspect the response immediately from wp-admin for debugging. 
- Keep the change surgical and temporary without modifying business logic, endpoints, or creating new pages. 

### Description
- Added a temporary UI block to the existing dashboard page at `includes/Admin/Pages/DashboardPage.php` containing the test HTML (`#kerbcycle-test-pickup-exception` button and `#kerbcycle-ai-test-result` `<pre>`) and a `TEMPORARY ADMIN TEST HOOK FOR AI / n8n INTEGRATION` comment. 
- Registered a new admin AJAX action and handler `kerbcycle_test_pickup_exception` in `includes/Admin/Ajax/AdminAjax.php` which verifies the nonce (`kerbcycle_qr_nonce`) and `current_user_can('manage_options')`, then calls the existing service helper and returns JSON via `wp_send_json_success`/`wp_send_json_error`. 
- Reused existing service logic by adding a thin public wrapper `send_pickup_exception_to_n8n()` in `includes/Services/QrService.php` that delegates to the existing `send_pickup_exception_webhook()` helper, and updated the helper to return structured results or `WP_Error` for admin feedback without changing its behavior for normal plugin flows. 
- Extended the main admin JS in `assets/js/admin.js` to wire the `#kerbcycle-test-pickup-exception` click handler which disables the button, shows loading text, sends an AJAX POST to `admin-ajax.php` with `action=kerbcycle_test_pickup_exception` and the existing `kerbcycle_ajax.nonce`, then pretty-prints the JSON response into `#kerbcycle-ai-test-result` and restores the button. 

### Testing
- Ran `php -l includes/Admin/Pages/DashboardPage.php` and it reported no syntax errors. 
- Ran `php -l includes/Admin/Ajax/AdminAjax.php` and it reported no syntax errors. 
- Ran `php -l includes/Services/QrService.php` and it reported no syntax errors. 
- Ran `node --check assets/js/admin.js` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c740fbd17c832da439747a0b82ef47)