### PR TITLE
Add local pickup exception persistence and update admin flow to save before webhook

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -11,6 +11,7 @@ use Kerbcycle\QrCode\Services\QrService;
 use Kerbcycle\QrCode\Helpers\Nonces;
 use Kerbcycle\QrCode\Data\Repositories\MessageLogRepository;
 use Kerbcycle\QrCode\Data\Repositories\ErrorLogRepository;
+use Kerbcycle\QrCode\Data\Repositories\PickupExceptionRepository;
 use Kerbcycle\QrCode\Admin\Pages\DashboardPage;
 
 /**
@@ -438,6 +439,22 @@ class AdminAjax
             'timestamp'   => $timestamp,
         ];
 
+        $now_utc_mysql = current_time('mysql', true);
+        $exception_id = PickupExceptionRepository::create([
+            'qr_code'      => $qr_code,
+            'customer_id'  => $customer_id,
+            'issue'        => $issue,
+            'notes'        => $notes,
+            'submitted_at' => $timestamp,
+            'webhook_sent' => 0,
+            'created_at'   => $now_utc_mysql,
+            'updated_at'   => $now_utc_mysql,
+        ]);
+
+        if ($exception_id < 1) {
+            wp_send_json_error(['message' => __('Failed to save pickup exception locally.', 'kerbcycle')], 500);
+        }
+
         // Local save intentionally happens first; webhook delivery must not block local persistence.
         ErrorLogRepository::log([
             'type'    => 'pickup_exception',
@@ -455,16 +472,29 @@ class AdminAjax
         ]);
 
         if (is_wp_error($result)) {
+            PickupExceptionRepository::update_result($exception_id, [
+                'webhook_sent'             => 0,
+                'webhook_status_code'      => 0,
+                'webhook_response_body'    => $result->get_error_message(),
+                'ai_severity'              => '',
+                'ai_category'              => '',
+                'ai_summary'               => '',
+                'ai_recommended_action'    => '',
+                'updated_at'               => current_time('mysql', true),
+            ]);
+
             // Webhook failures return partial success because local persistence already succeeded.
             wp_send_json_success([
                 'status'      => 'partial_success',
                 'message'     => __('Pickup exception saved locally, but webhook delivery failed.', 'kerbcycle'),
-                'local_save'  => ['success' => true],
+                'exception_id' => $exception_id,
+                'local_save'  => ['success' => true, 'id' => $exception_id],
                 'webhook'     => [
                     'success' => false,
                     'message' => $result->get_error_message(),
                     'code'    => $result->get_error_code(),
                 ],
+                'ai_recommended_action' => '',
                 'ai_summary'  => '',
                 'ai_category' => '',
                 'ai_severity' => '',
@@ -474,24 +504,56 @@ class AdminAjax
         if (!empty($result['success'])) {
             $body = isset($result['body']) ? $result['body'] : '';
             $decoded_body = json_decode((string) $body, true);
+            $ai_summary = is_array($decoded_body) && isset($decoded_body['summary']) ? (string) $decoded_body['summary'] : '';
+            $ai_category = is_array($decoded_body) && isset($decoded_body['category']) ? (string) $decoded_body['category'] : '';
+            $ai_severity = is_array($decoded_body) && isset($decoded_body['severity']) ? (string) $decoded_body['severity'] : '';
+            $ai_recommended_action = is_array($decoded_body) && isset($decoded_body['recommended_action']) ? (string) $decoded_body['recommended_action'] : '';
+
+            PickupExceptionRepository::update_result($exception_id, [
+                'webhook_sent'             => 1,
+                'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+                'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
+                'ai_severity'              => $ai_severity,
+                'ai_category'              => $ai_category,
+                'ai_summary'               => $ai_summary,
+                'ai_recommended_action'    => $ai_recommended_action,
+                'updated_at'               => current_time('mysql', true),
+            ]);
+
             wp_send_json_success([
                 'status'      => 'success',
                 'message'     => __('Pickup exception saved locally and sent to webhook.', 'kerbcycle'),
-                'local_save'  => ['success' => true],
+                'exception_id' => $exception_id,
+                'local_save'  => ['success' => true, 'id' => $exception_id],
                 'webhook'     => $result,
                 'webhook_body' => $body,
-                'ai_summary'  => is_array($decoded_body) && isset($decoded_body['summary']) ? (string) $decoded_body['summary'] : '',
-                'ai_category' => is_array($decoded_body) && isset($decoded_body['category']) ? (string) $decoded_body['category'] : '',
-                'ai_severity' => is_array($decoded_body) && isset($decoded_body['severity']) ? (string) $decoded_body['severity'] : '',
+                'ai_recommended_action' => $ai_recommended_action,
+                'ai_summary'  => $ai_summary,
+                'ai_category' => $ai_category,
+                'ai_severity' => $ai_severity,
             ]);
         }
+
+        $result_body = isset($result['body']) ? $result['body'] : '';
+        PickupExceptionRepository::update_result($exception_id, [
+            'webhook_sent'             => 0,
+            'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+            'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
+            'ai_severity'              => '',
+            'ai_category'              => '',
+            'ai_summary'               => '',
+            'ai_recommended_action'    => '',
+            'updated_at'               => current_time('mysql', true),
+        ]);
 
         wp_send_json_success([
             'status'      => 'partial_success',
             'message'     => __('Pickup exception saved locally, but webhook delivery failed.', 'kerbcycle'),
-            'local_save'  => ['success' => true],
+            'exception_id' => $exception_id,
+            'local_save'  => ['success' => true, 'id' => $exception_id],
             'webhook'     => is_array($result) ? $result : ['success' => false],
             'webhook_body' => isset($result['body']) ? $result['body'] : '',
+            'ai_recommended_action' => '',
             'ai_summary'  => '',
             'ai_category' => '',
             'ai_severity' => '',

--- a/includes/Data/Repositories/PickupExceptionRepository.php
+++ b/includes/Data/Repositories/PickupExceptionRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Kerbcycle\QrCode\Data\Repositories;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class PickupExceptionRepository
+{
+    public static function create(array $args)
+    {
+        global $wpdb;
+
+        $table = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
+        $inserted = $wpdb->insert($table, $args, [
+            '%s', // qr_code
+            '%d', // customer_id
+            '%s', // issue
+            '%s', // notes
+            '%s', // submitted_at
+            '%d', // webhook_sent
+            '%s', // created_at
+            '%s', // updated_at
+        ]);
+
+        if ($inserted === false) {
+            return 0;
+        }
+
+        return (int) $wpdb->insert_id;
+    }
+
+    public static function update_result($id, array $args)
+    {
+        global $wpdb;
+
+        $table = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
+        return $wpdb->update(
+            $table,
+            $args,
+            ['id' => (int) $id],
+            ['%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s'],
+            ['%d']
+        );
+    }
+}

--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -115,5 +115,31 @@ class Activator
         ) $charset_collate;";
 
         dbDelta($sql);
+
+        // Create pickup exceptions table
+        $pickup_exceptions_table = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
+        $sql = "CREATE TABLE $pickup_exceptions_table (
+            id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+            qr_code VARCHAR(255) DEFAULT '',
+            customer_id BIGINT(20) UNSIGNED DEFAULT 0,
+            issue VARCHAR(255) NOT NULL,
+            notes LONGTEXT,
+            submitted_at VARCHAR(50) NOT NULL,
+            webhook_sent TINYINT(1) NOT NULL DEFAULT 0,
+            webhook_status_code INT DEFAULT NULL,
+            webhook_response_body LONGTEXT,
+            ai_severity VARCHAR(100) DEFAULT '',
+            ai_category VARCHAR(100) DEFAULT '',
+            ai_summary LONGTEXT,
+            ai_recommended_action LONGTEXT,
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL,
+            PRIMARY KEY  (id),
+            KEY created_at_idx (created_at),
+            KEY submitted_at_idx (submitted_at),
+            KEY webhook_sent_idx (webhook_sent)
+        ) $charset_collate;";
+
+        dbDelta($sql);
     }
 }


### PR DESCRIPTION
### Motivation
- Insert a minimal local source-of-truth for pickup exceptions where the plugin already manages DB tables, and ensure admin submissions persist locally before any webhook delivery. The existing activation path `Activator::activate()` is the natural insertion point for a plugin-managed table. 
- Use the existing admin handler `test_pickup_exception()` in `includes/Admin/Ajax/AdminAjax.php` as the minimal touchpoint for saving and reconciling webhook/AI results.

### Description
- Added a new DB table via the existing activation/dbDelta flow in `includes/Install/Activator.php`: `{$wpdb->prefix}kerbcycle_pickup_exceptions` with the requested schema fields (id, qr_code, customer_id, issue, notes, submitted_at, webhook_sent, webhook_status_code, webhook_response_body, ai_severity, ai_category, ai_summary, ai_recommended_action, created_at, updated_at). 
- Added a minimal repository `PickupExceptionRepository` (`includes/Data/Repositories/PickupExceptionRepository.php`) with `create()` for the initial insert and `update_result()` for writing webhook/AI outcome fields back to the saved row. 
- Updated the admin AJAX flow in `includes/Admin/Ajax/AdminAjax.php` (`test_pickup_exception`) to: sanitize inputs as before; create a UTC timestamp fallback; insert the local exception row first (primary source of truth); call the existing webhook helper unchanged; update the saved record with webhook and AI results on success or failure; and return `exception_id`, `local_save` and clear webhook success/failure indicators in the AJAX response. The existing `ErrorLogRepository::log()` behavior is left intact as supplemental logging. 

Patch summary:
- Files changed: `includes/Install/Activator.php`, `includes/Data/Repositories/PickupExceptionRepository.php`, `includes/Admin/Ajax/AdminAjax.php`.
- Table added: `{$wpdb->prefix}kerbcycle_pickup_exceptions` (new, not reusing error logs).
- Fields stored locally on initial save: `qr_code`, `customer_id`, `issue`, `notes`, `submitted_at`, `webhook_sent = 0`, `created_at`, `updated_at`.
- Fields written back after webhook: `webhook_sent`, `webhook_status_code`, `webhook_response_body`, `ai_severity`, `ai_category`, `ai_summary`, `ai_recommended_action`, `updated_at` via `PickupExceptionRepository::update_result()` called from `test_pickup_exception()`.
- Non-blocking behavior: local insert occurs before webhook dispatch and the local record remains persisted even if webhook delivery fails.

### Testing
- Ran PHP lint checks: `php -l includes/Install/Activator.php`, `php -l includes/Data/Repositories/PickupExceptionRepository.php`, `php -l includes/Admin/Ajax/AdminAjax.php` and all returned "No syntax errors detected". (succeeded)
- Verified changes staged/committed and file diffs; no runtime/unit tests were present for this flow in the repository. (inspection only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c877e7a0d8832d8fa0dc3498e3293a)