### PR TITLE
Add pickup-exception `status` lifecycle and admin badges

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -447,6 +447,7 @@ class AdminAjax
             'notes'        => $notes,
             'submitted_at' => $timestamp,
             'webhook_sent' => 0,
+            'status'       => 'pending',
             'created_at'   => $now_utc_mysql,
             'updated_at'   => $now_utc_mysql,
         ]);
@@ -474,6 +475,7 @@ class AdminAjax
         if (is_wp_error($result)) {
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 0,
+                'status'                   => 'failed',
                 'webhook_status_code'      => 0,
                 'webhook_response_body'    => $result->get_error_message(),
                 'ai_severity'              => '',
@@ -511,6 +513,7 @@ class AdminAjax
 
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 1,
+                'status'                   => 'sent',
                 'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
                 'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
                 'ai_severity'              => $ai_severity,
@@ -537,6 +540,7 @@ class AdminAjax
         $result_body = isset($result['body']) ? $result['body'] : '';
         PickupExceptionRepository::update_result($exception_id, [
             'webhook_sent'             => 0,
+            'status'                   => 'failed',
             'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
             'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
             'ai_severity'              => '',

--- a/includes/Admin/Pages/PickupExceptionsPage.php
+++ b/includes/Admin/Pages/PickupExceptionsPage.php
@@ -28,7 +28,7 @@ class PickupExceptionsPage
         $limit = 50;
 
         $sql = $wpdb->prepare(
-            "SELECT id, submitted_at, qr_code, customer_id, issue, ai_severity, ai_category, webhook_sent, ai_recommended_action, ai_summary
+            "SELECT id, submitted_at, qr_code, customer_id, issue, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary
             FROM {$table_name}
             ORDER BY id DESC
             LIMIT %d",
@@ -41,6 +41,30 @@ class PickupExceptionsPage
             <h1><?php esc_html_e('Pickup Exceptions', 'kerbcycle'); ?></h1>
             <p><?php esc_html_e('This page shows locally stored pickup exceptions and webhook/AI outcome data.', 'kerbcycle'); ?></p>
             <?php $this->render_retry_notice(); ?>
+            <style>
+                .kerb-badge {
+                    display: inline-block;
+                    padding: 2px 8px;
+                    border-radius: 12px;
+                    font-size: 12px;
+                    font-weight: 600;
+                }
+
+                .kerb-badge-success {
+                    background: #d1fae5;
+                    color: #065f46;
+                }
+
+                .kerb-badge-error {
+                    background: #fee2e2;
+                    color: #7f1d1d;
+                }
+
+                .kerb-badge-pending {
+                    background: #fef3c7;
+                    color: #92400e;
+                }
+            </style>
 
             <table class="wp-list-table widefat fixed striped">
                 <thead>
@@ -52,7 +76,7 @@ class PickupExceptionsPage
                         <th><?php esc_html_e('Issue', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Severity', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Category', 'kerbcycle'); ?></th>
-                        <th><?php esc_html_e('Webhook Sent', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Recommended Action', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('AI Summary', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Actions', 'kerbcycle'); ?></th>
@@ -73,7 +97,18 @@ class PickupExceptionsPage
                             <td><?php echo esc_html($record->issue); ?></td>
                             <td><?php echo esc_html($record->ai_severity); ?></td>
                             <td><?php echo esc_html($record->ai_category); ?></td>
-                            <td><?php echo esc_html(((int) $record->webhook_sent) === 1 ? 'Yes' : 'No'); ?></td>
+                            <td>
+                                <?php
+                                $status = isset($record->status) ? (string) $record->status : (((int) $record->webhook_sent) === 1 ? 'sent' : 'failed');
+                                if ($status === 'sent') {
+                                    echo '<span class="kerb-badge kerb-badge-success">' . esc_html__('Sent', 'kerbcycle') . '</span>';
+                                } elseif ($status === 'failed') {
+                                    echo '<span class="kerb-badge kerb-badge-error">' . esc_html__('Failed', 'kerbcycle') . '</span>';
+                                } else {
+                                    echo '<span class="kerb-badge kerb-badge-pending">' . esc_html__('Pending', 'kerbcycle') . '</span>';
+                                }
+                                ?>
+                            </td>
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_recommended_action), 20, '…')); ?></td>
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_summary), 20, '…')); ?></td>
                             <td>
@@ -145,6 +180,7 @@ class PickupExceptionsPage
         if (is_wp_error($result)) {
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 0,
+                'status'                   => 'failed',
                 'webhook_status_code'      => 0,
                 'webhook_response_body'    => $result->get_error_message(),
                 'ai_severity'              => '',
@@ -167,6 +203,7 @@ class PickupExceptionsPage
 
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 1,
+                'status'                   => 'sent',
                 'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
                 'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
                 'ai_severity'              => $ai_severity,
@@ -182,6 +219,7 @@ class PickupExceptionsPage
         $result_body = isset($result['body']) ? $result['body'] : '';
         PickupExceptionRepository::update_result($exception_id, [
             'webhook_sent'             => 0,
+            'status'                   => 'failed',
             'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
             'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
             'ai_severity'              => '',

--- a/includes/Data/Repositories/PickupExceptionRepository.php
+++ b/includes/Data/Repositories/PickupExceptionRepository.php
@@ -20,6 +20,7 @@ class PickupExceptionRepository
             '%s', // notes
             '%s', // submitted_at
             '%d', // webhook_sent
+            '%s', // status
             '%s', // created_at
             '%s', // updated_at
         ]);
@@ -40,7 +41,7 @@ class PickupExceptionRepository
             $table,
             $args,
             ['id' => (int) $id],
-            ['%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s'],
+            ['%d', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s'],
             ['%d']
         );
     }

--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -126,6 +126,7 @@ class Activator
             notes LONGTEXT,
             submitted_at VARCHAR(50) NOT NULL,
             webhook_sent TINYINT(1) NOT NULL DEFAULT 0,
+            status VARCHAR(20) DEFAULT 'pending',
             webhook_status_code INT DEFAULT NULL,
             webhook_response_body LONGTEXT,
             ai_severity VARCHAR(100) DEFAULT '',


### PR DESCRIPTION
### Motivation
- Provide a clear lifecycle for pickup exceptions (pending → sent → failed) instead of the current binary `webhook_sent` display so admins can see processing state and retry behavior at-a-glance.

### Description
- Add `status VARCHAR(20) DEFAULT 'pending'` to the pickup exceptions table schema used by the plugin `dbDelta` SQL (`includes/Install/Activator.php`).
- Initialize new records with `'status' => 'pending'` on create and keep `webhook_sent = 0` for backward compatibility (`includes/Admin/Ajax/AdminAjax.php` and `PickupExceptionRepository::create`).
- Update webhook result persistence in both the initial submit and retry paths to set `status = 'sent'` on success and `status = 'failed'` on failure in addition to updating `webhook_sent` (`includes/Admin/Ajax/AdminAjax.php` and `includes/Admin/Pages/PickupExceptionsPage.php`).
- Expose `status` in the admin list query (`SELECT ..., status`) and replace the “Webhook Sent” column with a `Status` column that renders inline WordPress-native badges for `Sent`, `Failed`, and `Pending` while falling back to `webhook_sent` for older rows (`includes/Admin/Pages/PickupExceptionsPage.php`).
- Add minimal scoped badge CSS (`.kerb-badge`, `.kerb-badge-success`, `.kerb-badge-error`, `.kerb-badge-pending`) inline in the admin page render to keep the change surgical and self-contained.
- Extend `PickupExceptionRepository` bindings so `create` and `update_result` handle the new `status` field without removing any existing fields.

### Testing
- Ran PHP syntax checks with `php -l` on the modified files and all returned "No syntax errors detected" for `includes/Install/Activator.php`, `includes/Data/Repositories/PickupExceptionRepository.php`, `includes/Admin/Ajax/AdminAjax.php`, and `includes/Admin/Pages/PickupExceptionsPage.php`.
- Verified code changes are present via pattern searches (`rg`) for `status` insertion points, badge classes, and admin query changes; expected patterns were found.
- No automated unit tests were changed; the manual smoke checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdc03eae68832d8f3e94951e498855)