### PR TITLE
Add `status` to pickup exceptions, improve webhook handling and UI badges

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -447,6 +447,7 @@ class AdminAjax
             'notes'        => $notes,
             'submitted_at' => $timestamp,
             'webhook_sent' => 0,
+            'status'       => 'pending',
             'created_at'   => $now_utc_mysql,
             'updated_at'   => $now_utc_mysql,
         ]);
@@ -475,6 +476,7 @@ class AdminAjax
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 0,
                 'webhook_status_code'      => 0,
+                'status'                   => 'failed',
                 'webhook_response_body'    => $result->get_error_message(),
                 'ai_severity'              => '',
                 'ai_category'              => '',
@@ -501,17 +503,37 @@ class AdminAjax
             ]);
         }
 
-        if (!empty($result['success'])) {
+        $result_status_code = isset($result['status_code']) ? (int) $result['status_code'] : 0;
+        $is_webhook_success = is_array($result) && (
+            !empty($result['success'])
+            || !empty($result['ok'])
+            || ($result_status_code >= 200 && $result_status_code < 300)
+        );
+
+        if ($is_webhook_success) {
             $body = isset($result['body']) ? $result['body'] : '';
-            $decoded_body = json_decode((string) $body, true);
-            $ai_summary = is_array($decoded_body) && isset($decoded_body['summary']) ? (string) $decoded_body['summary'] : '';
-            $ai_category = is_array($decoded_body) && isset($decoded_body['category']) ? (string) $decoded_body['category'] : '';
-            $ai_severity = is_array($decoded_body) && isset($decoded_body['severity']) ? (string) $decoded_body['severity'] : '';
-            $ai_recommended_action = is_array($decoded_body) && isset($decoded_body['recommended_action']) ? (string) $decoded_body['recommended_action'] : '';
+            $decoded_body = is_array($body) ? $body : json_decode((string) $body, true);
+            $ai_payload = [];
+
+            if (is_array($decoded_body)) {
+                if (isset($decoded_body['result']) && is_array($decoded_body['result'])) {
+                    $ai_payload = $decoded_body['result'];
+                } elseif (isset($decoded_body['data']) && is_array($decoded_body['data'])) {
+                    $ai_payload = $decoded_body['data'];
+                } else {
+                    $ai_payload = $decoded_body;
+                }
+            }
+
+            $ai_summary = isset($ai_payload['summary']) ? (string) $ai_payload['summary'] : '';
+            $ai_category = isset($ai_payload['category']) ? (string) $ai_payload['category'] : '';
+            $ai_severity = isset($ai_payload['severity']) ? (string) $ai_payload['severity'] : '';
+            $ai_recommended_action = isset($ai_payload['recommended_action']) ? (string) $ai_payload['recommended_action'] : '';
 
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 1,
-                'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+                'webhook_status_code'      => $result_status_code,
+                'status'                   => 'sent',
                 'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
                 'ai_severity'              => $ai_severity,
                 'ai_category'              => $ai_category,
@@ -538,6 +560,7 @@ class AdminAjax
         PickupExceptionRepository::update_result($exception_id, [
             'webhook_sent'             => 0,
             'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+            'status'                   => 'failed',
             'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
             'ai_severity'              => '',
             'ai_category'              => '',

--- a/includes/Admin/Pages/PickupExceptionsPage.php
+++ b/includes/Admin/Pages/PickupExceptionsPage.php
@@ -28,7 +28,7 @@ class PickupExceptionsPage
         $limit = 50;
 
         $sql = $wpdb->prepare(
-            "SELECT id, submitted_at, qr_code, customer_id, issue, ai_severity, ai_category, webhook_sent, ai_recommended_action, ai_summary
+            "SELECT id, submitted_at, qr_code, customer_id, issue, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary
             FROM {$table_name}
             ORDER BY id DESC
             LIMIT %d",
@@ -41,6 +41,27 @@ class PickupExceptionsPage
             <h1><?php esc_html_e('Pickup Exceptions', 'kerbcycle'); ?></h1>
             <p><?php esc_html_e('This page shows locally stored pickup exceptions and webhook/AI outcome data.', 'kerbcycle'); ?></p>
             <?php $this->render_retry_notice(); ?>
+            <style>
+                .kerb-badge {
+                    display: inline-block;
+                    padding: 2px 8px;
+                    border-radius: 12px;
+                    font-size: 12px;
+                    font-weight: 600;
+                }
+                .kerb-badge-success {
+                    background: #d1fae5;
+                    color: #065f46;
+                }
+                .kerb-badge-error {
+                    background: #fee2e2;
+                    color: #7f1d1d;
+                }
+                .kerb-badge-pending {
+                    background: #fef3c7;
+                    color: #92400e;
+                }
+            </style>
 
             <table class="wp-list-table widefat fixed striped">
                 <thead>
@@ -52,7 +73,7 @@ class PickupExceptionsPage
                         <th><?php esc_html_e('Issue', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Severity', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Category', 'kerbcycle'); ?></th>
-                        <th><?php esc_html_e('Webhook Sent', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Recommended Action', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('AI Summary', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Actions', 'kerbcycle'); ?></th>
@@ -73,7 +94,18 @@ class PickupExceptionsPage
                             <td><?php echo esc_html($record->issue); ?></td>
                             <td><?php echo esc_html($record->ai_severity); ?></td>
                             <td><?php echo esc_html($record->ai_category); ?></td>
-                            <td><?php echo esc_html(((int) $record->webhook_sent) === 1 ? 'Yes' : 'No'); ?></td>
+                            <td>
+                                <?php
+                                $status = isset($record->status) ? (string) $record->status : (((int) $record->webhook_sent) === 1 ? 'sent' : 'failed');
+                                if ($status === 'sent') {
+                                    echo '<span class="kerb-badge kerb-badge-success">Sent</span>';
+                                } elseif ($status === 'failed') {
+                                    echo '<span class="kerb-badge kerb-badge-error">Failed</span>';
+                                } else {
+                                    echo '<span class="kerb-badge kerb-badge-pending">Pending</span>';
+                                }
+                                ?>
+                            </td>
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_recommended_action), 20, '…')); ?></td>
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_summary), 20, '…')); ?></td>
                             <td>
@@ -146,6 +178,7 @@ class PickupExceptionsPage
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 0,
                 'webhook_status_code'      => 0,
+                'status'                   => 'failed',
                 'webhook_response_body'    => $result->get_error_message(),
                 'ai_severity'              => '',
                 'ai_category'              => '',
@@ -168,6 +201,7 @@ class PickupExceptionsPage
             PickupExceptionRepository::update_result($exception_id, [
                 'webhook_sent'             => 1,
                 'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+                'status'                   => 'sent',
                 'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
                 'ai_severity'              => $ai_severity,
                 'ai_category'              => $ai_category,
@@ -183,6 +217,7 @@ class PickupExceptionsPage
         PickupExceptionRepository::update_result($exception_id, [
             'webhook_sent'             => 0,
             'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+            'status'                   => 'failed',
             'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
             'ai_severity'              => '',
             'ai_category'              => '',

--- a/includes/Data/Repositories/PickupExceptionRepository.php
+++ b/includes/Data/Repositories/PickupExceptionRepository.php
@@ -20,6 +20,7 @@ class PickupExceptionRepository
             '%s', // notes
             '%s', // submitted_at
             '%d', // webhook_sent
+            '%s', // status
             '%s', // created_at
             '%s', // updated_at
         ]);
@@ -40,7 +41,7 @@ class PickupExceptionRepository
             $table,
             $args,
             ['id' => (int) $id],
-            ['%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s'],
+            ['%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s'],
             ['%d']
         );
     }

--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -126,6 +126,7 @@ class Activator
             notes LONGTEXT,
             submitted_at VARCHAR(50) NOT NULL,
             webhook_sent TINYINT(1) NOT NULL DEFAULT 0,
+            status VARCHAR(20) DEFAULT 'pending',
             webhook_status_code INT DEFAULT NULL,
             webhook_response_body LONGTEXT,
             ai_severity VARCHAR(100) DEFAULT '',


### PR DESCRIPTION
### Motivation
- Introduce an explicit `status` field to track pickup exception lifecycle beyond the binary `webhook_sent` flag. 
- Make webhook delivery detection and AI response parsing more robust to varying webhook response shapes so retries and AI metadata are captured correctly.

### Description
- Add a `status` column to the `kerbcycle_pickup_exceptions` table with default `'pending'` in `Activator` and include it in the insert schema in `PickupExceptionRepository::create` by adding the corresponding `%s` placeholder. 
- Extend `PickupExceptionRepository::update_result` to accept the extra `status` field by adding the extra format placeholder. 
- In `AdminAjax.php` set `status` to `'pending'` on local create, detect webhook success by checking `success`, `ok`, or HTTP `status_code` in the 2xx range, set `status` to `'sent'` or `'failed'` accordingly, and parse AI payloads nested under `result` or `data` when present. 
- In `PickupExceptionsPage.php` query and display the new `status` column, render colored badges for `Sent`/`Failed`/`Pending`, and update the retry flow to set `status` on success or failure.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdc8d91960832d98a046b49c836071)