### PR TITLE
Add failed-only filter and retry metadata to Pickup Exceptions

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -695,6 +695,12 @@ function initKerbcycleAdmin() {
     const params = new URLSearchParams();
     params.append("action", "kerbcycle_get_pickup_exceptions");
     params.append("security", kerbcycle_ajax.nonce);
+    const pickupStatusFilter = new URLSearchParams(window.location.search).get(
+      "status_filter",
+    );
+    if (pickupStatusFilter === "failed") {
+      params.append("status_filter", "failed");
+    }
 
     return fetch(kerbcycle_ajax.ajax_url, {
       method: "POST",
@@ -711,7 +717,7 @@ function initKerbcycleAdmin() {
         const rows = data.data.rows;
         if (!rows.length) {
           pickupExceptionsTbody.innerHTML =
-            '<tr><td colspan="11">No pickup exceptions found.</td></tr>';
+            '<tr><td colspan="13">No pickup exceptions found.</td></tr>';
           return;
         }
 
@@ -731,6 +737,8 @@ function initKerbcycleAdmin() {
               <td>${escapeHtml(row.ai_severity || "")}</td>
               <td>${escapeHtml(row.ai_category || "")}</td>
               <td>${buildPickupExceptionStatusBadge(row.status || "pending")}</td>
+              <td>${escapeHtml(Number.isFinite(Number(row.retry_count)) ? String(Number(row.retry_count)) : "0")}</td>
+              <td>${escapeHtml(row.last_retry_at || "—")}</td>
               <td>${escapeHtml(trimPickupText(row.ai_recommended_action || ""))}</td>
               <td>${escapeHtml(trimPickupText(row.ai_summary || ""))}</td>
               <td>
@@ -739,7 +747,7 @@ function initKerbcycleAdmin() {
               </td>
             </tr>
             <tr class="kerbcycle-pickup-details-row" data-exception-id="${escapeHtml(row.id)}" style="display:none;">
-              <td colspan="11">
+              <td colspan="13">
                 <div class="kerbcycle-pickup-details-content">
                   <p><strong>Issue:</strong><br>${pickupDetailText(row.issue)}</p>
                   <p><strong>Notes:</strong><br>${pickupDetailText(row.notes)}</p>
@@ -750,6 +758,8 @@ function initKerbcycleAdmin() {
                   <pre>${pickupRawText(row.webhook_response_body)}</pre>
                   <p><strong>Submitted At:</strong> ${pickupDetailText(row.submitted_at)}</p>
                   <p><strong>Updated At:</strong> ${pickupDetailText(row.updated_at)}</p>
+                  <p><strong>Retry Count:</strong> ${pickupDetailText(Number.isFinite(Number(row.retry_count)) ? String(Number(row.retry_count)) : "0")}</p>
+                  <p><strong>Last Retry:</strong> ${pickupDetailText(row.last_retry_at || "—")}</p>
                   <p><strong>Customer ID:</strong> ${pickupDetailText(row.customer_id)}</p>
                   <p><strong>QR Code:</strong> ${pickupDetailText(row.qr_code)}</p>
                 </div>

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -409,6 +409,7 @@ class AdminAjax
         if (!current_user_can('manage_options')) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
+        \Kerbcycle\QrCode\Install\Activator::activate();
 
         $qr_code_raw = isset($_POST['qr_code']) ? wp_unslash($_POST['qr_code']) : '';
         $customer_id_raw = isset($_POST['customer_id']) ? wp_unslash($_POST['customer_id']) : '';
@@ -450,6 +451,8 @@ class AdminAjax
             'submitted_at' => $timestamp,
             'webhook_sent' => 0,
             'status'       => 'pending',
+            'retry_count'  => 0,
+            'last_retry_at' => null,
             'created_at'   => $now_utc_mysql,
             'updated_at'   => $now_utc_mysql,
         ]);
@@ -591,17 +594,31 @@ class AdminAjax
         if (!current_user_can('manage_options')) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
+        \Kerbcycle\QrCode\Install\Activator::activate();
 
         global $wpdb;
         $table_name = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
         $limit = 50;
-        $sql = $wpdb->prepare(
-            "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body
-            FROM {$table_name}
-            ORDER BY id DESC
-            LIMIT %d",
-            $limit
-        );
+        $status_filter = isset($_POST['status_filter']) ? sanitize_key(wp_unslash($_POST['status_filter'])) : '';
+        if ($status_filter === 'failed') {
+            $sql = $wpdb->prepare(
+                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
+                FROM {$table_name}
+                WHERE status = %s
+                ORDER BY id DESC
+                LIMIT %d",
+                'failed',
+                $limit
+            );
+        } else {
+            $sql = $wpdb->prepare(
+                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
+                FROM {$table_name}
+                ORDER BY id DESC
+                LIMIT %d",
+                $limit
+            );
+        }
         $records = $wpdb->get_results($sql);
         $rows = [];
 
@@ -609,13 +626,17 @@ class AdminAjax
             $status = isset($record->status) ? (string) $record->status : (((int) $record->webhook_sent) === 1 ? 'sent' : 'failed');
             $retry_url = '';
             if (((int) $record->webhook_sent) === 0) {
+                $retry_args = [
+                    'page' => 'kerbcycle-pickup-exceptions',
+                    'kerbcycle_action' => 'retry_pickup_exception',
+                    'exception_id' => (int) $record->id,
+                ];
+                if ($status_filter === 'failed') {
+                    $retry_args['status_filter'] = 'failed';
+                }
                 $retry_url = wp_nonce_url(
                     add_query_arg(
-                        [
-                            'page' => 'kerbcycle-pickup-exceptions',
-                            'kerbcycle_action' => 'retry_pickup_exception',
-                            'exception_id' => (int) $record->id,
-                        ],
+                        $retry_args,
                         admin_url('admin.php')
                     ),
                     'kerbcycle_retry_pickup_exception_' . (int) $record->id
@@ -637,6 +658,8 @@ class AdminAjax
                 'ai_summary' => isset($record->ai_summary) ? (string) $record->ai_summary : '',
                 'webhook_status_code' => isset($record->webhook_status_code) ? (string) $record->webhook_status_code : '',
                 'webhook_response_body' => isset($record->webhook_response_body) ? (string) $record->webhook_response_body : '',
+                'retry_count' => isset($record->retry_count) ? (int) $record->retry_count : 0,
+                'last_retry_at' => isset($record->last_retry_at) ? (string) $record->last_retry_at : '',
                 'retry_url' => $retry_url,
                 'can_retry' => ((int) $record->webhook_sent) === 0,
             ];
@@ -651,6 +674,7 @@ class AdminAjax
         if (!current_user_can('manage_options')) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
+        \Kerbcycle\QrCode\Install\Activator::activate();
 
         $exception_id = isset($_POST['exception_id']) ? absint(wp_unslash($_POST['exception_id'])) : 0;
         if ($exception_id < 1) {
@@ -668,6 +692,13 @@ class AdminAjax
         if ((int) $record->webhook_sent === 1) {
             wp_send_json_error(['message' => __('This pickup exception is not eligible for retry.', 'kerbcycle')], 400);
         }
+
+        $retry_timestamp = current_time('mysql', true);
+        PickupExceptionRepository::update_result($exception_id, [
+            'retry_count' => ((int) $record->retry_count) + 1,
+            'last_retry_at' => $retry_timestamp,
+            'updated_at' => $retry_timestamp,
+        ]);
 
         $result = $this->qr_service->send_pickup_exception_to_n8n([
             'qr_code'     => (string) $record->qr_code,

--- a/includes/Admin/Pages/PickupExceptionsPage.php
+++ b/includes/Admin/Pages/PickupExceptionsPage.php
@@ -19,6 +19,7 @@ class PickupExceptionsPage
         if (!current_user_can('manage_options')) {
             return;
         }
+        \Kerbcycle\QrCode\Install\Activator::activate();
 
         $this->handle_retry_request();
 
@@ -26,20 +27,41 @@ class PickupExceptionsPage
 
         $table_name = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
         $limit = 50;
-
-        $sql = $wpdb->prepare(
-            "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body
-            FROM {$table_name}
-            ORDER BY id DESC
-            LIMIT %d",
-            $limit
-        );
+        $status_filter = isset($_GET['status_filter']) ? sanitize_key(wp_unslash($_GET['status_filter'])) : '';
+        if ($status_filter === 'failed') {
+            $sql = $wpdb->prepare(
+                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
+                FROM {$table_name}
+                WHERE status = %s
+                ORDER BY id DESC
+                LIMIT %d",
+                'failed',
+                $limit
+            );
+        } else {
+            $sql = $wpdb->prepare(
+                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
+                FROM {$table_name}
+                ORDER BY id DESC
+                LIMIT %d",
+                $limit
+            );
+        }
 
         $records = $wpdb->get_results($sql);
         ?>
         <div class="wrap">
             <h1><?php esc_html_e('Pickup Exceptions', 'kerbcycle'); ?></h1>
             <p><?php esc_html_e('This page shows locally stored pickup exceptions and webhook/AI outcome data.', 'kerbcycle'); ?></p>
+            <p>
+                <?php
+                $all_url = add_query_arg(['page' => 'kerbcycle-pickup-exceptions'], admin_url('admin.php'));
+                $failed_url = add_query_arg(['page' => 'kerbcycle-pickup-exceptions', 'status_filter' => 'failed'], admin_url('admin.php'));
+                ?>
+                <a href="<?php echo esc_url($all_url); ?>" class="<?php echo esc_attr($status_filter === 'failed' ? '' : 'current'); ?>"><?php esc_html_e('All', 'kerbcycle'); ?></a>
+                |
+                <a href="<?php echo esc_url($failed_url); ?>" class="<?php echo esc_attr($status_filter === 'failed' ? 'current' : ''); ?>"><?php esc_html_e('Failed Only', 'kerbcycle'); ?></a>
+            </p>
             <?php $this->render_retry_notice(); ?>
             <style>
                 .kerb-badge {
@@ -90,6 +112,8 @@ class PickupExceptionsPage
                         <th><?php esc_html_e('Severity', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Category', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Retry Count', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Last Retry', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Recommended Action', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('AI Summary', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Actions', 'kerbcycle'); ?></th>
@@ -98,7 +122,7 @@ class PickupExceptionsPage
                 <tbody id="kerbcycle-pickup-exceptions-tbody">
                 <?php if (empty($records)) : ?>
                     <tr>
-                        <td colspan="11"><?php esc_html_e('No pickup exceptions found.', 'kerbcycle'); ?></td>
+                        <td colspan="13"><?php esc_html_e('No pickup exceptions found.', 'kerbcycle'); ?></td>
                     </tr>
                 <?php else : ?>
                     <?php foreach ($records as $record) : ?>
@@ -122,19 +146,25 @@ class PickupExceptionsPage
                                 }
                                 ?>
                             </td>
+                            <td><?php echo esc_html((string) (isset($record->retry_count) ? (int) $record->retry_count : 0)); ?></td>
+                            <td><?php echo esc_html(!empty($record->last_retry_at) ? (string) $record->last_retry_at : '—'); ?></td>
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_recommended_action), 20, '…')); ?></td>
                             <td><?php echo esc_html(wp_trim_words(wp_strip_all_tags((string) $record->ai_summary), 20, '…')); ?></td>
                             <td>
                                 <button type="button" class="button button-small kerbcycle-view-details" data-exception-id="<?php echo esc_attr((string) (int) $record->id); ?>" aria-expanded="false"><?php esc_html_e('View Details', 'kerbcycle'); ?></button>
                                 <?php if (((int) $record->webhook_sent) === 0) : ?>
                                     <?php
+                                    $retry_args = [
+                                        'page' => 'kerbcycle-pickup-exceptions',
+                                        'kerbcycle_action' => 'retry_pickup_exception',
+                                        'exception_id' => (int) $record->id,
+                                    ];
+                                    if ($status_filter === 'failed') {
+                                        $retry_args['status_filter'] = 'failed';
+                                    }
                                     $retry_url = wp_nonce_url(
                                         add_query_arg(
-                                            [
-                                                'page' => 'kerbcycle-pickup-exceptions',
-                                                'kerbcycle_action' => 'retry_pickup_exception',
-                                                'exception_id' => (int) $record->id,
-                                            ],
+                                            $retry_args,
                                             admin_url('admin.php')
                                         ),
                                         'kerbcycle_retry_pickup_exception_' . (int) $record->id
@@ -145,7 +175,7 @@ class PickupExceptionsPage
                             </td>
                         </tr>
                         <tr class="kerbcycle-pickup-details-row" data-exception-id="<?php echo esc_attr((string) (int) $record->id); ?>">
-                            <td colspan="11">
+                            <td colspan="13">
                                 <div class="kerbcycle-pickup-details-content">
                                     <p><strong><?php esc_html_e('Issue', 'kerbcycle'); ?>:</strong><br><?php echo nl2br(esc_html((string) $record->issue)); ?></p>
                                     <p><strong><?php esc_html_e('Notes', 'kerbcycle'); ?>:</strong><br><?php echo nl2br(esc_html((string) $record->notes)); ?></p>
@@ -156,6 +186,8 @@ class PickupExceptionsPage
                                     <pre><?php echo esc_html((string) $record->webhook_response_body); ?></pre>
                                     <p><strong><?php esc_html_e('Submitted At', 'kerbcycle'); ?>:</strong> <?php echo esc_html((string) $record->submitted_at); ?></p>
                                     <p><strong><?php esc_html_e('Updated At', 'kerbcycle'); ?>:</strong> <?php echo esc_html((string) $record->updated_at); ?></p>
+                                    <p><strong><?php esc_html_e('Retry Count', 'kerbcycle'); ?>:</strong> <?php echo esc_html((string) (isset($record->retry_count) ? (int) $record->retry_count : 0)); ?></p>
+                                    <p><strong><?php esc_html_e('Last Retry', 'kerbcycle'); ?>:</strong> <?php echo esc_html(!empty($record->last_retry_at) ? (string) $record->last_retry_at : '—'); ?></p>
                                     <p><strong><?php esc_html_e('Customer ID', 'kerbcycle'); ?>:</strong> <?php echo esc_html((string) $record->customer_id); ?></p>
                                     <p><strong><?php esc_html_e('QR Code', 'kerbcycle'); ?>:</strong> <?php echo esc_html((string) $record->qr_code); ?></p>
                                 </div>
@@ -197,6 +229,13 @@ class PickupExceptionsPage
         if ((int) $record->webhook_sent === 1) {
             $this->redirect_with_retry_notice('error', __('This pickup exception is not eligible for retry.', 'kerbcycle'));
         }
+
+        $retry_timestamp = current_time('mysql', true);
+        PickupExceptionRepository::update_result($exception_id, [
+            'retry_count' => ((int) $record->retry_count) + 1,
+            'last_retry_at' => $retry_timestamp,
+            'updated_at' => $retry_timestamp,
+        ]);
 
         $result = (new QrService())->send_pickup_exception_to_n8n([
             'qr_code'     => (string) $record->qr_code,
@@ -271,6 +310,9 @@ class PickupExceptionsPage
             ],
             admin_url('admin.php')
         );
+        if (isset($_GET['status_filter']) && sanitize_key(wp_unslash($_GET['status_filter'])) === 'failed') {
+            $redirect_url = add_query_arg('status_filter', 'failed', $redirect_url);
+        }
 
         wp_safe_redirect($redirect_url);
         exit;

--- a/includes/Data/Repositories/PickupExceptionRepository.php
+++ b/includes/Data/Repositories/PickupExceptionRepository.php
@@ -21,6 +21,8 @@ class PickupExceptionRepository
             '%s', // submitted_at
             '%d', // webhook_sent
             '%s', // status
+            '%d', // retry_count
+            '%s', // last_retry_at
             '%s', // created_at
             '%s', // updated_at
         ]);
@@ -37,11 +39,29 @@ class PickupExceptionRepository
         global $wpdb;
 
         $table = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
+        $format_map = [
+            'webhook_sent' => '%d',
+            'webhook_status_code' => '%d',
+            'status' => '%s',
+            'webhook_response_body' => '%s',
+            'ai_severity' => '%s',
+            'ai_category' => '%s',
+            'ai_summary' => '%s',
+            'ai_recommended_action' => '%s',
+            'retry_count' => '%d',
+            'last_retry_at' => '%s',
+            'updated_at' => '%s',
+        ];
+        $formats = [];
+        foreach ($args as $key => $value) {
+            $formats[] = isset($format_map[$key]) ? $format_map[$key] : '%s';
+        }
+
         return $wpdb->update(
             $table,
             $args,
             ['id' => (int) $id],
-            ['%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s'],
+            $formats,
             ['%d']
         );
     }

--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -129,6 +129,8 @@ class Activator
             status VARCHAR(20) DEFAULT 'pending',
             webhook_status_code INT DEFAULT NULL,
             webhook_response_body LONGTEXT,
+            retry_count INT NOT NULL DEFAULT 0,
+            last_retry_at DATETIME NULL,
             ai_severity VARCHAR(100) DEFAULT '',
             ai_category VARCHAR(100) DEFAULT '',
             ai_summary LONGTEXT,


### PR DESCRIPTION
### Motivation
- This change adds minimal operational metadata and a lightweight filter so admins can focus on failed pickup exception deliveries and see retry history; migration, admin UI, and retry handling locations are `includes/Install/Activator.php` (dbDelta CREATE TABLE block), `includes/Admin/Pages/PickupExceptionsPage.php` (admin page rendering and link-retry flow), and the retry handlers in `includes/Admin/Ajax/AdminAjax.php::retry_pickup_exception()` and `includes/Admin/Pages/PickupExceptionsPage::handle_retry_request()`.
- The goal is surgical: extend the existing `kerbcycle_pickup_exceptions` table, reuse existing flows and UI, and keep the page read-only except for the existing retry action.

### Description
- Schema: added `retry_count INT NOT NULL DEFAULT 0` and `last_retry_at DATETIME NULL` to the pickup exceptions schema using the existing `dbDelta` migration in `includes/Install/Activator.php` so upgrades are safe and automatic.
- Persistence: initialize new rows with `'retry_count' => 0` and `'last_retry_at' => null` on create via the existing creation path, and extended `PickupExceptionRepository` insert/update formatting to include the new fields.
- Retry behavior: increment `retry_count` and set `last_retry_at` (UTC/MySQL via `current_time('mysql', true)`) on manual retry in both the AJAX retry handler and the admin page retry handler, performed immediately before sending the webhook; initial submission does not increment retries.
- UI & queries: added a minimal `All / Failed Only` filter using `status_filter=failed`, updated server-side queries in both the page render and AJAX list endpoint to conditionally apply `WHERE status = 'failed'` while preserving `ORDER BY id DESC` and `LIMIT 50`, and added `Retry Count` and `Last Retry` columns (and details-row entries) to server-rendered and live-refreshed rows; the JS polling now carries `status_filter` from the page URL so the filter state remains stable after refresh.
- Files changed and key items: `includes/Install/Activator.php`, `includes/Data/Repositories/PickupExceptionRepository.php`, `includes/Admin/Ajax/AdminAjax.php`, `includes/Admin/Pages/PickupExceptionsPage.php`, and `assets/js/admin.js`; schema columns added `retry_count` and `last_retry_at`; filter UI added (`status_filter=failed`); query changes made in page render and AJAX list; retry metadata incremented on manual retry only.

### Testing
- Linted PHP files with `php -l` for `includes/Install/Activator.php`, `includes/Data/Repositories/PickupExceptionRepository.php`, `includes/Admin/Ajax/AdminAjax.php`, and `includes/Admin/Pages/PickupExceptionsPage.php`, and all reported no syntax errors.
- Verified that the AJAX list payload includes `retry_count`/`last_retry_at` and that JS renders the new columns and preserves filter state during refresh (manual inspection of code paths; no browser UI tests run).
- No automated unit tests exist for this area, so changes were kept minimal and localized to make manual review and rollback straightforward.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0642fe87c832d9ae3617eae65df9b)