### PR TITLE
Add AI Settings admin page for environment-based pickup-exception webhooks

### DIFF
--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -153,6 +153,16 @@ class Admin
             [$routing, 'render']
         );
 
+        $ai_settings = Pages\AiSettingsPage::instance();
+        add_submenu_page(
+            'kerbcycle-qr-manager',
+            'AI Settings',
+            'AI Settings',
+            'manage_options',
+            'kerbcycle-ai-settings',
+            [$ai_settings, 'render']
+        );
+
         add_submenu_page(
             'kerbcycle-qr-manager',
             'Plugin Integrations',

--- a/includes/Admin/Pages/AiSettingsPage.php
+++ b/includes/Admin/Pages/AiSettingsPage.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Kerbcycle\QrCode\Admin\Pages;
+
+use Kerbcycle\QrCode\Services\AiSettingsService;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Admin page and helpers for configuring AI webhook integration.
+ */
+class AiSettingsPage
+{
+    private const OPTION_KEY = 'kerbcycle_ai_webhook_options';
+
+    /**
+     * Singleton instance.
+     *
+     * @var self|null
+     */
+    private static $instance = null;
+
+    /**
+     * Get the singleton instance.
+     */
+    public static function instance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Constructor hooks.
+     */
+    private function __construct()
+    {
+        add_action('admin_init', [$this, 'register_settings']);
+    }
+
+    /**
+     * Render the admin page.
+     */
+    public function render()
+    {
+        $options = AiSettingsService::get_options();
+        $webhook_url = AiSettingsService::current_webhook_url($options);
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('AI Settings', 'kerbcycle'); ?></h1>
+            <p class="description"><?php esc_html_e('The selected environment determines which pickup-exception webhook URL is active.', 'kerbcycle'); ?></p>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields(self::OPTION_KEY);
+                do_settings_sections(self::OPTION_KEY);
+                submit_button(__('Save AI Settings', 'kerbcycle'));
+                ?>
+            </form>
+
+            <h2><?php esc_html_e('Active webhook', 'kerbcycle'); ?></h2>
+            <p>
+                <code><?php echo esc_html($webhook_url !== '' ? $webhook_url : __('Not configured', 'kerbcycle')); ?></code>
+            </p>
+        </div>
+        <?php
+    }
+
+    /**
+     * Register AI webhook settings and fields.
+     */
+    public function register_settings()
+    {
+        register_setting(self::OPTION_KEY, self::OPTION_KEY, [$this, 'sanitize_options']);
+
+        add_settings_section(
+            'kc_ai_main',
+            __('Pickup Exception Webhook', 'kerbcycle'),
+            '__return_false',
+            self::OPTION_KEY
+        );
+
+        add_settings_field(
+            'env',
+            __('Environment', 'kerbcycle'),
+            [$this, 'render_environment_field'],
+            self::OPTION_KEY,
+            'kc_ai_main'
+        );
+
+        add_settings_field(
+            'webhook_url_dev',
+            __('Development webhook URL', 'kerbcycle'),
+            function () {
+                $this->render_webhook_url_field('webhook_url_dev');
+            },
+            self::OPTION_KEY,
+            'kc_ai_main'
+        );
+
+        add_settings_field(
+            'webhook_url_stage',
+            __('Staging webhook URL', 'kerbcycle'),
+            function () {
+                $this->render_webhook_url_field('webhook_url_stage');
+            },
+            self::OPTION_KEY,
+            'kc_ai_main'
+        );
+
+        add_settings_field(
+            'webhook_url_prod',
+            __('Production webhook URL', 'kerbcycle'),
+            function () {
+                $this->render_webhook_url_field('webhook_url_prod');
+            },
+            self::OPTION_KEY,
+            'kc_ai_main'
+        );
+
+        add_settings_field(
+            'timeout',
+            __('Request timeout (s)', 'kerbcycle'),
+            [$this, 'render_timeout_field'],
+            self::OPTION_KEY,
+            'kc_ai_main'
+        );
+    }
+
+    /**
+     * Sanitize saved options.
+     *
+     * @param array $input Raw options.
+     */
+    public function sanitize_options($input)
+    {
+        $input = is_array($input) ? $input : [];
+        $defaults = AiSettingsService::defaults();
+
+        $output = [];
+        $env = isset($input['env']) ? $input['env'] : $defaults['env'];
+        $output['env'] = in_array($env, ['dev', 'stage', 'prod'], true) ? $env : $defaults['env'];
+
+        foreach (['webhook_url_dev', 'webhook_url_stage', 'webhook_url_prod'] as $key) {
+            $output[$key] = esc_url_raw(trim($input[$key] ?? ''));
+        }
+
+        $timeout = isset($input['timeout']) ? (int) $input['timeout'] : $defaults['timeout'];
+        $output['timeout'] = max(1, min(60, $timeout));
+
+        return $output;
+    }
+
+    /**
+     * Render environment selector.
+     */
+    public function render_environment_field()
+    {
+        $options = AiSettingsService::get_options();
+        ?>
+        <select name="<?php echo esc_attr(self::OPTION_KEY); ?>[env]">
+            <option value="dev" <?php selected($options['env'], 'dev'); ?>><?php esc_html_e('Development', 'kerbcycle'); ?></option>
+            <option value="stage" <?php selected($options['env'], 'stage'); ?>><?php esc_html_e('Staging', 'kerbcycle'); ?></option>
+            <option value="prod" <?php selected($options['env'], 'prod'); ?>><?php esc_html_e('Production', 'kerbcycle'); ?></option>
+        </select>
+        <?php
+    }
+
+    /**
+     * Render webhook URL input field.
+     */
+    private function render_webhook_url_field($key)
+    {
+        $options = AiSettingsService::get_options();
+        printf(
+            '<input type="url" size="60" name="%1$s[%2$s]" value="%3$s" placeholder="https://your-n8n.example.com/webhook/..." />',
+            esc_attr(self::OPTION_KEY),
+            esc_attr($key),
+            esc_attr($options[$key])
+        );
+    }
+
+    /**
+     * Render timeout field.
+     */
+    public function render_timeout_field()
+    {
+        $options = AiSettingsService::get_options();
+        printf(
+            '<input type="number" min="1" max="60" name="%1$s[timeout]" value="%2$s" />',
+            esc_attr(self::OPTION_KEY),
+            esc_attr($options['timeout'])
+        );
+    }
+}

--- a/includes/Services/AiSettingsService.php
+++ b/includes/Services/AiSettingsService.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Kerbcycle\QrCode\Services;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Centralized service for managing AI webhook settings.
+ */
+class AiSettingsService
+{
+    private const OPTION_KEY = 'kerbcycle_ai_webhook_options';
+
+    /**
+     * Retrieve stored options merged with defaults.
+     */
+    public static function get_options()
+    {
+        return wp_parse_args(get_option(self::OPTION_KEY, []), self::defaults());
+    }
+
+    /**
+     * Provide default option values.
+     */
+    public static function defaults()
+    {
+        return [
+            'env'                  => 'dev',
+            'webhook_url_dev'      => '',
+            'webhook_url_stage'    => '',
+            'webhook_url_prod'     => '',
+            'timeout'              => 20,
+        ];
+    }
+
+    /**
+     * Determine the active webhook URL based on selected environment.
+     */
+    public static function current_webhook_url($options = null)
+    {
+        $options = $options ?: self::get_options();
+        $environment = $options['env'];
+        $map = [
+            'dev'   => $options['webhook_url_dev'],
+            'stage' => $options['webhook_url_stage'],
+            'prod'  => $options['webhook_url_prod'],
+        ];
+
+        $url = isset($map[$environment]) ? trim((string) $map[$environment]) : '';
+
+        /**
+         * Filter the resolved pickup exception webhook URL.
+         */
+        return apply_filters('kerbcycle/ai/pickup_exception_webhook_url', $url, $options);
+    }
+
+    /**
+     * Determine the configured timeout.
+     */
+    public static function current_timeout($options = null)
+    {
+        $options = $options ?: self::get_options();
+        $timeout = isset($options['timeout']) ? (int) $options['timeout'] : 20;
+
+        return max(1, min(60, $timeout));
+    }
+}

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -148,9 +148,16 @@ class QrService
 
     private function send_pickup_exception_webhook(array $data)
     {
-        $webhook_url = defined('KERBCYCLE_PICKUP_EXCEPTION_WEBHOOK_URL')
-            ? KERBCYCLE_PICKUP_EXCEPTION_WEBHOOK_URL
-            : get_option('kerbcycle_pickup_exception_webhook_url', '');
+        $options = AiSettingsService::get_options();
+        $webhook_url = AiSettingsService::current_webhook_url($options);
+
+        if ($webhook_url === '' && defined('KERBCYCLE_PICKUP_EXCEPTION_WEBHOOK_URL')) {
+            $webhook_url = KERBCYCLE_PICKUP_EXCEPTION_WEBHOOK_URL;
+        }
+
+        if ($webhook_url === '') {
+            $webhook_url = get_option('kerbcycle_pickup_exception_webhook_url', '');
+        }
 
         $webhook_url = is_string($webhook_url) ? trim($webhook_url) : '';
         if ($webhook_url === '') {
@@ -168,7 +175,7 @@ class QrService
 
         $response = wp_remote_post($webhook_url, [
             'method'  => 'POST',
-            'timeout' => 20,
+            'timeout' => AiSettingsService::current_timeout($options),
             'headers' => [
                 'Content-Type' => 'application/json',
             ],


### PR DESCRIPTION
### Motivation
- Use the existing OSRM settings page pattern to provide an admin-manageable way to configure per-environment webhook URLs for the `pickup_exception` → n8n integration. 
- Provide environment-based resolution so the plugin can choose the active webhook without hardcoding URLs or changing the n8n workflow. 

### Description
- Identified the OSRM settings implementation (`includes/Admin/Pages/RoutingPage.php`) as the pattern to follow and added a minimal `AI Settings` page as a submenu under the KerbCycle admin menu. 
- Added `includes/Admin/Pages/AiSettingsPage.php` implementing a Settings API form with `Environment` dropdown and fields for `Development webhook URL`, `Staging webhook URL`, `Production webhook URL`, and a `Request timeout` numeric field, with sanitization via `esc_url_raw` and timeout clamped to `1–60`. 
- Added `includes/Services/AiSettingsService.php` to centralize defaults/options (`kerbcycle_ai_webhook_options`) and provide `current_webhook_url()` and `current_timeout()` helpers to resolve the active URL and timeout from the selected environment. 
- Updated `includes/Services/QrService.php` so `send_pickup_exception_webhook()` uses `AiSettingsService::current_webhook_url()` (with legacy fallbacks to the existing constant/option) and `AiSettingsService::current_timeout()` for the remote request timeout, and registered the page in `includes/Admin/Admin.php`. 

### Testing
- Ran PHP syntax checks with `php -l` against the modified/new files and all returned `No syntax errors detected` for `includes/Admin/Pages/AiSettingsPage.php`, `includes/Services/AiSettingsService.php`, `includes/Services/QrService.php`, and `includes/Admin/Admin.php`. 
- No other automated test suites were executed in this patch; manual admin UI verification is expected when the plugin is activated in a WordPress instance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c853edb8ac832da8d89aab00c5b603)