### PR TITLE
Add Report Exception action to front-end scanner shortcode UI

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -590,6 +590,16 @@ function initKerbcycleScanner() {
   const scanResult = document.getElementById("scan-result");
   const assignBtn = document.getElementById("assign-qr-btn");
   const resetBtn = document.getElementById("reset-scan-btn");
+  const reportExceptionBtn = document.getElementById("report-exception-btn");
+  const exceptionFormWrap = document.getElementById("scanner-exception-form-wrap");
+  const exceptionQrField = document.getElementById("scanner-exception-qr-code");
+  const exceptionCustomerField = document.getElementById(
+    "scanner-exception-customer-id",
+  );
+  const exceptionIssueField = document.getElementById("scanner-exception-issue");
+  const exceptionNotesField = document.getElementById("scanner-exception-notes");
+  const submitExceptionBtn = document.getElementById("scanner-submit-exception");
+  const exceptionStatus = document.getElementById("scanner-exception-status");
   const customerIdField = document.getElementById("customer-id");
   let scannedCode = "";
 
@@ -915,6 +925,115 @@ function initKerbcycleScanner() {
           // Always attempt to reactivate the scanner after handling the
           // assignment request, even when the server returns an error.
           activateScanner({ showError: true });
+        });
+    });
+  }
+
+  function setExceptionStatus(type, html) {
+    if (!exceptionStatus) return;
+    exceptionStatus.style.display = "block";
+    exceptionStatus.classList.remove("error", "updated");
+    if (type === "error") {
+      exceptionStatus.classList.add("error");
+    } else {
+      exceptionStatus.classList.add("updated");
+    }
+    exceptionStatus.innerHTML = html;
+  }
+
+  function prefillExceptionFields() {
+    if (exceptionQrField) {
+      exceptionQrField.value = scannedCode || "";
+    }
+    if (exceptionCustomerField && customerIdField) {
+      exceptionCustomerField.value = customerIdField.value || "";
+    }
+  }
+
+  if (reportExceptionBtn && exceptionFormWrap) {
+    reportExceptionBtn.addEventListener("click", () => {
+      const isHidden = exceptionFormWrap.style.display === "none";
+      exceptionFormWrap.style.display = isHidden ? "block" : "none";
+      if (isHidden) {
+        prefillExceptionFields();
+      }
+    });
+  }
+
+  if (submitExceptionBtn) {
+    submitExceptionBtn.addEventListener("click", () => {
+      const qrCode = exceptionQrField ? exceptionQrField.value.trim() : "";
+      const customerId = exceptionCustomerField
+        ? exceptionCustomerField.value.trim()
+        : "";
+      const issue = exceptionIssueField ? exceptionIssueField.value.trim() : "";
+      const notes = exceptionNotesField ? exceptionNotesField.value.trim() : "";
+
+      if (!issue) {
+        setExceptionStatus("error", "<strong>❌ Issue is required.</strong>");
+        return;
+      }
+
+      if (!qrCode && !customerId) {
+        setExceptionStatus(
+          "error",
+          "<strong>❌ Provide at least a QR Code or Customer ID.</strong>",
+        );
+        return;
+      }
+
+      submitExceptionBtn.disabled = true;
+      submitExceptionBtn.setAttribute("aria-busy", "true");
+      setExceptionStatus("success", "Saving and sending pickup exception...");
+
+      const params = new URLSearchParams();
+      params.append("action", "kerbcycle_test_pickup_exception");
+      params.append("security", kerbcycle_ajax.nonce);
+      params.append("qr_code", qrCode);
+      params.append("customer_id", customerId);
+      params.append("issue", issue);
+      params.append("notes", notes);
+
+      fetch(kerbcycle_ajax.ajax_url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        },
+        body: params.toString(),
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          if (data && data.success && data.data) {
+            const payload = data.data;
+            const isFullSuccess = payload.status === "success";
+            const msg = payload.message || "Pickup exception submitted.";
+            setExceptionStatus(
+              isFullSuccess ? "success" : "error",
+              `<strong>${isFullSuccess ? "✅" : "⚠️"} ${escapeHtml(msg)}</strong>`,
+            );
+            if (exceptionIssueField) {
+              exceptionIssueField.value = "";
+            }
+            if (exceptionNotesField) {
+              exceptionNotesField.value = "";
+            }
+          } else {
+            const msg =
+              data && data.data && data.data.message
+                ? data.data.message
+                : "Unable to submit pickup exception.";
+            setExceptionStatus("error", `<strong>❌ ${escapeHtml(msg)}</strong>`);
+          }
+        })
+        .catch((error) => {
+          setExceptionStatus(
+            "error",
+            `<strong>❌ Unable to submit pickup exception.</strong><br>${escapeHtml(String(error))}`,
+          );
+        })
+        .finally(() => {
+          submitExceptionBtn.disabled = false;
+          submitExceptionBtn.removeAttribute("aria-busy");
         });
     });
   }

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -406,7 +406,7 @@ class AdminAjax
     public function test_pickup_exception()
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
-        if (!current_user_can('manage_options')) {
+        if (!is_user_logged_in()) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
         \Kerbcycle\QrCode\Install\Activator::activate();

--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -63,6 +63,15 @@ class Shortcodes
             <div class="kerbcycle-scanner-actions">
                 <button id="assign-qr-btn" class="button button-primary">Assign QR Code</button>
                 <button id="reset-scan-btn" class="button button-primary"><?php esc_html_e('Scan Reset', 'kerbcycle'); ?></button>
+                <button id="report-exception-btn" class="button"><?php esc_html_e('Report Exception', 'kerbcycle'); ?></button>
+            </div>
+            <div id="scanner-exception-form-wrap" style="display:none; margin-top:12px;">
+                <input type="text" id="scanner-exception-qr-code" placeholder="<?php esc_attr_e('QR Code', 'kerbcycle'); ?>" style="width:100%; margin-bottom:8px;" />
+                <input type="number" id="scanner-exception-customer-id" min="1" step="1" placeholder="<?php esc_attr_e('Customer ID', 'kerbcycle'); ?>" style="width:100%; margin-bottom:8px;" />
+                <input type="text" id="scanner-exception-issue" placeholder="<?php esc_attr_e('Issue (required)', 'kerbcycle'); ?>" style="width:100%; margin-bottom:8px;" />
+                <textarea id="scanner-exception-notes" rows="3" placeholder="<?php esc_attr_e('Notes', 'kerbcycle'); ?>" style="width:100%; margin-bottom:8px;"></textarea>
+                <button id="scanner-submit-exception" class="button button-primary"><?php esc_html_e('Submit Exception', 'kerbcycle'); ?></button>
+                <div id="scanner-exception-status" class="updated" style="display:none; margin-top:10px;"></div>
             </div>
             <div id="reader" style="width: 100%; max-width: 400px; margin-top: 20px;"></div>
             <div id="scan-result" class="updated" style="display: none;"></div>


### PR DESCRIPTION
### Motivation
- Provide operators on the actual front-end scanner page a minimal way to report pickup exceptions without leaving the scanner workflow. 
- Reuse the existing pickup-exception persistence, webhook, and AI pipeline rather than creating duplicate backend logic. 
- Keep the UI small and consistent with the scanner shortcode, and use the same AJAX/nonce/localization patterns already present on the front-end scanner.

### Description
- Added a `Report Exception` button and a lightweight inline form (fields: `QR Code`, `Customer ID`, `Issue` (required), `Notes`) to the scanner shortcode output by updating `includes/Public/Shortcodes.php`. 
- Wired the form into the front-end scanner script in `assets/js/qr-scanner.js` to toggle the form, prefill `QR Code` from the current `scannedCode` and `Customer ID` from the selected `customer-id`, validate `issue`, submit asynchronously using the existing `kerbcycle_ajax` AJAX + nonce pattern to the existing action `kerbcycle_test_pickup_exception`, and show inline success/partial/error messages while only clearing `issue` and `notes` on success. 
- Reused the existing backend handler and pipeline in `includes/Admin/Ajax/AdminAjax.php` by leaving all save/webhook/AI behavior intact and relaxing the permission check to `is_user_logged_in()` so logged-in front-end operators can submit while the nonce verification remains in place. 
- Files changed: `includes/Public/Shortcodes.php`, `assets/js/qr-scanner.js`, and `includes/Admin/Ajax/AdminAjax.php`.

### Testing
- Ran PHP syntax checks which passed for `includes/Public/Shortcodes.php` and `includes/Admin/Ajax/AdminAjax.php`. 
- Ran a JS syntax check with `node --check` which passed for `assets/js/qr-scanner.js`. 
- No browser UI automation was run in this environment; runtime verification was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d075d05a6c832d8fb13f5f3488e0da)