### PR TITLE
Harden auth and input validation for KerbCycle privileged flows

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -293,6 +293,17 @@ class AdminAjax
             wp_send_json_error(['message' => __('No file uploaded.', 'kerbcycle')]);
         }
 
+        $file_name = isset($_FILES['import_file']['name']) ? sanitize_file_name(wp_unslash($_FILES['import_file']['name'])) : '';
+        $extension = strtolower(pathinfo($file_name, PATHINFO_EXTENSION));
+        if ($extension !== 'csv') {
+            wp_send_json_error(['message' => __('Only CSV files are allowed.', 'kerbcycle')]);
+        }
+
+        $file_size = isset($_FILES['import_file']['size']) ? (int) $_FILES['import_file']['size'] : 0;
+        if ($file_size < 1 || $file_size > 5 * MB_IN_BYTES) {
+            wp_send_json_error(['message' => __('Invalid file size.', 'kerbcycle')]);
+        }
+
         $handle = fopen($_FILES['import_file']['tmp_name'], 'r');
         if (!$handle) {
             wp_send_json_error(['message' => __('Could not read uploaded file.', 'kerbcycle')]);
@@ -406,7 +417,7 @@ class AdminAjax
     public function test_pickup_exception()
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
-        if (!is_user_logged_in()) {
+        if (!current_user_can('manage_options')) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
         \Kerbcycle\QrCode\Install\Activator::activate();

--- a/includes/Admin/Pages/RoutingPage.php
+++ b/includes/Admin/Pages/RoutingPage.php
@@ -394,6 +394,9 @@ class RoutingPage
     public function ajax_test()
     {
         check_ajax_referer('kc_osrm_test');
+        if (!current_user_can('manage_options')) {
+            wp_send_json(['ok' => false, 'error' => __('Unauthorized', 'kerbcycle')], 403);
+        }
 
         $options = OsrmService::get_options();
         $endpoint = OsrmService::current_endpoint($options);

--- a/includes/Api/RestService.php
+++ b/includes/Api/RestService.php
@@ -46,7 +46,7 @@ class RestService
             'methods'  => 'GET',
             'callback' => [new Controllers\QrController(), 'get_qr_status'],
             'permission_callback' => function () {
-                return is_user_logged_in();
+                return current_user_can('edit_posts');
             },
         ]);
 


### PR DESCRIPTION
### Motivation
- Close privilege and input-validation gaps discovered during an audit of AJAX/REST/upload handlers that could allow lower-privileged users to trigger admin/scanner/webhook flows or upload unexpected files. 
- Apply minimal, surgical fixes that preserve existing routes, nonces, option names, DB tables and response shapes while enforcing appropriate guards. 

### Description
- `includes/Admin/Ajax/AdminAjax.php`: tightened `test_pickup_exception()` to require `current_user_can('manage_options')` instead of `is_user_logged_in()` and added CSV extension and file-size checks to the import flow to ensure only reasonable CSV uploads are processed. 
- `includes/Admin/Pages/RoutingPage.php`: added an explicit `current_user_can('manage_options')` check to `ajax_test()` (after the nonce) to prevent lower-privileged users from invoking the outbound OSRM test. 
- `includes/Api/RestService.php`: narrowed the `/kerbcycle/v1/qr-status` route `permission_callback` from `is_user_logged_in()` to `current_user_can('edit_posts')` to reduce data exposure to only editors+ roles. 

### Testing
- Ran PHP syntax checks which all succeeded: `php -l includes/Admin/Ajax/AdminAjax.php`, `php -l includes/Admin/Pages/RoutingPage.php`, and `php -l includes/Api/RestService.php` (no syntax errors). 
- Verified the modified handlers return appropriate JSON/WP_Error on unauthorized access by inspection and ensured added upload checks are simple and deterministic (file extension and size bounds). 
- No other automated unit tests were executed in this patch; manual/role-based integration tests recommended in the PR notes (UI role checks and `/qr-status` access expectations).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d59f821724832db7dda3b5d6ae5b2d)