### PR TITLE
Add minimal admin Pickup Exception submission flow

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -634,10 +634,22 @@ function initKerbcycleAdmin() {
   const aiStatus = document.getElementById("kerbcycle-ai-status");
   const aiResult = document.getElementById("kerbcycle-ai-result");
   const pickupExceptionTestBtn = document.getElementById(
-    "kerbcycle-test-pickup-exception",
+    "kerbcycle-submit-pickup-exception",
   );
   const pickupExceptionTestResult = document.getElementById(
     "kerbcycle-ai-test-result",
+  );
+  const pickupExceptionQrCode = document.getElementById(
+    "kerbcycle-pickup-exception-qr-code",
+  );
+  const pickupExceptionCustomerId = document.getElementById(
+    "kerbcycle-pickup-exception-customer-id",
+  );
+  const pickupExceptionIssue = document.getElementById(
+    "kerbcycle-pickup-exception-issue",
+  );
+  const pickupExceptionNotes = document.getElementById(
+    "kerbcycle-pickup-exception-notes",
   );
 
   function renderAiList(items) {
@@ -765,14 +777,21 @@ function initKerbcycleAdmin() {
     pickupExceptionTestBtn.addEventListener("click", function () {
       const originalText = pickupExceptionTestBtn.textContent;
       pickupExceptionTestBtn.disabled = true;
-      pickupExceptionTestBtn.textContent = "Testing...";
+      pickupExceptionTestBtn.textContent = "Submitting...";
       if (pickupExceptionTestResult) {
-        pickupExceptionTestResult.textContent = "Loading AI webhook response...";
+        pickupExceptionTestResult.textContent = "Saving and sending pickup exception...";
       }
 
       const params = new URLSearchParams();
       params.append("action", "kerbcycle_test_pickup_exception");
       params.append("security", kerbcycle_ajax.nonce);
+      params.append("qr_code", pickupExceptionQrCode ? pickupExceptionQrCode.value : "");
+      params.append(
+        "customer_id",
+        pickupExceptionCustomerId ? pickupExceptionCustomerId.value : "",
+      );
+      params.append("issue", pickupExceptionIssue ? pickupExceptionIssue.value : "");
+      params.append("notes", pickupExceptionNotes ? pickupExceptionNotes.value : "");
 
       fetch(kerbcycle_ajax.ajax_url, {
         method: "POST",
@@ -784,7 +803,17 @@ function initKerbcycleAdmin() {
         .then((res) => res.json())
         .then((data) => {
           if (pickupExceptionTestResult) {
-            pickupExceptionTestResult.textContent = JSON.stringify(data, null, 2);
+            const payload = data && data.data ? data.data : {};
+            const output = {
+              status: payload.status || (data.success ? "success" : "error"),
+              message: payload.message || "",
+              local_save: payload.local_save || { success: false },
+              webhook: payload.webhook || {},
+              ai_summary: payload.ai_summary || "",
+              ai_category: payload.ai_category || "",
+              ai_severity: payload.ai_severity || "",
+            };
+            pickupExceptionTestResult.textContent = JSON.stringify(output, null, 2);
           }
         })
         .catch((error) => {

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -10,6 +10,7 @@ use Kerbcycle\QrCode\Services\ReportService;
 use Kerbcycle\QrCode\Services\QrService;
 use Kerbcycle\QrCode\Helpers\Nonces;
 use Kerbcycle\QrCode\Data\Repositories\MessageLogRepository;
+use Kerbcycle\QrCode\Data\Repositories\ErrorLogRepository;
 use Kerbcycle\QrCode\Admin\Pages\DashboardPage;
 
 /**
@@ -401,31 +402,99 @@ class AdminAjax
 
     public function test_pickup_exception()
     {
-        // TEMPORARY ADMIN TEST HOOK FOR AI / n8n INTEGRATION
         Nonces::verify('kerbcycle_qr_nonce', 'security');
         if (!current_user_can('manage_options')) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
 
+        $qr_code_raw = isset($_POST['qr_code']) ? wp_unslash($_POST['qr_code']) : '';
+        $customer_id_raw = isset($_POST['customer_id']) ? wp_unslash($_POST['customer_id']) : '';
+        $issue_raw = isset($_POST['issue']) ? wp_unslash($_POST['issue']) : '';
+        $notes_raw = isset($_POST['notes']) ? wp_unslash($_POST['notes']) : '';
+        $timestamp_raw = isset($_POST['timestamp']) ? wp_unslash($_POST['timestamp']) : '';
+
+        $qr_code = sanitize_text_field($qr_code_raw);
+        $customer_id = absint($customer_id_raw);
+        $issue = sanitize_text_field($issue_raw);
+        $notes = sanitize_textarea_field($notes_raw);
+        $timestamp = sanitize_text_field($timestamp_raw);
+        if ($timestamp === '') {
+            $timestamp = gmdate('c');
+        }
+
+        if ($issue === '') {
+            wp_send_json_error(['message' => __('Issue is required.', 'kerbcycle')], 400);
+        }
+
+        if ($qr_code === '' && $customer_id < 1) {
+            wp_send_json_error(['message' => __('Provide at least a QR Code or Customer ID.', 'kerbcycle')], 400);
+        }
+
+        $payload = [
+            'qr_code'     => $qr_code,
+            'customer_id' => $customer_id,
+            'issue'       => $issue,
+            'notes'       => $notes,
+            'timestamp'   => $timestamp,
+        ];
+
+        // Local save intentionally happens first; webhook delivery must not block local persistence.
+        ErrorLogRepository::log([
+            'type'    => 'pickup_exception',
+            'message' => wp_json_encode($payload),
+            'page'    => 'kerbcycle-qr-manager',
+            'status'  => 'saved',
+        ]);
+
         $result = $this->qr_service->send_pickup_exception_to_n8n([
-            'qr_code'     => 'KC-TEST-1001',
-            'customer_id' => get_current_user_id(),
-            'issue'       => 'bag damaged',
-            'notes'       => 'admin test trigger',
-            'timestamp'   => gmdate('c'),
+            'qr_code'     => $qr_code,
+            'customer_id' => $customer_id,
+            'issue'       => $issue,
+            'notes'       => $notes,
+            'timestamp'   => $timestamp,
         ]);
 
         if (is_wp_error($result)) {
-            wp_send_json_error([
-                'message' => $result->get_error_message(),
-                'code'    => $result->get_error_code(),
+            // Webhook failures return partial success because local persistence already succeeded.
+            wp_send_json_success([
+                'status'      => 'partial_success',
+                'message'     => __('Pickup exception saved locally, but webhook delivery failed.', 'kerbcycle'),
+                'local_save'  => ['success' => true],
+                'webhook'     => [
+                    'success' => false,
+                    'message' => $result->get_error_message(),
+                    'code'    => $result->get_error_code(),
+                ],
+                'ai_summary'  => '',
+                'ai_category' => '',
+                'ai_severity' => '',
             ]);
         }
 
         if (!empty($result['success'])) {
-            wp_send_json_success($result);
+            $body = isset($result['body']) ? $result['body'] : '';
+            $decoded_body = json_decode((string) $body, true);
+            wp_send_json_success([
+                'status'      => 'success',
+                'message'     => __('Pickup exception saved locally and sent to webhook.', 'kerbcycle'),
+                'local_save'  => ['success' => true],
+                'webhook'     => $result,
+                'webhook_body' => $body,
+                'ai_summary'  => is_array($decoded_body) && isset($decoded_body['summary']) ? (string) $decoded_body['summary'] : '',
+                'ai_category' => is_array($decoded_body) && isset($decoded_body['category']) ? (string) $decoded_body['category'] : '',
+                'ai_severity' => is_array($decoded_body) && isset($decoded_body['severity']) ? (string) $decoded_body['severity'] : '',
+            ]);
         }
 
-        wp_send_json_error($result);
+        wp_send_json_success([
+            'status'      => 'partial_success',
+            'message'     => __('Pickup exception saved locally, but webhook delivery failed.', 'kerbcycle'),
+            'local_save'  => ['success' => true],
+            'webhook'     => is_array($result) ? $result : ['success' => false],
+            'webhook_body' => isset($result['body']) ? $result['body'] : '',
+            'ai_summary'  => '',
+            'ai_category' => '',
+            'ai_severity' => '',
+        ]);
     }
 }

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -119,11 +119,20 @@ class DashboardPage
                         </div>
                         <p id="kerbcycle-ai-status" class="description" aria-live="polite"></p>
                         <div id="kerbcycle-ai-result" class="notice inline" style="display:none;"></div>
-                        <?php // TEMPORARY ADMIN TEST HOOK FOR AI / n8n INTEGRATION ?>
                         <div class="kerbcycle-ai-test">
-                            <h3><?php esc_html_e('AI Test (Temporary)', 'kerbcycle'); ?></h3>
-                            <button id="kerbcycle-test-pickup-exception" class="button button-primary">
-                                <?php esc_html_e('Test Pickup Exception → n8n', 'kerbcycle'); ?>
+                            <h3><?php esc_html_e('Pickup Exception', 'kerbcycle'); ?></h3>
+                            <div class="qr-select-group" style="margin-bottom:8px;">
+                                <input type="text" id="kerbcycle-pickup-exception-qr-code" placeholder="<?php esc_attr_e('QR Code', 'kerbcycle'); ?>" />
+                                <input type="number" id="kerbcycle-pickup-exception-customer-id" min="1" step="1" placeholder="<?php esc_attr_e('Customer ID', 'kerbcycle'); ?>" />
+                            </div>
+                            <div class="qr-select-group" style="margin-bottom:8px;">
+                                <input type="text" id="kerbcycle-pickup-exception-issue" placeholder="<?php esc_attr_e('Issue (required)', 'kerbcycle'); ?>" />
+                            </div>
+                            <div class="qr-select-group" style="margin-bottom:8px;">
+                                <textarea id="kerbcycle-pickup-exception-notes" rows="3" style="width:100%;" placeholder="<?php esc_attr_e('Notes', 'kerbcycle'); ?>"></textarea>
+                            </div>
+                            <button id="kerbcycle-submit-pickup-exception" class="button button-primary">
+                                <?php esc_html_e('Submit Pickup Exception', 'kerbcycle'); ?>
                             </button>
                             <pre id="kerbcycle-ai-test-result" style="margin-top:10px;"></pre>
                         </div>


### PR DESCRIPTION
### Motivation
- Replace the temporary admin-only test button with a minimal, operator-entered `Pickup Exception` admin tool that captures real inputs and triggers the existing webhook path. 
- Keep changes surgical and reuse existing admin UI, AJAX pattern, webhook helper, and plugin persistence conventions without redesigning scanner flows. 

### Description
- Replaced the temporary AI test block with a small form on the dashboard (`QR Code`, `Customer ID`, `Issue`, `Notes`) and a `Submit Pickup Exception` button in `includes/Admin/Pages/DashboardPage.php`. 
- Added client-side JS to asynchronously POST the form using the existing AJAX pattern and render a structured response in `#kerbcycle-ai-test-result` in `assets/js/admin.js`. 
- Extended the existing AJAX handler `test_pickup_exception` in `includes/Admin/Ajax/AdminAjax.php` to verify nonce and admin capability, sanitize inputs, require `issue`, require at least one of `qr_code` or `customer_id`, and create a UTC ISO-8601 timestamp when missing. 
- Persisted the exception locally before webhook dispatch using the existing `ErrorLogRepository::log` into `kerbcycle_error_logs`, then called the existing webhook helper `QrService::send_pickup_exception_to_n8n()` and returned either full success or partial-success (local save ok, webhook failed) responses. 

### Testing
- Ran PHP linting on modified PHP files with `php -l includes/Admin/Pages/DashboardPage.php` and `php -l includes/Admin/Ajax/AdminAjax.php`, both succeeded. 
- Validated front-end bundle syntax with Node by loading `assets/js/admin.js` via `node -e "new Function(require('fs').readFileSync('assets/js/admin.js','utf8')); console.log('admin.js syntax ok')"`, which succeeded. 
- No integration tests run; manual browser verification recommended to confirm admin rendering, AJAX submission, and webhook interactions in a staging environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c86dd80cd4832da9557cbe15641d8b)