### PR TITLE
Harden QR lifecycle guards and make pickup-exception retries idempotent

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -24,6 +24,7 @@ use Kerbcycle\QrCode\Admin\Pages\DashboardPage;
 class AdminAjax
 {
     private $qr_service;
+    private const RETRY_LOCK_TTL = 120;
 
     /**
      * Initialize the class and set its properties.
@@ -704,6 +705,10 @@ class AdminAjax
             wp_send_json_error(['message' => __('This pickup exception is not eligible for retry.', 'kerbcycle')], 400);
         }
 
+        if (!$this->acquire_retry_lock($exception_id)) {
+            wp_send_json_error(['message' => __('Retry already in progress for this pickup exception.', 'kerbcycle')], 409);
+        }
+
         $retry_timestamp = current_time('mysql', true);
         PickupExceptionRepository::update_result($exception_id, [
             'retry_count' => ((int) $record->retry_count) + 1,
@@ -731,7 +736,7 @@ class AdminAjax
                 'ai_recommended_action'    => '',
                 'updated_at'               => current_time('mysql', true),
             ]);
-
+            $this->release_retry_lock($exception_id);
             wp_send_json_error(['message' => __('Retry failed. The record remains saved locally.', 'kerbcycle')], 500);
         }
 
@@ -754,7 +759,7 @@ class AdminAjax
                 'ai_recommended_action'    => $ai_recommended_action,
                 'updated_at'               => current_time('mysql', true),
             ]);
-
+            $this->release_retry_lock($exception_id);
             wp_send_json_success(['message' => __('Pickup exception resent successfully.', 'kerbcycle')]);
         }
 
@@ -770,7 +775,28 @@ class AdminAjax
             'ai_recommended_action'    => '',
             'updated_at'               => current_time('mysql', true),
         ]);
-
+        $this->release_retry_lock($exception_id);
         wp_send_json_error(['message' => __('Retry failed. The record remains saved locally.', 'kerbcycle')], 500);
+    }
+
+    private function retry_lock_key($exception_id)
+    {
+        return 'kerbcycle_pickup_retry_lock_' . (int) $exception_id;
+    }
+
+    private function acquire_retry_lock($exception_id)
+    {
+        $key = $this->retry_lock_key($exception_id);
+        $now = time();
+        $expires_at = (int) get_option($key, 0);
+        if ($expires_at > 0 && $expires_at <= $now) {
+            delete_option($key);
+        }
+        return add_option($key, (string) ($now + self::RETRY_LOCK_TTL), '', 'no');
+    }
+
+    private function release_retry_lock($exception_id)
+    {
+        delete_option($this->retry_lock_key($exception_id));
     }
 }

--- a/includes/Admin/Pages/PickupExceptionsPage.php
+++ b/includes/Admin/Pages/PickupExceptionsPage.php
@@ -14,6 +14,8 @@ if (!defined('ABSPATH')) {
  */
 class PickupExceptionsPage
 {
+    private const RETRY_LOCK_TTL = 120;
+
     public function render()
     {
         if (!current_user_can('manage_options')) {
@@ -230,6 +232,10 @@ class PickupExceptionsPage
             $this->redirect_with_retry_notice('error', __('This pickup exception is not eligible for retry.', 'kerbcycle'));
         }
 
+        if (!$this->acquire_retry_lock($exception_id)) {
+            $this->redirect_with_retry_notice('error', __('Retry already in progress for this pickup exception.', 'kerbcycle'));
+        }
+
         $retry_timestamp = current_time('mysql', true);
         PickupExceptionRepository::update_result($exception_id, [
             'retry_count' => ((int) $record->retry_count) + 1,
@@ -257,7 +263,7 @@ class PickupExceptionsPage
                 'ai_recommended_action'    => '',
                 'updated_at'               => current_time('mysql', true),
             ]);
-
+            $this->release_retry_lock($exception_id);
             $this->redirect_with_retry_notice('error', __('Retry failed. The record remains saved locally.', 'kerbcycle'));
         }
 
@@ -280,7 +286,7 @@ class PickupExceptionsPage
                 'ai_recommended_action'    => $ai_recommended_action,
                 'updated_at'               => current_time('mysql', true),
             ]);
-
+            $this->release_retry_lock($exception_id);
             $this->redirect_with_retry_notice('success', __('Pickup exception resent successfully.', 'kerbcycle'));
         }
 
@@ -296,8 +302,29 @@ class PickupExceptionsPage
             'ai_recommended_action'    => '',
             'updated_at'               => current_time('mysql', true),
         ]);
-
+        $this->release_retry_lock($exception_id);
         $this->redirect_with_retry_notice('error', __('Retry failed. The record remains saved locally.', 'kerbcycle'));
+    }
+
+    private function retry_lock_key($exception_id)
+    {
+        return 'kerbcycle_pickup_retry_lock_' . (int) $exception_id;
+    }
+
+    private function acquire_retry_lock($exception_id)
+    {
+        $key = $this->retry_lock_key($exception_id);
+        $now = time();
+        $expires_at = (int) get_option($key, 0);
+        if ($expires_at > 0 && $expires_at <= $now) {
+            delete_option($key);
+        }
+        return add_option($key, (string) ($now + self::RETRY_LOCK_TTL), '', 'no');
+    }
+
+    private function release_retry_lock($exception_id)
+    {
+        delete_option($this->retry_lock_key($exception_id));
     }
 
     private function redirect_with_retry_notice($status, $message)

--- a/includes/Services/QrService.php
+++ b/includes/Services/QrService.php
@@ -41,6 +41,11 @@ class QrService
 
     public function assign($qr_code, $user_id, $send_email, $send_sms, $send_reminder)
     {
+        $user_id = (int) $user_id;
+        if ($user_id < 1 || !get_userdata($user_id)) {
+            return new \WP_Error('invalid_customer', __('Invalid customer selected.', 'kerbcycle'));
+        }
+
         $existing = $this->repository->find_by_qr_code($qr_code);
         if ($existing && isset($existing->status) && $existing->status === 'assigned') {
             if ((int) $existing->user_id === (int) $user_id) {
@@ -83,6 +88,22 @@ class QrService
         if ($result === false) {
             return new \WP_Error('db_error', 'Failed to assign QR code in database.');
         }
+        if ($result === 0) {
+            $latest = $this->repository->find_by_qr_code($qr_code);
+            if ($latest && isset($latest->status) && $latest->status === 'assigned') {
+                if ((int) $latest->user_id === $user_id) {
+                    return new \WP_Error(
+                        'qr_code_already_assigned',
+                        __('This QR code is already assigned to the selected customer.', 'kerbcycle')
+                    );
+                }
+                return new \WP_Error(
+                    'qr_code_already_assigned',
+                    __('This QR code was assigned by another request. Refresh and try again.', 'kerbcycle')
+                );
+            }
+            return new \WP_Error('db_error', 'Failed to assign QR code in database.');
+        }
 
         $sms_result   = null;
         $email_result = null;
@@ -107,6 +128,9 @@ class QrService
         $row = $this->repository->find_by_qr_code($qr_code);
         if (!$row) {
             return new \WP_Error('not_found', 'QR code not found.');
+        }
+        if (!isset($row->status) || $row->status !== 'assigned') {
+            return new \WP_Error('invalid_state', __('QR code is not currently assigned.', 'kerbcycle'));
         }
 
         $result = $this->repository->release_latest_assigned($qr_code);


### PR DESCRIPTION
### Motivation

- Prevent race conditions and duplicate side effects when assigning/releasing QR codes or retrying pickup-exception webhooks.
- Ensure server-side validation prevents impossible assigned states created from stale client input.
- Make manual/admin retry flows idempotent so concurrent retries cannot produce duplicate outbound webhooks.

### Description

- Added server-side customer validation in `QrService::assign()` to reject invalid or non-existent `customer_id` values. 
- Added no-op update handling in `QrService::assign()` so when DB updates affect `0` rows the code re-checks the latest state and fails safely instead of proceeding as if successful. 
- Added an explicit current-state precondition in `QrService::release()` to block releases when the QR is not currently `assigned`. 
- Introduced a short-lived per-exception retry lock (TTL) and helper methods (`retry_lock_key`, `acquire_retry_lock`, `release_retry_lock`) in both `includes/Admin/Ajax/AdminAjax.php` and `includes/Admin/Pages/PickupExceptionsPage.php` to prevent concurrent retry attempts from triggering duplicate webhook sends; stale-lock cleanup is implemented before acquiring a lock. 
- All changes are localized to the assignment/release and pickup-exception retry paths and do not change routes, option names, DB schema, response shapes, hooks, or UI contracts.

### Testing

- Ran syntax checks: `php -l includes/Services/QrService.php`, `php -l includes/Admin/Ajax/AdminAjax.php`, and `php -l includes/Admin/Pages/PickupExceptionsPage.php` and they returned no syntax errors. (success)
- Executed the existing test file `php tests/capture_admin_notices_test.php` which completed without error in this environment. (success)
- Manual verification checklist (to run in staging): confirm concurrent assign attempts yield one success + one informative error, rapid/duplicate retry attempts return a “retry in progress” response or are blocked, stale-lock expiry (~120s) allows subsequent retry, and release attempts on non-assigned QR codes return an explicit invalid-state error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b1ad07e8832d8260d000a979fd8c)