### PR TITLE
Add admin-only Retry Webhook action for pickup exceptions

### DIFF
--- a/includes/Admin/Pages/PickupExceptionsPage.php
+++ b/includes/Admin/Pages/PickupExceptionsPage.php
@@ -2,6 +2,9 @@
 
 namespace Kerbcycle\QrCode\Admin\Pages;
 
+use Kerbcycle\QrCode\Data\Repositories\PickupExceptionRepository;
+use Kerbcycle\QrCode\Services\QrService;
+
 if (!defined('ABSPATH')) {
     exit;
 }
@@ -16,6 +19,8 @@ class PickupExceptionsPage
         if (!current_user_can('manage_options')) {
             return;
         }
+
+        $this->handle_retry_request();
 
         global $wpdb;
 
@@ -35,6 +40,7 @@ class PickupExceptionsPage
         <div class="wrap">
             <h1><?php esc_html_e('Pickup Exceptions', 'kerbcycle'); ?></h1>
             <p><?php esc_html_e('This page shows locally stored pickup exceptions and webhook/AI outcome data.', 'kerbcycle'); ?></p>
+            <?php $this->render_retry_notice(); ?>
 
             <table class="wp-list-table widefat fixed striped">
                 <thead>
@@ -49,12 +55,13 @@ class PickupExceptionsPage
                         <th><?php esc_html_e('Webhook Sent', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Recommended Action', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('AI Summary', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Actions', 'kerbcycle'); ?></th>
                     </tr>
                 </thead>
                 <tbody>
                 <?php if (empty($records)) : ?>
                     <tr>
-                        <td colspan="10"><?php esc_html_e('No pickup exceptions found.', 'kerbcycle'); ?></td>
+                        <td colspan="11"><?php esc_html_e('No pickup exceptions found.', 'kerbcycle'); ?></td>
                     </tr>
                 <?php else : ?>
                     <?php foreach ($records as $record) : ?>
@@ -69,11 +76,156 @@ class PickupExceptionsPage
                             <td><?php echo esc_html(((int) $record->webhook_sent) === 1 ? 'Yes' : 'No'); ?></td>
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_recommended_action), 20, '…')); ?></td>
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_summary), 20, '…')); ?></td>
+                            <td>
+                                <?php if (((int) $record->webhook_sent) === 0) : ?>
+                                    <?php
+                                    $retry_url = wp_nonce_url(
+                                        add_query_arg(
+                                            [
+                                                'page' => 'kerbcycle-pickup-exceptions',
+                                                'kerbcycle_action' => 'retry_pickup_exception',
+                                                'exception_id' => (int) $record->id,
+                                            ],
+                                            admin_url('admin.php')
+                                        ),
+                                        'kerbcycle_retry_pickup_exception_' . (int) $record->id
+                                    );
+                                    ?>
+                                    <a href="<?php echo esc_url($retry_url); ?>" class="button button-small"><?php esc_html_e('Retry Webhook', 'kerbcycle'); ?></a>
+                                <?php else : ?>
+                                    <span aria-hidden="true">—</span>
+                                <?php endif; ?>
+                            </td>
                         </tr>
                     <?php endforeach; ?>
                 <?php endif; ?>
                 </tbody>
             </table>
+        </div>
+        <?php
+    }
+
+    private function handle_retry_request()
+    {
+        if (!isset($_GET['kerbcycle_action']) || $_GET['kerbcycle_action'] !== 'retry_pickup_exception') {
+            return;
+        }
+
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        $exception_id = isset($_GET['exception_id']) ? absint($_GET['exception_id']) : 0;
+        if ($exception_id < 1) {
+            $this->redirect_with_retry_notice('error', __('Invalid pickup exception ID.', 'kerbcycle'));
+        }
+
+        check_admin_referer('kerbcycle_retry_pickup_exception_' . $exception_id);
+
+        global $wpdb;
+        $table_name = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
+        $record = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table_name} WHERE id = %d", $exception_id));
+
+        if (!$record) {
+            $this->redirect_with_retry_notice('error', __('Pickup exception record not found.', 'kerbcycle'));
+        }
+
+        if ((int) $record->webhook_sent === 1) {
+            $this->redirect_with_retry_notice('error', __('This pickup exception is not eligible for retry.', 'kerbcycle'));
+        }
+
+        $result = (new QrService())->send_pickup_exception_to_n8n([
+            'qr_code'     => (string) $record->qr_code,
+            'customer_id' => (int) $record->customer_id,
+            'issue'       => (string) $record->issue,
+            'notes'       => (string) $record->notes,
+            'timestamp'   => !empty($record->submitted_at) ? (string) $record->submitted_at : '',
+        ]);
+
+        if (is_wp_error($result)) {
+            PickupExceptionRepository::update_result($exception_id, [
+                'webhook_sent'             => 0,
+                'webhook_status_code'      => 0,
+                'webhook_response_body'    => $result->get_error_message(),
+                'ai_severity'              => '',
+                'ai_category'              => '',
+                'ai_summary'               => '',
+                'ai_recommended_action'    => '',
+                'updated_at'               => current_time('mysql', true),
+            ]);
+
+            $this->redirect_with_retry_notice('error', __('Retry failed. The record remains saved locally.', 'kerbcycle'));
+        }
+
+        if (!empty($result['success'])) {
+            $body = isset($result['body']) ? $result['body'] : '';
+            $decoded_body = json_decode((string) $body, true);
+            $ai_summary = is_array($decoded_body) && isset($decoded_body['summary']) ? (string) $decoded_body['summary'] : '';
+            $ai_category = is_array($decoded_body) && isset($decoded_body['category']) ? (string) $decoded_body['category'] : '';
+            $ai_severity = is_array($decoded_body) && isset($decoded_body['severity']) ? (string) $decoded_body['severity'] : '';
+            $ai_recommended_action = is_array($decoded_body) && isset($decoded_body['recommended_action']) ? (string) $decoded_body['recommended_action'] : '';
+
+            PickupExceptionRepository::update_result($exception_id, [
+                'webhook_sent'             => 1,
+                'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+                'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
+                'ai_severity'              => $ai_severity,
+                'ai_category'              => $ai_category,
+                'ai_summary'               => $ai_summary,
+                'ai_recommended_action'    => $ai_recommended_action,
+                'updated_at'               => current_time('mysql', true),
+            ]);
+
+            $this->redirect_with_retry_notice('success', __('Pickup exception resent successfully.', 'kerbcycle'));
+        }
+
+        $result_body = isset($result['body']) ? $result['body'] : '';
+        PickupExceptionRepository::update_result($exception_id, [
+            'webhook_sent'             => 0,
+            'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+            'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
+            'ai_severity'              => '',
+            'ai_category'              => '',
+            'ai_summary'               => '',
+            'ai_recommended_action'    => '',
+            'updated_at'               => current_time('mysql', true),
+        ]);
+
+        $this->redirect_with_retry_notice('error', __('Retry failed. The record remains saved locally.', 'kerbcycle'));
+    }
+
+    private function redirect_with_retry_notice($status, $message)
+    {
+        $redirect_url = add_query_arg(
+            [
+                'page' => 'kerbcycle-pickup-exceptions',
+                'retry_status' => sanitize_key((string) $status),
+                'retry_message' => (string) $message,
+            ],
+            admin_url('admin.php')
+        );
+
+        wp_safe_redirect($redirect_url);
+        exit;
+    }
+
+    private function render_retry_notice()
+    {
+        if (!isset($_GET['retry_status'])) {
+            return;
+        }
+
+        $status = sanitize_key(wp_unslash($_GET['retry_status']));
+        $message = isset($_GET['retry_message']) ? sanitize_text_field(wp_unslash((string) $_GET['retry_message'])) : '';
+
+        if ($message === '') {
+            return;
+        }
+
+        $notice_class = $status === 'success' ? 'notice notice-success' : 'notice notice-error';
+        ?>
+        <div class="<?php echo esc_attr($notice_class); ?> is-dismissible">
+            <p><?php echo esc_html($message); ?></p>
         </div>
         <?php
     }


### PR DESCRIPTION
### Motivation
- The admin page that lists locally saved pickup exceptions (`includes/Admin/Pages/PickupExceptionsPage.php`) should allow an authorized admin to resend failed webhook deliveries without changing the stored record.
- The safest minimal insertion point is inside `render()` before output so the retry request can be handled in the same page lifecycle (`$this->handle_retry_request()`), preserving existing patterns and keeping the page read-only except for a single retry action.

### Description
- Added a minimal `Actions` column and per-row `Retry Webhook` button shown only when `webhook_sent === 0`, using a per-record nonce via `wp_nonce_url()` so only eligible rows expose the action.
- Implemented `handle_retry_request()` inside `PickupExceptionsPage` that enforces capability `manage_options`, verifies the per-record nonce with `check_admin_referer()`, loads the record from the existing `kerbcycle_pickup_exceptions` table by ID, checks eligibility, rebuilds the webhook payload from stored fields and calls the existing helper `QrService::send_pickup_exception_to_n8n()`.
- On result, updates the same local row via the existing repository pattern `PickupExceptionRepository::update_result()` with fields: `webhook_sent`, `webhook_status_code`, `webhook_response_body`, `ai_severity`, `ai_category`, `ai_summary`, `ai_recommended_action`, and `updated_at` (no insert, no duplicate record creation).
- Adds simple admin notices via query args and `render_retry_notice()` that display success or clean error messages after redirect, keeping UI styling minimal and consistent.
- Files changed: `includes/Admin/Pages/PickupExceptionsPage.php` only; no refactors, renames or other pages touched.

### Testing
- Syntax check: `php -l includes/Admin/Pages/PickupExceptionsPage.php` completed with no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdb7e665bc832d929127412ad8079e)