### PR TITLE
Add scanner-side pickup exception submission panel

### DIFF
--- a/assets/js/dashboard-scanner.js
+++ b/assets/js/dashboard-scanner.js
@@ -226,10 +226,58 @@ function initDashboardScanner() {
   const sendEmailCheckbox = document.getElementById("send-email");
   const sendSmsCheckbox = document.getElementById("send-sms");
   const sendReminderCheckbox = document.getElementById("send-reminder");
+  const scannerReportExceptionBtn = document.getElementById(
+    "kerbcycle-scanner-report-exception-btn",
+  );
+  const scannerExceptionFormWrap = document.getElementById(
+    "kerbcycle-scanner-exception-form-wrap",
+  );
+  const scannerExceptionQrCodeField = document.getElementById(
+    "kerbcycle-scanner-exception-qr-code",
+  );
+  const scannerExceptionCustomerIdField = document.getElementById(
+    "kerbcycle-scanner-exception-customer-id",
+  );
+  const scannerExceptionIssueField = document.getElementById(
+    "kerbcycle-scanner-exception-issue",
+  );
+  const scannerExceptionNotesField = document.getElementById(
+    "kerbcycle-scanner-exception-notes",
+  );
+  const scannerSubmitExceptionBtn = document.getElementById(
+    "kerbcycle-scanner-submit-exception",
+  );
+  const scannerExceptionStatus = document.getElementById(
+    "kerbcycle-scanner-exception-status",
+  );
   let scanner = null;
   let lastScannedCode = "";
   let addInProgress = false;
   let assignInProgress = false;
+  let exceptionSubmitInProgress = false;
+
+  function setScannerExceptionStatus(message, type = "success") {
+    if (!scannerExceptionStatus) {
+      return;
+    }
+    scannerExceptionStatus.style.display = "block";
+    scannerExceptionStatus.style.color =
+      type === "error" ? "#b32d2e" : "#1d2327";
+    scannerExceptionStatus.textContent = message;
+  }
+
+  function syncScannerExceptionContext() {
+    if (scannerExceptionQrCodeField && lastScannedCode) {
+      scannerExceptionQrCodeField.value = lastScannedCode;
+    }
+    if (
+      scannerExceptionCustomerIdField &&
+      dashboardCustomerField &&
+      dashboardCustomerField.value
+    ) {
+      scannerExceptionCustomerIdField.value = dashboardCustomerField.value;
+    }
+  }
 
   function updateAddButtonState() {
     if (!addFromScannerBtn) {
@@ -281,6 +329,7 @@ function initDashboardScanner() {
   if (dashboardCustomerField) {
     dashboardCustomerField.addEventListener("change", () => {
       updateAssignButtonState();
+      syncScannerExceptionContext();
     });
     if (
       dashboardCustomerField._searchable &&
@@ -291,6 +340,110 @@ function initDashboardScanner() {
         updateAssignButtonState,
       );
     }
+  }
+
+  syncScannerExceptionContext();
+
+  if (scannerReportExceptionBtn && scannerExceptionFormWrap) {
+    scannerReportExceptionBtn.addEventListener("click", () => {
+      const isOpen = scannerExceptionFormWrap.style.display !== "none";
+      if (isOpen) {
+        scannerExceptionFormWrap.style.display = "none";
+        scannerReportExceptionBtn.textContent = "Report Exception";
+        return;
+      }
+      syncScannerExceptionContext();
+      scannerExceptionFormWrap.style.display = "block";
+      scannerReportExceptionBtn.textContent = "Hide Exception Form";
+      if (scannerExceptionIssueField) {
+        scannerExceptionIssueField.focus();
+      }
+    });
+  }
+
+  if (scannerSubmitExceptionBtn) {
+    scannerSubmitExceptionBtn.addEventListener("click", () => {
+      if (exceptionSubmitInProgress) {
+        return;
+      }
+
+      const issue = scannerExceptionIssueField
+        ? scannerExceptionIssueField.value.trim()
+        : "";
+      if (!issue) {
+        setScannerExceptionStatus("Issue is required.", "error");
+        return;
+      }
+
+      exceptionSubmitInProgress = true;
+      scannerSubmitExceptionBtn.disabled = true;
+      setScannerExceptionStatus("Saving and sending pickup exception...");
+
+      const params = new URLSearchParams();
+      params.append("action", "kerbcycle_test_pickup_exception");
+      params.append("security", kerbcycle_ajax.nonce);
+      params.append(
+        "qr_code",
+        scannerExceptionQrCodeField ? scannerExceptionQrCodeField.value : "",
+      );
+      params.append(
+        "customer_id",
+        scannerExceptionCustomerIdField
+          ? scannerExceptionCustomerIdField.value
+          : "",
+      );
+      params.append("issue", issue);
+      params.append(
+        "notes",
+        scannerExceptionNotesField ? scannerExceptionNotesField.value : "",
+      );
+
+      fetch(kerbcycle_ajax.ajax_url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        },
+        body: params.toString(),
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          const payload = data && data.data ? data.data : {};
+          if (data && data.success) {
+            setScannerExceptionStatus(
+              payload.message || "Pickup exception saved and submitted.",
+              "success",
+            );
+            if (scannerExceptionIssueField) {
+              scannerExceptionIssueField.value = "";
+            }
+            if (scannerExceptionNotesField) {
+              scannerExceptionNotesField.value = "";
+            }
+            document.dispatchEvent(
+              new CustomEvent("kerbcycle-pickup-exception-submitted", {
+                detail: data,
+              }),
+            );
+            return;
+          }
+          setScannerExceptionStatus(
+            payload.message || "Unable to submit pickup exception.",
+            "error",
+          );
+        })
+        .catch((error) => {
+          setScannerExceptionStatus(
+            error && error.message
+              ? error.message
+              : "Unable to submit pickup exception.",
+            "error",
+          );
+        })
+        .finally(() => {
+          exceptionSubmitInProgress = false;
+          scannerSubmitExceptionBtn.disabled = false;
+        });
+    });
   }
 
   function pauseActiveScanner() {
@@ -660,6 +813,7 @@ function initDashboardScanner() {
     const onScanSuccess = (decodedText) => {
       pauseActiveScanner();
       lastScannedCode = decodedText || "";
+      syncScannerExceptionContext();
       updateAddButtonState();
       updateAssignButtonState();
       const safeCode = escapeHtml(decodedText || "");

--- a/includes/Admin/Pages/DashboardPage.php
+++ b/includes/Admin/Pages/DashboardPage.php
@@ -109,6 +109,36 @@ class DashboardPage
                     ?>
                 <?php endif; ?>
                 <div id="scan-result" class="updated"></div>
+                <div id="kerbcycle-scanner-exception-panel" class="postbox" style="margin-top:12px;">
+                    <h2 class="hndle"><?php esc_html_e('Pickup Exception', 'kerbcycle'); ?></h2>
+                    <div class="inside">
+                        <p class="description"><?php esc_html_e('Report a real pickup exception from the current scan context.', 'kerbcycle'); ?></p>
+                        <button id="kerbcycle-scanner-report-exception-btn" class="button">
+                            <?php esc_html_e('Report Exception', 'kerbcycle'); ?>
+                        </button>
+                        <div id="kerbcycle-scanner-exception-form-wrap" style="display:none; margin-top:10px;">
+                            <div class="qr-select-group" style="margin-bottom:8px;">
+                                <input type="text" id="kerbcycle-scanner-exception-qr-code" placeholder="<?php esc_attr_e('QR Code', 'kerbcycle'); ?>" />
+                                <input type="number" id="kerbcycle-scanner-exception-customer-id" min="1" step="1" placeholder="<?php esc_attr_e('Customer ID', 'kerbcycle'); ?>" />
+                            </div>
+                            <div class="qr-select-group" style="margin-bottom:8px;">
+                                <input type="text" id="kerbcycle-scanner-exception-issue" placeholder="<?php esc_attr_e('Issue (required)', 'kerbcycle'); ?>" />
+                            </div>
+                            <div class="qr-select-group" style="margin-bottom:8px;">
+                                <textarea id="kerbcycle-scanner-exception-notes" rows="3" style="width:100%;" placeholder="<?php esc_attr_e('Notes', 'kerbcycle'); ?>"></textarea>
+                            </div>
+                            <button id="kerbcycle-scanner-submit-exception" class="button button-primary">
+                                <?php esc_html_e('Submit Pickup Exception', 'kerbcycle'); ?>
+                            </button>
+                            <p id="kerbcycle-scanner-exception-status" class="description" style="margin-top:8px;"></p>
+                            <p class="description" style="margin-top:4px;">
+                                <a href="<?php echo esc_url(admin_url('admin.php?page=kerbcycle-pickup-exceptions')); ?>">
+                                    <?php esc_html_e('View Pickup Exceptions', 'kerbcycle'); ?>
+                                </a>
+                            </p>
+                        </div>
+                    </div>
+                </div>
                 <div id="kerbcycle-ai-panel" class="postbox">
                     <h2 class="hndle"><?php esc_html_e('AI Assistant (Beta)', 'kerbcycle'); ?></h2>
                     <div class="inside">


### PR DESCRIPTION
### Motivation
- Allow operators to report a real pickup exception directly from the dashboard scanner workflow while reusing the existing pickup-exception pipeline (local save, webhook, AI) without adding a second backend flow. 
- Keep the change surgical and UI-only on the scanner/admin page so scanner behavior and the existing Pickup Exceptions admin page remain unchanged.

### Description
- Added a small inline `Pickup Exception` panel to `includes/Admin/Pages/DashboardPage.php` containing a `Report Exception` toggle button, fields for `QR Code`, `Customer ID`, `Issue`, `Notes`, a `Submit Pickup Exception` button, a status line, and a link to the existing Pickup Exceptions admin page. 
- Implemented scanner-side wiring in `assets/js/dashboard-scanner.js` to toggle the form, prefill `qr_code` from the last scanned value and `customer_id` from the dashboard customer select when available, and submit asynchronously via the existing AJAX action `kerbcycle_test_pickup_exception` (no new backend handler or duplicate pipeline). 
- Submit logic follows the existing AJAX pattern (`URLSearchParams` → `fetch` to `kerbcycle_ajax.ajax_url`) and surfaces clean success/error messages in the scanner UI while leaving scan lifecycle unchanged; on success the code keeps QR/customer context and clears only `Issue` and `Notes`. 
- Minimal scope: only touched two files and made no DB, webhook, n8n, AI, or backend flow changes.

### Testing
- Ran PHP syntax check: `php -l includes/Admin/Pages/DashboardPage.php` which passed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d068ead13c832db6666f4309a35cd5)