### PR TITLE
Persist pickup exception records before webhook and update row with webhook/AI results

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -11,7 +11,6 @@ use Kerbcycle\QrCode\Services\QrService;
 use Kerbcycle\QrCode\Helpers\Nonces;
 use Kerbcycle\QrCode\Data\Repositories\MessageLogRepository;
 use Kerbcycle\QrCode\Data\Repositories\ErrorLogRepository;
-use Kerbcycle\QrCode\Data\Repositories\PickupExceptionRepository;
 use Kerbcycle\QrCode\Admin\Pages\DashboardPage;
 
 /**
@@ -439,8 +438,10 @@ class AdminAjax
             'timestamp'   => $timestamp,
         ];
 
+        global $wpdb;
+        $pickup_exceptions_table = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
         $now_utc_mysql = current_time('mysql', true);
-        $exception_id = PickupExceptionRepository::create([
+        $inserted = $wpdb->insert($pickup_exceptions_table, [
             'qr_code'      => $qr_code,
             'customer_id'  => $customer_id,
             'issue'        => $issue,
@@ -449,9 +450,20 @@ class AdminAjax
             'webhook_sent' => 0,
             'created_at'   => $now_utc_mysql,
             'updated_at'   => $now_utc_mysql,
+        ], [
+            '%s',
+            '%d',
+            '%s',
+            '%s',
+            '%s',
+            '%d',
+            '%s',
+            '%s',
         ]);
+        $exception_id = (int) $wpdb->insert_id;
 
-        if ($exception_id < 1) {
+        if ($inserted === false || $exception_id < 1) {
+            error_log('KerbCycle pickup exception DB insert failed: ' . $wpdb->last_error);
             wp_send_json_error(['message' => __('Failed to save pickup exception locally.', 'kerbcycle')], 500);
         }
 
@@ -472,7 +484,7 @@ class AdminAjax
         ]);
 
         if (is_wp_error($result)) {
-            PickupExceptionRepository::update_result($exception_id, [
+            $wpdb->update($pickup_exceptions_table, [
                 'webhook_sent'             => 0,
                 'webhook_status_code'      => 0,
                 'webhook_response_body'    => $result->get_error_message(),
@@ -481,6 +493,19 @@ class AdminAjax
                 'ai_summary'               => '',
                 'ai_recommended_action'    => '',
                 'updated_at'               => current_time('mysql', true),
+            ], [
+                'id' => $exception_id,
+            ], [
+                '%d',
+                '%d',
+                '%s',
+                '%s',
+                '%s',
+                '%s',
+                '%s',
+                '%s',
+            ], [
+                '%d',
             ]);
 
             // Webhook failures return partial success because local persistence already succeeded.
@@ -488,6 +513,7 @@ class AdminAjax
                 'status'      => 'partial_success',
                 'message'     => __('Pickup exception saved locally, but webhook delivery failed.', 'kerbcycle'),
                 'exception_id' => $exception_id,
+                'local_record_id' => $exception_id,
                 'local_save'  => ['success' => true, 'id' => $exception_id],
                 'webhook'     => [
                     'success' => false,
@@ -509,7 +535,7 @@ class AdminAjax
             $ai_severity = is_array($decoded_body) && isset($decoded_body['severity']) ? (string) $decoded_body['severity'] : '';
             $ai_recommended_action = is_array($decoded_body) && isset($decoded_body['recommended_action']) ? (string) $decoded_body['recommended_action'] : '';
 
-            PickupExceptionRepository::update_result($exception_id, [
+            $wpdb->update($pickup_exceptions_table, [
                 'webhook_sent'             => 1,
                 'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
                 'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
@@ -518,12 +544,26 @@ class AdminAjax
                 'ai_summary'               => $ai_summary,
                 'ai_recommended_action'    => $ai_recommended_action,
                 'updated_at'               => current_time('mysql', true),
+            ], [
+                'id' => $exception_id,
+            ], [
+                '%d',
+                '%d',
+                '%s',
+                '%s',
+                '%s',
+                '%s',
+                '%s',
+                '%s',
+            ], [
+                '%d',
             ]);
 
             wp_send_json_success([
                 'status'      => 'success',
                 'message'     => __('Pickup exception saved locally and sent to webhook.', 'kerbcycle'),
                 'exception_id' => $exception_id,
+                'local_record_id' => $exception_id,
                 'local_save'  => ['success' => true, 'id' => $exception_id],
                 'webhook'     => $result,
                 'webhook_body' => $body,
@@ -535,7 +575,7 @@ class AdminAjax
         }
 
         $result_body = isset($result['body']) ? $result['body'] : '';
-        PickupExceptionRepository::update_result($exception_id, [
+        $wpdb->update($pickup_exceptions_table, [
             'webhook_sent'             => 0,
             'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
             'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
@@ -544,12 +584,26 @@ class AdminAjax
             'ai_summary'               => '',
             'ai_recommended_action'    => '',
             'updated_at'               => current_time('mysql', true),
+        ], [
+            'id' => $exception_id,
+        ], [
+            '%d',
+            '%d',
+            '%s',
+            '%s',
+            '%s',
+            '%s',
+            '%s',
+            '%s',
+        ], [
+            '%d',
         ]);
 
         wp_send_json_success([
             'status'      => 'partial_success',
             'message'     => __('Pickup exception saved locally, but webhook delivery failed.', 'kerbcycle'),
             'exception_id' => $exception_id,
+            'local_record_id' => $exception_id,
             'local_save'  => ['success' => true, 'id' => $exception_id],
             'webhook'     => is_array($result) ? $result : ['success' => false],
             'webhook_body' => isset($result['body']) ? $result['body'] : '',


### PR DESCRIPTION
### Motivation
- Handler patched: `AdminAjax::test_pickup_exception()` (AJAX action `wp_ajax_kerbcycle_test_pickup_exception`) in `includes/Admin/Ajax/AdminAjax.php` to make the DB the primary persistence for pickup exceptions. 
- The intent is to insert a structured record into `kerbcycle_pickup_exceptions` before calling the webhook helper and then update that same row with webhook/AI results so the record exists even if webhook delivery fails.

### Description
- Insert a local row directly into `$wpdb->prefix . 'kerbcycle_pickup_exceptions'` before invoking `send_pickup_exception_to_n8n()`, saving `qr_code`, `customer_id`, `issue`, `notes`, `submitted_at`, `webhook_sent = 0`, `created_at`, and `updated_at`, and capturing `$wpdb->insert_id` as the canonical record id. 
- If the insert fails the code logs `$wpdb->last_error` and returns a clear AJAX error response `Failed to save pickup exception locally.`. 
- After the webhook returns, the code updates the same DB row (`id = $exception_id`) with `webhook_sent`, `webhook_status_code`, `webhook_response_body`, `ai_severity`, `ai_category`, `ai_summary`, `ai_recommended_action`, and `updated_at` across the WP_Error, success, and non-success branches. 
- The existing `ErrorLogRepository::log(...)` call is preserved and the AJAX responses now include `local_record_id` so callers can distinguish local save success from webhook success.

Patch summary:
- files changed: `includes/Admin/Ajax/AdminAjax.php` only. 
- insert point added: direct `$wpdb->insert()` into `$wpdb->prefix . 'kerbcycle_pickup_exceptions'` before webhook call and capture `$wpdb->insert_id`. 
- update point added: `$wpdb->update()` on `id = $exception_id` to store webhook and AI outcome fields in all result branches. 
- AJAX response additions: include `local_record_id` in success/partial-success responses and preserve `local_save` information. 
- error logging preserved: existing `ErrorLogRepository::log(...)` kept and `$wpdb->last_error` is logged on insert failure.

### Testing
- Ran PHP syntax check `php -l includes/Admin/Ajax/AdminAjax.php` which returned no syntax errors. 
- Verified changes staged and committed to the repository with a commit message and `git status` showing the single modified file. 
- No automated unit tests were present or run; runtime behavior should be validated in an environment where the `kerbcycle_pickup_exceptions` table exists and the webhook endpoint is reachable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c88741237c832d8c4012d9bb8c092b)