### PR TITLE
Preserve Pickup Exceptions detail expansion across polling refreshes

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -948,6 +948,7 @@ function initKerbcycleAdmin() {
 
   if (pickupExceptionsTbody) {
     let pickupExceptionsPollingInterval = null;
+    const expandedPickupExceptionIds = new Set();
 
     function startPolling() {
       if (pickupExceptionsPollingInterval || document.hidden) {
@@ -988,6 +989,11 @@ function initKerbcycleAdmin() {
         detailsRow.style.display = isOpen ? "none" : "table-row";
         detailsButton.setAttribute("aria-expanded", isOpen ? "false" : "true");
         detailsButton.textContent = isOpen ? "View Details" : "Hide Details";
+        if (isOpen) {
+          expandedPickupExceptionIds.delete(exceptionId);
+        } else {
+          expandedPickupExceptionIds.add(exceptionId);
+        }
         return;
       }
 
@@ -1043,6 +1049,39 @@ function initKerbcycleAdmin() {
       refreshPickupExceptionsTable();
       startPolling();
     });
+
+    const originalRefreshPickupExceptionsTable = refreshPickupExceptionsTable;
+    refreshPickupExceptionsTable = function () {
+      return originalRefreshPickupExceptionsTable().then(() => {
+        if (!pickupExceptionsTbody) {
+          return;
+        }
+        const visibleIds = new Set(
+          Array.from(
+            pickupExceptionsTbody.querySelectorAll('tr[data-exception-id]'),
+            (row) => row.getAttribute("data-exception-id"),
+          ).filter(Boolean),
+        );
+        Array.from(expandedPickupExceptionIds).forEach((id) => {
+          if (!visibleIds.has(id)) {
+            expandedPickupExceptionIds.delete(id);
+            return;
+          }
+          const detailsRow = pickupExceptionsTbody.querySelector(
+            `.kerbcycle-pickup-details-row[data-exception-id="${id}"]`,
+          );
+          const detailsButton = pickupExceptionsTbody.querySelector(
+            `.kerbcycle-view-details[data-exception-id="${id}"]`,
+          );
+          if (!detailsRow || !detailsButton) {
+            return;
+          }
+          detailsRow.style.display = "table-row";
+          detailsButton.setAttribute("aria-expanded", "true");
+          detailsButton.textContent = "Hide Details";
+        });
+      });
+    };
 
     startPolling();
   }


### PR DESCRIPTION
### Motivation
- The Pickup Exceptions table is refetched every 5 seconds and currently collapses any open inline "View Details" rows on refresh, creating a poor UX.
- The goal is to persist open/closed state across DOM refreshes while keeping the existing polling and retry/status behavior unchanged.
- Use stable `data-exception-id` values already present in the rendered rows to track and reapply expanded state without backend changes.

### Description
- Updated `assets/js/admin.js` only and reused the existing `data-exception-id` attributes (no PHP/markup changes required). 
- Added a lightweight in-memory store `expandedPickupExceptionIds = new Set()` to remember which exception IDs are expanded. 
- Kept the existing delegated click handler for `.kerbcycle-view-details` and amended it to add/remove IDs from the `Set` when rows are opened/closed. 
- Wrapped `refreshPickupExceptionsTable()` so that after each successful table refresh it re-applies expanded state for IDs in the `Set` and prunes IDs for records no longer present; polling remains at 5 seconds and retry/status rendering is unchanged.

### Testing
- Ran syntax check with `node --check assets/js/admin.js` which completed without errors. 
- Verified the repository status and committed the single-file change with `git` to ensure only `assets/js/admin.js` was modified. 
- No automated unit tests were added or modified; the patch is surgical and limited to client-side behavior and preserved existing polling logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d055ed24dc832d9ab8295d4f3689be)