### PR TITLE
Add wp-admin Pickup Exceptions read-only list page

### DIFF
--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -117,6 +117,16 @@ class Admin
             [new Pages\ErrorsPage(), 'render']
         );
 
+
+        add_submenu_page(
+            'kerbcycle-qr-manager',
+            'Pickup Exceptions',
+            'Pickup Exceptions',
+            'manage_options',
+            'kerbcycle-pickup-exceptions',
+            [new Pages\PickupExceptionsPage(), 'render']
+        );
+
         add_submenu_page(
             'kerbcycle-qr-manager',
             'Settings',

--- a/includes/Admin/Pages/PickupExceptionsPage.php
+++ b/includes/Admin/Pages/PickupExceptionsPage.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Kerbcycle\QrCode\Admin\Pages;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Admin page to display pickup exception logs.
+ */
+class PickupExceptionsPage
+{
+    public function render()
+    {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
+        $limit = 50;
+
+        $sql = $wpdb->prepare(
+            "SELECT id, submitted_at, qr_code, customer_id, issue, ai_severity, ai_category, webhook_sent, ai_recommended_action, ai_summary
+            FROM {$table_name}
+            ORDER BY id DESC
+            LIMIT %d",
+            $limit
+        );
+
+        $records = $wpdb->get_results($sql);
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Pickup Exceptions', 'kerbcycle'); ?></h1>
+            <p><?php esc_html_e('This page shows locally stored pickup exceptions and webhook/AI outcome data.', 'kerbcycle'); ?></p>
+
+            <table class="wp-list-table widefat fixed striped">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e('ID', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Submitted At', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('QR Code', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Customer ID', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Issue', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Severity', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Category', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Webhook Sent', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Recommended Action', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('AI Summary', 'kerbcycle'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php if (empty($records)) : ?>
+                    <tr>
+                        <td colspan="10"><?php esc_html_e('No pickup exceptions found.', 'kerbcycle'); ?></td>
+                    </tr>
+                <?php else : ?>
+                    <?php foreach ($records as $record) : ?>
+                        <tr>
+                            <td><?php echo esc_html($record->id); ?></td>
+                            <td><?php echo esc_html($record->submitted_at); ?></td>
+                            <td><?php echo esc_html($record->qr_code); ?></td>
+                            <td><?php echo esc_html($record->customer_id); ?></td>
+                            <td><?php echo esc_html($record->issue); ?></td>
+                            <td><?php echo esc_html($record->ai_severity); ?></td>
+                            <td><?php echo esc_html($record->ai_category); ?></td>
+                            <td><?php echo esc_html(((int) $record->webhook_sent) === 1 ? 'Yes' : 'No'); ?></td>
+                            <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_recommended_action), 20, '…')); ?></td>
+                            <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_summary), 20, '…')); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal admin-facing view so authorized admins can inspect locally stored `pickup_exception` records and their webhook/AI results without querying the database directly.

### Description
- Register a new `Pickup Exceptions` submenu under the existing KerbCycle `QR Codes` menu in `includes/Admin/Admin.php` and add a small read-only page class `includes/Admin/Pages/PickupExceptionsPage.php` that queries `$wpdb->prefix . 'kerbcycle_pickup_exceptions'` for `id, submitted_at, qr_code, customer_id, issue, ai_severity, ai_category, webhook_sent, ai_recommended_action, ai_summary`, orders by newest first (`ORDER BY id DESC`), limits to the latest 50 rows, and renders an escaped HTML table showing `ID`, `Submitted At`, `QR Code`, `Customer ID`, `Issue`, `Severity`, `Category`, `Webhook Sent` and the optional `Recommended Action` and `AI Summary` (trimmed) while keeping the page fully read-only.

### Testing
- Ran `php -l includes/Admin/Admin.php` and `php -l includes/Admin/Pages/PickupExceptionsPage.php`, and both reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8900ef770832d8e505d0c4931431a)