### PR TITLE
Pause Pickup Exceptions polling when tab is hidden

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -917,6 +917,25 @@ function initKerbcycleAdmin() {
   }
 
   if (pickupExceptionsTbody) {
+    let pickupExceptionsPollingInterval = null;
+
+    function startPolling() {
+      if (pickupExceptionsPollingInterval || document.hidden) {
+        return;
+      }
+      pickupExceptionsPollingInterval = setInterval(() => {
+        refreshPickupExceptionsTable();
+      }, 5000);
+    }
+
+    function stopPolling() {
+      if (!pickupExceptionsPollingInterval) {
+        return;
+      }
+      clearInterval(pickupExceptionsPollingInterval);
+      pickupExceptionsPollingInterval = null;
+    }
+
     document.addEventListener("kerbcycle-pickup-exception-submitted", () => {
       refreshPickupExceptionsTable();
     });
@@ -966,9 +985,16 @@ function initKerbcycleAdmin() {
         });
     });
 
-    setInterval(() => {
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) {
+        stopPolling();
+        return;
+      }
       refreshPickupExceptionsTable();
-    }, 5000);
+      startPolling();
+    });
+
+    startPolling();
   }
 
   if (userField && assignedSelect) {


### PR DESCRIPTION
### Motivation
- Reduce unnecessary 5-second AJAX polling on the Pickup Exceptions admin page by pausing the refresh loop when the browser tab is not visible, while preserving current behavior when the page is active.
- Make a surgical, minimal change that reuses existing polling logic and only affects the Pickup Exceptions page.

### Description
- Patched `assets/js/admin.js` and added minimal polling control functions `startPolling()` and `stopPolling()` scoped inside the existing `if (pickupExceptionsTbody) { ... }` guard so only the Pickup Exceptions page is affected.
- Kept the existing 5-second cadence by calling `setInterval(..., 5000)` from `startPolling()` and reused the existing `refreshPickupExceptionsTable()` function for all refreshes.
- Added a `document.addEventListener('visibilitychange', ...)` handler that calls `stopPolling()` when `document.hidden === true` and calls `refreshPickupExceptionsTable()` once then `startPolling()` when `document.hidden === false` so the table is refreshed immediately on focus and the interval is resumed.
- Prevented duplicate intervals by storing the interval id in `pickupExceptionsPollingInterval` and returning early from `startPolling()` when an interval already exists; `stopPolling()` clears and nulls the id.

### Testing
- Ran file inspection commands `git diff -- assets/js/admin.js` and `nl -ba assets/js/admin.js | sed -n '860,945p'` and `nl -ba assets/js/admin.js | sed -n '918,1005p'` to verify the patch is present and correctly scoped, and these checks completed successfully.
- Verified repository status with `git status --short` and committed the change, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0370ea214832d99dbede650c9bcc9)