### PR TITLE
Harden QR REST permissions and validate inputs

### DIFF
--- a/includes/Api/Controllers/QrController.php
+++ b/includes/Api/Controllers/QrController.php
@@ -32,12 +32,20 @@ class QrController
      */
     public function handle_qr_code_scan(WP_REST_Request $request)
     {
-        if (!current_user_can('edit_posts')) {
+        if (!current_user_can('manage_options')) {
             return new \WP_Error('rest_forbidden', __('Unauthorized', 'kerbcycle'), ['status' => 403]);
         }
 
         $qr_code = sanitize_text_field($request->get_param('qr_code'));
         $user_id = intval($request->get_param('user_id'));
+
+        if ($qr_code === '') {
+            return new \WP_Error('invalid_qr_code', __('QR code is required.', 'kerbcycle'), ['status' => 400]);
+        }
+
+        if ($user_id < 1 || !get_userdata($user_id)) {
+            return new \WP_Error('invalid_user', __('Invalid customer selected.', 'kerbcycle'), ['status' => 400]);
+        }
 
         $nonce_check = Nonces::verify('kerbcycle_qr_nonce', 'nonce', $request);
         if (is_wp_error($nonce_check)) {
@@ -85,6 +93,10 @@ class QrController
      */
     public function get_qr_status(WP_REST_Request $request)
     {
+        if (!current_user_can('manage_options')) {
+            return new \WP_Error('rest_forbidden', __('Unauthorized', 'kerbcycle'), ['status' => 403]);
+        }
+
         global $wpdb;
         $qr_code = sanitize_text_field($request['qr_code']);
         $table   = $wpdb->prefix . 'kerbcycle_qr_codes';

--- a/includes/Api/RestService.php
+++ b/includes/Api/RestService.php
@@ -38,7 +38,7 @@ class RestService
             'methods'  => 'POST',
             'callback' => [new Controllers\QrController(), 'handle_qr_code_scan'],
             'permission_callback' => function () {
-                return current_user_can('edit_posts');
+                return current_user_can('manage_options');
             },
         ]);
 
@@ -46,7 +46,7 @@ class RestService
             'methods'  => 'GET',
             'callback' => [new Controllers\QrController(), 'get_qr_status'],
             'permission_callback' => function () {
-                return current_user_can('edit_posts');
+                return current_user_can('manage_options');
             },
         ]);
 


### PR DESCRIPTION
### Motivation

- Reduce risk of low-privilege users mutating QR assignment state or probing QR status via the REST API by tightening permissions and adding server-side checks.
- Remove frontend→backend trust assumptions by validating required inputs before any state mutation.
- Add controller-level authorization as defense-in-depth in case route wiring changes.

### Description

- Tightened REST route permission callbacks for `/kerbcycle/v1/qr-code/scanned` and `/kerbcycle/v1/qr-status/...` from `edit_posts` to `manage_options` in `includes/Api/RestService.php`.
- Enforced admin-only access checks at the controller level in `QrController::handle_qr_code_scan` and `QrController::get_qr_status` to provide defense-in-depth in `includes/Api/Controllers/QrController.php`.
- Added server-side validation in `QrController::handle_qr_code_scan` to reject empty `qr_code` and to require a valid existing `user_id` before calling the assignment logic, returning appropriate `WP_Error` responses.

### Testing

- Ran PHP syntax checks with `php -l includes/Api/RestService.php` and `php -l includes/Api/Controllers/QrController.php`, both succeeded.
- Verified no syntax errors introduced by the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b9577540832d9ac1213d97e654bb)