### PR TITLE
Add in-place AJAX refresh for Pickup Exceptions admin table

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -651,6 +651,84 @@ function initKerbcycleAdmin() {
   const pickupExceptionNotes = document.getElementById(
     "kerbcycle-pickup-exception-notes",
   );
+  const pickupExceptionsTbody = document.getElementById(
+    "kerbcycle-pickup-exceptions-tbody",
+  );
+
+  function buildPickupExceptionStatusBadge(status) {
+    if (status === "sent") {
+      return '<span class="kerb-badge kerb-badge-success">Sent</span>';
+    }
+    if (status === "failed") {
+      return '<span class="kerb-badge kerb-badge-error">Failed</span>';
+    }
+    return '<span class="kerb-badge kerb-badge-pending">Pending</span>';
+  }
+
+  function trimPickupText(value, maxWords = 20) {
+    const text = String(value || "").replace(/\s+/g, " ").trim();
+    if (!text) {
+      return "";
+    }
+    const words = text.split(" ");
+    if (words.length <= maxWords) {
+      return text;
+    }
+    return `${words.slice(0, maxWords).join(" ")}…`;
+  }
+
+  function refreshPickupExceptionsTable() {
+    if (!pickupExceptionsTbody) {
+      return Promise.resolve();
+    }
+
+    const params = new URLSearchParams();
+    params.append("action", "kerbcycle_get_pickup_exceptions");
+    params.append("security", kerbcycle_ajax.nonce);
+
+    return fetch(kerbcycle_ajax.ajax_url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+      },
+      body: params.toString(),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data || !data.success || !data.data || !Array.isArray(data.data.rows)) {
+          return;
+        }
+        const rows = data.data.rows;
+        if (!rows.length) {
+          pickupExceptionsTbody.innerHTML =
+            '<tr><td colspan="11">No pickup exceptions found.</td></tr>';
+          return;
+        }
+
+        pickupExceptionsTbody.innerHTML = rows
+          .map((row) => {
+            const actionHtml =
+              row.can_retry && row.retry_url
+                ? `<a href="${escapeHtml(row.retry_url)}" class="button button-small kerbcycle-retry-webhook" data-exception-id="${escapeHtml(row.id)}">Retry Webhook</a>`
+                : '<span aria-hidden="true">—</span>';
+
+            return `<tr>
+              <td>${escapeHtml(row.id)}</td>
+              <td>${escapeHtml(row.submitted_at || "")}</td>
+              <td>${escapeHtml(row.qr_code || "")}</td>
+              <td>${escapeHtml(row.customer_id || "")}</td>
+              <td>${escapeHtml(row.issue || "")}</td>
+              <td>${escapeHtml(row.ai_severity || "")}</td>
+              <td>${escapeHtml(row.ai_category || "")}</td>
+              <td>${buildPickupExceptionStatusBadge(row.status || "pending")}</td>
+              <td>${escapeHtml(trimPickupText(row.ai_recommended_action || ""))}</td>
+              <td>${escapeHtml(trimPickupText(row.ai_summary || ""))}</td>
+              <td>${actionHtml}</td>
+            </tr>`;
+          })
+          .join("");
+      });
+  }
 
   function renderAiList(items) {
     if (!Array.isArray(items) || !items.length) {
@@ -802,6 +880,9 @@ function initKerbcycleAdmin() {
       })
         .then((res) => res.json())
         .then((data) => {
+          document.dispatchEvent(
+            new CustomEvent("kerbcycle-pickup-exception-submitted", { detail: data }),
+          );
           if (pickupExceptionTestResult) {
             const payload = data && data.data ? data.data : {};
             const output = {
@@ -833,6 +914,61 @@ function initKerbcycleAdmin() {
           pickupExceptionTestBtn.textContent = originalText;
         });
     });
+  }
+
+  if (pickupExceptionsTbody) {
+    document.addEventListener("kerbcycle-pickup-exception-submitted", () => {
+      refreshPickupExceptionsTable();
+    });
+
+    pickupExceptionsTbody.addEventListener("click", function (event) {
+      const retryLink = event.target.closest(".kerbcycle-retry-webhook");
+      if (!retryLink) {
+        return;
+      }
+      event.preventDefault();
+
+      const exceptionId = retryLink.getAttribute("data-exception-id");
+      if (!exceptionId) {
+        return;
+      }
+
+      retryLink.classList.add("disabled");
+      retryLink.setAttribute("aria-disabled", "true");
+
+      const params = new URLSearchParams();
+      params.append("action", "kerbcycle_retry_pickup_exception");
+      params.append("security", kerbcycle_ajax.nonce);
+      params.append("exception_id", exceptionId);
+
+      fetch(kerbcycle_ajax.ajax_url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        },
+        body: params.toString(),
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          const message =
+            data && data.data && data.data.message
+              ? data.data.message
+              : "Retry request completed.";
+          showToast(message, !(data && data.success));
+          return refreshPickupExceptionsTable();
+        })
+        .catch((error) => {
+          showToast(error.message || "Retry request failed.", true);
+        })
+        .finally(() => {
+          retryLink.classList.remove("disabled");
+          retryLink.removeAttribute("aria-disabled");
+        });
+    });
+
+    setInterval(() => {
+      refreshPickupExceptionsTable();
+    }, 10000);
   }
 
   if (userField && assignedSelect) {

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -46,6 +46,8 @@ class AdminAjax
         add_action('wp_ajax_kerbcycle_qr_report_data', [$this, 'ajax_report_data']);
         add_action('wp_ajax_kerbcycle_delete_logs', [$this, 'delete_logs']);
         add_action('wp_ajax_kerbcycle_test_pickup_exception', [$this, 'test_pickup_exception']);
+        add_action('wp_ajax_kerbcycle_get_pickup_exceptions', [$this, 'get_pickup_exceptions']);
+        add_action('wp_ajax_kerbcycle_retry_pickup_exception', [$this, 'retry_pickup_exception']);
     }
 
     public function assign_qr_code()
@@ -581,5 +583,148 @@ class AdminAjax
             'ai_category' => '',
             'ai_severity' => '',
         ]);
+    }
+
+    public function get_pickup_exceptions()
+    {
+        Nonces::verify('kerbcycle_qr_nonce', 'security');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
+        }
+
+        global $wpdb;
+        $table_name = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
+        $limit = 50;
+        $sql = $wpdb->prepare(
+            "SELECT id, submitted_at, qr_code, customer_id, issue, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary
+            FROM {$table_name}
+            ORDER BY id DESC
+            LIMIT %d",
+            $limit
+        );
+        $records = $wpdb->get_results($sql);
+        $rows = [];
+
+        foreach ($records as $record) {
+            $status = isset($record->status) ? (string) $record->status : (((int) $record->webhook_sent) === 1 ? 'sent' : 'failed');
+            $retry_url = '';
+            if (((int) $record->webhook_sent) === 0) {
+                $retry_url = wp_nonce_url(
+                    add_query_arg(
+                        [
+                            'page' => 'kerbcycle-pickup-exceptions',
+                            'kerbcycle_action' => 'retry_pickup_exception',
+                            'exception_id' => (int) $record->id,
+                        ],
+                        admin_url('admin.php')
+                    ),
+                    'kerbcycle_retry_pickup_exception_' . (int) $record->id
+                );
+            }
+
+            $rows[] = [
+                'id' => (int) $record->id,
+                'submitted_at' => isset($record->submitted_at) ? (string) $record->submitted_at : '',
+                'qr_code' => isset($record->qr_code) ? (string) $record->qr_code : '',
+                'customer_id' => isset($record->customer_id) ? (string) $record->customer_id : '',
+                'issue' => isset($record->issue) ? (string) $record->issue : '',
+                'status' => $status,
+                'ai_severity' => isset($record->ai_severity) ? (string) $record->ai_severity : '',
+                'ai_category' => isset($record->ai_category) ? (string) $record->ai_category : '',
+                'ai_recommended_action' => isset($record->ai_recommended_action) ? (string) $record->ai_recommended_action : '',
+                'ai_summary' => isset($record->ai_summary) ? (string) $record->ai_summary : '',
+                'retry_url' => $retry_url,
+                'can_retry' => ((int) $record->webhook_sent) === 0,
+            ];
+        }
+
+        wp_send_json_success(['rows' => $rows]);
+    }
+
+    public function retry_pickup_exception()
+    {
+        Nonces::verify('kerbcycle_qr_nonce', 'security');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
+        }
+
+        $exception_id = isset($_POST['exception_id']) ? absint(wp_unslash($_POST['exception_id'])) : 0;
+        if ($exception_id < 1) {
+            wp_send_json_error(['message' => __('Invalid pickup exception ID.', 'kerbcycle')], 400);
+        }
+
+        global $wpdb;
+        $table_name = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
+        $record = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table_name} WHERE id = %d", $exception_id));
+
+        if (!$record) {
+            wp_send_json_error(['message' => __('Pickup exception record not found.', 'kerbcycle')], 404);
+        }
+
+        if ((int) $record->webhook_sent === 1) {
+            wp_send_json_error(['message' => __('This pickup exception is not eligible for retry.', 'kerbcycle')], 400);
+        }
+
+        $result = $this->qr_service->send_pickup_exception_to_n8n([
+            'qr_code'     => (string) $record->qr_code,
+            'customer_id' => (int) $record->customer_id,
+            'issue'       => (string) $record->issue,
+            'notes'       => (string) $record->notes,
+            'timestamp'   => !empty($record->submitted_at) ? (string) $record->submitted_at : '',
+        ]);
+
+        if (is_wp_error($result)) {
+            PickupExceptionRepository::update_result($exception_id, [
+                'webhook_sent'             => 0,
+                'webhook_status_code'      => 0,
+                'status'                   => 'failed',
+                'webhook_response_body'    => $result->get_error_message(),
+                'ai_severity'              => '',
+                'ai_category'              => '',
+                'ai_summary'               => '',
+                'ai_recommended_action'    => '',
+                'updated_at'               => current_time('mysql', true),
+            ]);
+
+            wp_send_json_error(['message' => __('Retry failed. The record remains saved locally.', 'kerbcycle')], 500);
+        }
+
+        if (!empty($result['success'])) {
+            $body = isset($result['body']) ? $result['body'] : '';
+            $decoded_body = json_decode((string) $body, true);
+            $ai_summary = is_array($decoded_body) && isset($decoded_body['summary']) ? (string) $decoded_body['summary'] : '';
+            $ai_category = is_array($decoded_body) && isset($decoded_body['category']) ? (string) $decoded_body['category'] : '';
+            $ai_severity = is_array($decoded_body) && isset($decoded_body['severity']) ? (string) $decoded_body['severity'] : '';
+            $ai_recommended_action = is_array($decoded_body) && isset($decoded_body['recommended_action']) ? (string) $decoded_body['recommended_action'] : '';
+
+            PickupExceptionRepository::update_result($exception_id, [
+                'webhook_sent'             => 1,
+                'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+                'status'                   => 'sent',
+                'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
+                'ai_severity'              => $ai_severity,
+                'ai_category'              => $ai_category,
+                'ai_summary'               => $ai_summary,
+                'ai_recommended_action'    => $ai_recommended_action,
+                'updated_at'               => current_time('mysql', true),
+            ]);
+
+            wp_send_json_success(['message' => __('Pickup exception resent successfully.', 'kerbcycle')]);
+        }
+
+        $result_body = isset($result['body']) ? $result['body'] : '';
+        PickupExceptionRepository::update_result($exception_id, [
+            'webhook_sent'             => 0,
+            'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+            'status'                   => 'failed',
+            'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
+            'ai_severity'              => '',
+            'ai_category'              => '',
+            'ai_summary'               => '',
+            'ai_recommended_action'    => '',
+            'updated_at'               => current_time('mysql', true),
+        ]);
+
+        wp_send_json_error(['message' => __('Retry failed. The record remains saved locally.', 'kerbcycle')], 500);
     }
 }

--- a/includes/Admin/Assets/AdminAssets.php
+++ b/includes/Admin/Assets/AdminAssets.php
@@ -55,7 +55,7 @@ class AdminAssets
             return;
         }
 
-        if (!in_array($hook, ['toplevel_page_kerbcycle-qr-manager', 'kerbcycle-qr-manager_page_kerbcycle-qr-history'])) {
+        if (!in_array($hook, ['toplevel_page_kerbcycle-qr-manager', 'kerbcycle-qr-manager_page_kerbcycle-qr-history', 'qr-codes_page_kerbcycle-pickup-exceptions'])) {
             return;
         }
 

--- a/includes/Admin/Pages/PickupExceptionsPage.php
+++ b/includes/Admin/Pages/PickupExceptionsPage.php
@@ -63,7 +63,7 @@ class PickupExceptionsPage
                 }
             </style>
 
-            <table class="wp-list-table widefat fixed striped">
+            <table id="kerbcycle-pickup-exceptions-table" class="wp-list-table widefat fixed striped">
                 <thead>
                     <tr>
                         <th><?php esc_html_e('ID', 'kerbcycle'); ?></th>
@@ -79,7 +79,7 @@ class PickupExceptionsPage
                         <th><?php esc_html_e('Actions', 'kerbcycle'); ?></th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody id="kerbcycle-pickup-exceptions-tbody">
                 <?php if (empty($records)) : ?>
                     <tr>
                         <td colspan="11"><?php esc_html_e('No pickup exceptions found.', 'kerbcycle'); ?></td>
@@ -123,7 +123,7 @@ class PickupExceptionsPage
                                         'kerbcycle_retry_pickup_exception_' . (int) $record->id
                                     );
                                     ?>
-                                    <a href="<?php echo esc_url($retry_url); ?>" class="button button-small"><?php esc_html_e('Retry Webhook', 'kerbcycle'); ?></a>
+                                    <a href="<?php echo esc_url($retry_url); ?>" class="button button-small kerbcycle-retry-webhook" data-exception-id="<?php echo esc_attr((string) (int) $record->id); ?>"><?php esc_html_e('Retry Webhook', 'kerbcycle'); ?></a>
                                 <?php else : ?>
                                     <span aria-hidden="true">—</span>
                                 <?php endif; ?>


### PR DESCRIPTION
### Motivation

- Enable the existing `Pickup Exceptions` admin table to update in place after form submission and webhook retry so admins don't need a full page reload.  
- Keep the page server-rendered on first load and apply a minimal, surgical enhancement that reuses existing admin enqueue/nonce patterns.  
- Preserve existing retry behavior and badge rendering while keeping the patch small and reversible.

### Description

- Enabled the main admin script on the Pickup Exceptions page by updating `includes/Admin/Assets/AdminAssets.php` to enqueue `assets/js/admin.js` for the `qr-codes_page_kerbcycle-pickup-exceptions` hook.  
- Added DOM targets and metadata in `includes/Admin/Pages/PickupExceptionsPage.php` by adding `id="kerbcycle-pickup-exceptions-table"`, `tbody id="kerbcycle-pickup-exceptions-tbody"`, and adding `class="kerbcycle-retry-webhook"` + `data-exception-id` to retry links so the JS can safely update and rewire actions.  
- Implemented two admin AJAX endpoints in `includes/Admin/Ajax/AdminAjax.php`: `kerbcycle_get_pickup_exceptions` (returns newest 50 rows) and `kerbcycle_retry_pickup_exception` (performs retry without a full page navigation), both verifying the `kerbcycle_qr_nonce` and `manage_options` capability.  
- The `get` endpoint returns per-row JSON with the required fields: `id`, `submitted_at`, `qr_code`, `customer_id`, `issue`, `status`, `ai_severity`, `ai_category`, `ai_recommended_action`, `ai_summary`, and retry metadata `retry_url` and `can_retry` so refreshed rows preserve valid retry nonces/URLs.  
- Added lightweight client logic to `assets/js/admin.js` to fetch `kerbcycle_get_pickup_exceptions`, safely escape values, replace the tbody, render consistent status badges, delegate retry clicks to call `kerbcycle_retry_pickup_exception`, refresh the table after submit/retry, and perform conservative polling every 10 seconds only when the table is present.

### Testing

- Lint and syntax checks succeeded for PHP files with `php -l includes/Admin/Ajax/AdminAjax.php`, `php -l includes/Admin/Pages/PickupExceptionsPage.php`, and `php -l includes/Admin/Assets/AdminAssets.php`.  
- Static check of the admin script succeeded with `node --check assets/js/admin.js`.  
- Changes were committed locally (single commit).  
- No automated browser/functional tests were available in this environment, so runtime verification in a WordPress admin instance is recommended to exercise submit, retry and the polling refresh paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf37df759c832dac247d7dc673b090)