### PR TITLE
Add pickup exception status lifecycle and admin badges

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -447,6 +447,7 @@ class AdminAjax
             'notes'        => $notes,
             'submitted_at' => $timestamp,
             'webhook_sent' => 0,
+            'status'       => 'pending',
             'created_at'   => $now_utc_mysql,
             'updated_at'   => $now_utc_mysql,
         ]);
@@ -475,6 +476,7 @@ class AdminAjax
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 0,
                 'webhook_status_code'      => 0,
+                'status'                   => 'failed',
                 'webhook_response_body'    => $result->get_error_message(),
                 'ai_severity'              => '',
                 'ai_category'              => '',
@@ -512,6 +514,7 @@ class AdminAjax
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 1,
                 'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+                'status'                   => 'sent',
                 'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
                 'ai_severity'              => $ai_severity,
                 'ai_category'              => $ai_category,
@@ -538,6 +541,7 @@ class AdminAjax
         PickupExceptionRepository::update_result($exception_id, [
             'webhook_sent'             => 0,
             'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+            'status'                   => 'failed',
             'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
             'ai_severity'              => '',
             'ai_category'              => '',

--- a/includes/Admin/Pages/PickupExceptionsPage.php
+++ b/includes/Admin/Pages/PickupExceptionsPage.php
@@ -28,7 +28,7 @@ class PickupExceptionsPage
         $limit = 50;
 
         $sql = $wpdb->prepare(
-            "SELECT id, submitted_at, qr_code, customer_id, issue, ai_severity, ai_category, webhook_sent, ai_recommended_action, ai_summary
+            "SELECT id, submitted_at, qr_code, customer_id, issue, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary
             FROM {$table_name}
             ORDER BY id DESC
             LIMIT %d",
@@ -41,6 +41,27 @@ class PickupExceptionsPage
             <h1><?php esc_html_e('Pickup Exceptions', 'kerbcycle'); ?></h1>
             <p><?php esc_html_e('This page shows locally stored pickup exceptions and webhook/AI outcome data.', 'kerbcycle'); ?></p>
             <?php $this->render_retry_notice(); ?>
+            <style>
+                .kerb-badge {
+                    display: inline-block;
+                    padding: 2px 8px;
+                    border-radius: 12px;
+                    font-size: 12px;
+                    font-weight: 600;
+                }
+                .kerb-badge-success {
+                    background: #d1fae5;
+                    color: #065f46;
+                }
+                .kerb-badge-error {
+                    background: #fee2e2;
+                    color: #7f1d1d;
+                }
+                .kerb-badge-pending {
+                    background: #fef3c7;
+                    color: #92400e;
+                }
+            </style>
 
             <table class="wp-list-table widefat fixed striped">
                 <thead>
@@ -52,7 +73,7 @@ class PickupExceptionsPage
                         <th><?php esc_html_e('Issue', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Severity', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Category', 'kerbcycle'); ?></th>
-                        <th><?php esc_html_e('Webhook Sent', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Recommended Action', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('AI Summary', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Actions', 'kerbcycle'); ?></th>
@@ -73,7 +94,18 @@ class PickupExceptionsPage
                             <td><?php echo esc_html($record->issue); ?></td>
                             <td><?php echo esc_html($record->ai_severity); ?></td>
                             <td><?php echo esc_html($record->ai_category); ?></td>
-                            <td><?php echo esc_html(((int) $record->webhook_sent) === 1 ? 'Yes' : 'No'); ?></td>
+                            <td>
+                                <?php
+                                $status = isset($record->status) ? (string) $record->status : (((int) $record->webhook_sent) === 1 ? 'sent' : 'failed');
+                                if ($status === 'sent') {
+                                    echo '<span class="kerb-badge kerb-badge-success">Sent</span>';
+                                } elseif ($status === 'failed') {
+                                    echo '<span class="kerb-badge kerb-badge-error">Failed</span>';
+                                } else {
+                                    echo '<span class="kerb-badge kerb-badge-pending">Pending</span>';
+                                }
+                                ?>
+                            </td>
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_recommended_action), 20, '…')); ?></td>
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_summary), 20, '…')); ?></td>
                             <td>
@@ -146,6 +178,7 @@ class PickupExceptionsPage
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 0,
                 'webhook_status_code'      => 0,
+                'status'                   => 'failed',
                 'webhook_response_body'    => $result->get_error_message(),
                 'ai_severity'              => '',
                 'ai_category'              => '',
@@ -168,6 +201,7 @@ class PickupExceptionsPage
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 1,
                 'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+                'status'                   => 'sent',
                 'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
                 'ai_severity'              => $ai_severity,
                 'ai_category'              => $ai_category,
@@ -183,6 +217,7 @@ class PickupExceptionsPage
         PickupExceptionRepository::update_result($exception_id, [
             'webhook_sent'             => 0,
             'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+            'status'                   => 'failed',
             'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
             'ai_severity'              => '',
             'ai_category'              => '',

--- a/includes/Data/Repositories/PickupExceptionRepository.php
+++ b/includes/Data/Repositories/PickupExceptionRepository.php
@@ -20,6 +20,7 @@ class PickupExceptionRepository
             '%s', // notes
             '%s', // submitted_at
             '%d', // webhook_sent
+            '%s', // status
             '%s', // created_at
             '%s', // updated_at
         ]);

--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -126,6 +126,7 @@ class Activator
             notes LONGTEXT,
             submitted_at VARCHAR(50) NOT NULL,
             webhook_sent TINYINT(1) NOT NULL DEFAULT 0,
+            status VARCHAR(20) DEFAULT 'pending',
             webhook_status_code INT DEFAULT NULL,
             webhook_response_body LONGTEXT,
             ai_severity VARCHAR(100) DEFAULT '',


### PR DESCRIPTION
### Motivation
- Improve admin visibility by replacing the binary `webhook_sent` display with a small lifecycle `status` (`pending`, `sent`, `failed`) for each pickup exception. 
- Preserve backward compatibility by keeping `webhook_sent` as a fallback and keeping existing webhook/ retry behaviour intact.

### Description
- Add `status VARCHAR(20) DEFAULT 'pending'` to the pickup exceptions table creation SQL in `Activator` so `dbDelta` will create/alter the column on activation. 
- Persist `status => 'pending'` on new pickup exception inserts while still writing `webhook_sent => 0` in the initial save (`PickupExceptionRepository::create` usage updated in `includes/Admin/Ajax/AdminAjax.php`).
- Update webhook result writes in both initial submit and retry flows to set `status` to `'sent'` on success and `'failed'` on failure while continuing to set `webhook_sent` for compatibility (changes in `includes/Admin/Ajax/AdminAjax.php` and `includes/Admin/Pages/PickupExceptionsPage.php`).
- Update admin list query to select `status` and replace the old `Webhook Sent` column with `Status`, rendering a small inline badge with a fallback to `webhook_sent` for legacy rows in `includes/Admin/Pages/PickupExceptionsPage.php`.
- Add minimal inline WordPress-native badge CSS to the Pickup Exceptions admin page for `kerb-badge`, `kerb-badge-success`, `kerb-badge-error`, and `kerb-badge-pending`.

### Testing
- Ran PHP syntax checks: `php -l includes/Install/Activator.php`, `php -l includes/Data/Repositories/PickupExceptionRepository.php`, `php -l includes/Admin/Ajax/AdminAjax.php`, and `php -l includes/Admin/Pages/PickupExceptionsPage.php`, and all reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdc8d91960832d98a046b49c836071)