### PR TITLE
Add inline expandable 'View Details' to Pickup Exceptions admin list

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -677,6 +677,16 @@ function initKerbcycleAdmin() {
     return `${words.slice(0, maxWords).join(" ")}…`;
   }
 
+  function pickupDetailText(value) {
+    const text = String(value || "").trim();
+    return text ? escapeHtml(text).replace(/\n/g, "<br>") : "—";
+  }
+
+  function pickupRawText(value) {
+    const text = String(value || "").trim();
+    return text ? escapeHtml(text) : "—";
+  }
+
   function refreshPickupExceptionsTable() {
     if (!pickupExceptionsTbody) {
       return Promise.resolve();
@@ -710,9 +720,9 @@ function initKerbcycleAdmin() {
             const actionHtml =
               row.can_retry && row.retry_url
                 ? `<a href="${escapeHtml(row.retry_url)}" class="button button-small kerbcycle-retry-webhook" data-exception-id="${escapeHtml(row.id)}">Retry Webhook</a>`
-                : '<span aria-hidden="true">—</span>';
+                : "";
 
-            return `<tr>
+            return `<tr data-exception-id="${escapeHtml(row.id)}">
               <td>${escapeHtml(row.id)}</td>
               <td>${escapeHtml(row.submitted_at || "")}</td>
               <td>${escapeHtml(row.qr_code || "")}</td>
@@ -723,7 +733,27 @@ function initKerbcycleAdmin() {
               <td>${buildPickupExceptionStatusBadge(row.status || "pending")}</td>
               <td>${escapeHtml(trimPickupText(row.ai_recommended_action || ""))}</td>
               <td>${escapeHtml(trimPickupText(row.ai_summary || ""))}</td>
-              <td>${actionHtml}</td>
+              <td>
+                <button type="button" class="button button-small kerbcycle-view-details" data-exception-id="${escapeHtml(row.id)}" aria-expanded="false">View Details</button>
+                ${actionHtml}
+              </td>
+            </tr>
+            <tr class="kerbcycle-pickup-details-row" data-exception-id="${escapeHtml(row.id)}" style="display:none;">
+              <td colspan="11">
+                <div class="kerbcycle-pickup-details-content">
+                  <p><strong>Issue:</strong><br>${pickupDetailText(row.issue)}</p>
+                  <p><strong>Notes:</strong><br>${pickupDetailText(row.notes)}</p>
+                  <p><strong>AI Summary:</strong><br>${pickupDetailText(row.ai_summary)}</p>
+                  <p><strong>Recommended Action:</strong><br>${pickupDetailText(row.ai_recommended_action)}</p>
+                  <p><strong>Webhook Status Code:</strong> ${pickupDetailText(row.webhook_status_code)}</p>
+                  <p><strong>Webhook Response Body:</strong></p>
+                  <pre>${pickupRawText(row.webhook_response_body)}</pre>
+                  <p><strong>Submitted At:</strong> ${pickupDetailText(row.submitted_at)}</p>
+                  <p><strong>Updated At:</strong> ${pickupDetailText(row.updated_at)}</p>
+                  <p><strong>Customer ID:</strong> ${pickupDetailText(row.customer_id)}</p>
+                  <p><strong>QR Code:</strong> ${pickupDetailText(row.qr_code)}</p>
+                </div>
+              </td>
             </tr>`;
           })
           .join("");
@@ -941,6 +971,26 @@ function initKerbcycleAdmin() {
     });
 
     pickupExceptionsTbody.addEventListener("click", function (event) {
+      const detailsButton = event.target.closest(".kerbcycle-view-details");
+      if (detailsButton) {
+        event.preventDefault();
+        const exceptionId = detailsButton.getAttribute("data-exception-id");
+        if (!exceptionId) {
+          return;
+        }
+        const detailsRow = pickupExceptionsTbody.querySelector(
+          `.kerbcycle-pickup-details-row[data-exception-id="${exceptionId}"]`,
+        );
+        if (!detailsRow) {
+          return;
+        }
+        const isOpen = detailsRow.style.display !== "none";
+        detailsRow.style.display = isOpen ? "none" : "table-row";
+        detailsButton.setAttribute("aria-expanded", isOpen ? "false" : "true");
+        detailsButton.textContent = isOpen ? "View Details" : "Hide Details";
+        return;
+      }
+
       const retryLink = event.target.closest(".kerbcycle-retry-webhook");
       if (!retryLink) {
         return;

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -596,7 +596,7 @@ class AdminAjax
         $table_name = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
         $limit = 50;
         $sql = $wpdb->prepare(
-            "SELECT id, submitted_at, qr_code, customer_id, issue, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary
+            "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body
             FROM {$table_name}
             ORDER BY id DESC
             LIMIT %d",
@@ -625,14 +625,18 @@ class AdminAjax
             $rows[] = [
                 'id' => (int) $record->id,
                 'submitted_at' => isset($record->submitted_at) ? (string) $record->submitted_at : '',
+                'updated_at' => isset($record->updated_at) ? (string) $record->updated_at : '',
                 'qr_code' => isset($record->qr_code) ? (string) $record->qr_code : '',
                 'customer_id' => isset($record->customer_id) ? (string) $record->customer_id : '',
                 'issue' => isset($record->issue) ? (string) $record->issue : '',
+                'notes' => isset($record->notes) ? (string) $record->notes : '',
                 'status' => $status,
                 'ai_severity' => isset($record->ai_severity) ? (string) $record->ai_severity : '',
                 'ai_category' => isset($record->ai_category) ? (string) $record->ai_category : '',
                 'ai_recommended_action' => isset($record->ai_recommended_action) ? (string) $record->ai_recommended_action : '',
                 'ai_summary' => isset($record->ai_summary) ? (string) $record->ai_summary : '',
+                'webhook_status_code' => isset($record->webhook_status_code) ? (string) $record->webhook_status_code : '',
+                'webhook_response_body' => isset($record->webhook_response_body) ? (string) $record->webhook_response_body : '',
                 'retry_url' => $retry_url,
                 'can_retry' => ((int) $record->webhook_sent) === 0,
             ];

--- a/includes/Admin/Pages/PickupExceptionsPage.php
+++ b/includes/Admin/Pages/PickupExceptionsPage.php
@@ -28,7 +28,7 @@ class PickupExceptionsPage
         $limit = 50;
 
         $sql = $wpdb->prepare(
-            "SELECT id, submitted_at, qr_code, customer_id, issue, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary
+            "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body
             FROM {$table_name}
             ORDER BY id DESC
             LIMIT %d",
@@ -61,6 +61,22 @@ class PickupExceptionsPage
                     background: #fef3c7;
                     color: #92400e;
                 }
+                .kerbcycle-pickup-details-row {
+                    display: none;
+                }
+                .kerbcycle-pickup-details-content {
+                    padding: 8px 12px;
+                }
+                .kerbcycle-pickup-details-content p {
+                    margin: 0 0 8px;
+                }
+                .kerbcycle-pickup-details-content pre {
+                    margin: 0 0 8px;
+                    max-height: 240px;
+                    overflow: auto;
+                    white-space: pre-wrap;
+                    word-break: break-word;
+                }
             </style>
 
             <table id="kerbcycle-pickup-exceptions-table" class="wp-list-table widefat fixed striped">
@@ -86,7 +102,7 @@ class PickupExceptionsPage
                     </tr>
                 <?php else : ?>
                     <?php foreach ($records as $record) : ?>
-                        <tr>
+                        <tr data-exception-id="<?php echo esc_attr((string) (int) $record->id); ?>">
                             <td><?php echo esc_html($record->id); ?></td>
                             <td><?php echo esc_html($record->submitted_at); ?></td>
                             <td><?php echo esc_html($record->qr_code); ?></td>
@@ -109,6 +125,7 @@ class PickupExceptionsPage
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_recommended_action), 20, '…')); ?></td>
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_summary), 20, '…')); ?></td>
                             <td>
+                                <button type="button" class="button button-small kerbcycle-view-details" data-exception-id="<?php echo esc_attr((string) (int) $record->id); ?>" aria-expanded="false"><?php esc_html_e('View Details', 'kerbcycle'); ?></button>
                                 <?php if (((int) $record->webhook_sent) === 0) : ?>
                                     <?php
                                     $retry_url = wp_nonce_url(
@@ -124,9 +141,24 @@ class PickupExceptionsPage
                                     );
                                     ?>
                                     <a href="<?php echo esc_url($retry_url); ?>" class="button button-small kerbcycle-retry-webhook" data-exception-id="<?php echo esc_attr((string) (int) $record->id); ?>"><?php esc_html_e('Retry Webhook', 'kerbcycle'); ?></a>
-                                <?php else : ?>
-                                    <span aria-hidden="true">—</span>
                                 <?php endif; ?>
+                            </td>
+                        </tr>
+                        <tr class="kerbcycle-pickup-details-row" data-exception-id="<?php echo esc_attr((string) (int) $record->id); ?>">
+                            <td colspan="11">
+                                <div class="kerbcycle-pickup-details-content">
+                                    <p><strong><?php esc_html_e('Issue', 'kerbcycle'); ?>:</strong><br><?php echo nl2br(esc_html((string) $record->issue)); ?></p>
+                                    <p><strong><?php esc_html_e('Notes', 'kerbcycle'); ?>:</strong><br><?php echo nl2br(esc_html((string) $record->notes)); ?></p>
+                                    <p><strong><?php esc_html_e('AI Summary', 'kerbcycle'); ?>:</strong><br><?php echo nl2br(esc_html((string) $record->ai_summary)); ?></p>
+                                    <p><strong><?php esc_html_e('Recommended Action', 'kerbcycle'); ?>:</strong><br><?php echo nl2br(esc_html((string) $record->ai_recommended_action)); ?></p>
+                                    <p><strong><?php esc_html_e('Webhook Status Code', 'kerbcycle'); ?>:</strong> <?php echo esc_html(isset($record->webhook_status_code) && $record->webhook_status_code !== null ? (string) $record->webhook_status_code : ''); ?></p>
+                                    <p><strong><?php esc_html_e('Webhook Response Body', 'kerbcycle'); ?>:</strong></p>
+                                    <pre><?php echo esc_html((string) $record->webhook_response_body); ?></pre>
+                                    <p><strong><?php esc_html_e('Submitted At', 'kerbcycle'); ?>:</strong> <?php echo esc_html((string) $record->submitted_at); ?></p>
+                                    <p><strong><?php esc_html_e('Updated At', 'kerbcycle'); ?>:</strong> <?php echo esc_html((string) $record->updated_at); ?></p>
+                                    <p><strong><?php esc_html_e('Customer ID', 'kerbcycle'); ?>:</strong> <?php echo esc_html((string) $record->customer_id); ?></p>
+                                    <p><strong><?php esc_html_e('QR Code', 'kerbcycle'); ?>:</strong> <?php echo esc_html((string) $record->qr_code); ?></p>
+                                </div>
                             </td>
                         </tr>
                     <?php endforeach; ?>


### PR DESCRIPTION
### Motivation
- Admins need to inspect full stored AI/webhook data for a pickup exception inline without leaving the existing list page, while preserving the current polling/retry behavior and keeping changes minimal.

### Description
- Updated server-rendered list in `includes/Admin/Pages/PickupExceptionsPage.php` to select additional fields needed for full details and added a small `View Details` button in the Actions column that toggles a hidden inline `<tr>` containing escaped detail content.
- Extended the AJAX refresh data source in `includes/Admin/Ajax/AdminAjax.php` (`get_pickup_exceptions`) to include the same extra fields so the inline details can be rendered during live polling without new endpoints.
- Added minimal client-side rendering and delegated toggle handling in `assets/js/admin.js` to output the hidden details `<tr>` during refresh and to expand/collapse rows after polling, preserving the existing retry flow and using admin-safe escaping.
- Patch includes light CSS scoped into the same page for the details row; all displayed values are escaped with `esc_html`/JS `escapeHtml` and long webhook bodies are shown inside a `<pre>`.
- Patch summary: files changed: `includes/Admin/Pages/PickupExceptionsPage.php`, `includes/Admin/Ajax/AdminAjax.php`, `assets/js/admin.js`; fields added to queries/rows: `updated_at`, `notes`, `webhook_status_code`, `webhook_response_body`; toggle UI: `View Details` button and hidden `<tr>` spanning table width; details fields shown: Issue, Notes, AI Summary, Recommended Action, Webhook Status Code, Webhook Response Body, Submitted At, Updated At, Customer ID, QR Code; JS behavior: rendering inline details during refresh and delegated expand/collapse that survives polling.

### Testing
- Ran PHP lint checks `php -l includes/Admin/Pages/PickupExceptionsPage.php` which succeeded.
- Ran PHP lint checks `php -l includes/Admin/Ajax/AdminAjax.php` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d050c17c44832d97825ad15c97c592)