### PR TITLE
Add security_boundary_characterization_test to exercise AJAX, REST and shortcode boundaries

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -223,7 +223,6 @@
   margin: 10px 0;
 }
 
-
 #kerbcycle-ai-panel {
   margin: 16px 0;
   max-width: 900px;

--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -90,7 +90,10 @@
   padding: 10px 14px;
   background: #0b5;
   color: #fff;
-  font: 600 14px/1 system-ui, Arial, sans-serif;
+  font:
+    600 14px/1 system-ui,
+    Arial,
+    sans-serif;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
   opacity: 0.96;
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -666,7 +666,9 @@ function initKerbcycleAdmin() {
   }
 
   function trimPickupText(value, maxWords = 20) {
-    const text = String(value || "").replace(/\s+/g, " ").trim();
+    const text = String(value || "")
+      .replace(/\s+/g, " ")
+      .trim();
     if (!text) {
       return "";
     }
@@ -711,7 +713,12 @@ function initKerbcycleAdmin() {
     })
       .then((res) => res.json())
       .then((data) => {
-        if (!data || !data.success || !data.data || !Array.isArray(data.data.rows)) {
+        if (
+          !data ||
+          !data.success ||
+          !data.data ||
+          !Array.isArray(data.data.rows)
+        ) {
           return;
         }
         const rows = data.data.rows;
@@ -786,7 +793,7 @@ function initKerbcycleAdmin() {
       .replaceAll("&", "&amp;")
       .replaceAll("<", "&lt;")
       .replaceAll(">", "&gt;")
-      .replaceAll("\"", "&quot;")
+      .replaceAll('"', "&quot;")
       .replaceAll("'", "&#039;");
   }
 
@@ -801,7 +808,10 @@ function initKerbcycleAdmin() {
 
   function callAiAction(action) {
     if (!kerbcycle_ajax.rest_url || !kerbcycle_ajax.rest_nonce) {
-      setAiResult("<p>AI endpoint is not configured in admin assets.</p>", "notice-error");
+      setAiResult(
+        "<p>AI endpoint is not configured in admin assets.</p>",
+        "notice-error",
+      );
       return;
     }
 
@@ -847,7 +857,10 @@ function initKerbcycleAdmin() {
                 )
             : [];
           const totalExceptions = Array.isArray(data.source?.groups)
-            ? data.source.groups.reduce((sum, group) => sum + (group.count || 0), 0)
+            ? data.source.groups.reduce(
+                (sum, group) => sum + (group.count || 0),
+                0,
+              )
             : 0;
 
           setAiResult(
@@ -872,7 +885,10 @@ function initKerbcycleAdmin() {
       })
       .catch((error) => {
         console.error("AI request failed:", error);
-        setAiResult(`<p>${escapeHtml(error.message || "AI request failed.")}</p>`, "notice-error");
+        setAiResult(
+          `<p>${escapeHtml(error.message || "AI request failed.")}</p>`,
+          "notice-error",
+        );
         if (aiStatus) {
           aiStatus.textContent = "AI request failed.";
         }
@@ -897,19 +913,29 @@ function initKerbcycleAdmin() {
       pickupExceptionTestBtn.disabled = true;
       pickupExceptionTestBtn.textContent = "Submitting...";
       if (pickupExceptionTestResult) {
-        pickupExceptionTestResult.textContent = "Saving and sending pickup exception...";
+        pickupExceptionTestResult.textContent =
+          "Saving and sending pickup exception...";
       }
 
       const params = new URLSearchParams();
       params.append("action", "kerbcycle_test_pickup_exception");
       params.append("security", kerbcycle_ajax.nonce);
-      params.append("qr_code", pickupExceptionQrCode ? pickupExceptionQrCode.value : "");
+      params.append(
+        "qr_code",
+        pickupExceptionQrCode ? pickupExceptionQrCode.value : "",
+      );
       params.append(
         "customer_id",
         pickupExceptionCustomerId ? pickupExceptionCustomerId.value : "",
       );
-      params.append("issue", pickupExceptionIssue ? pickupExceptionIssue.value : "");
-      params.append("notes", pickupExceptionNotes ? pickupExceptionNotes.value : "");
+      params.append(
+        "issue",
+        pickupExceptionIssue ? pickupExceptionIssue.value : "",
+      );
+      params.append(
+        "notes",
+        pickupExceptionNotes ? pickupExceptionNotes.value : "",
+      );
 
       fetch(kerbcycle_ajax.ajax_url, {
         method: "POST",
@@ -921,7 +947,9 @@ function initKerbcycleAdmin() {
         .then((res) => res.json())
         .then((data) => {
           document.dispatchEvent(
-            new CustomEvent("kerbcycle-pickup-exception-submitted", { detail: data }),
+            new CustomEvent("kerbcycle-pickup-exception-submitted", {
+              detail: data,
+            }),
           );
           if (pickupExceptionTestResult) {
             const payload = data && data.data ? data.data : {};
@@ -934,7 +962,11 @@ function initKerbcycleAdmin() {
               ai_category: payload.ai_category || "",
               ai_severity: payload.ai_severity || "",
             };
-            pickupExceptionTestResult.textContent = JSON.stringify(output, null, 2);
+            pickupExceptionTestResult.textContent = JSON.stringify(
+              output,
+              null,
+              2,
+            );
           }
         })
         .catch((error) => {
@@ -1068,7 +1100,7 @@ function initKerbcycleAdmin() {
         }
         const visibleIds = new Set(
           Array.from(
-            pickupExceptionsTbody.querySelectorAll('tr[data-exception-id]'),
+            pickupExceptionsTbody.querySelectorAll("tr[data-exception-id]"),
             (row) => row.getAttribute("data-exception-id"),
           ).filter(Boolean),
         );

--- a/assets/js/kc-osrm.js
+++ b/assets/js/kc-osrm.js
@@ -46,11 +46,9 @@
     }
 
     var storedStart = readStoredDefaultStart();
-    var start =
-      parseLatLon(storedStart) ||
+    var start = parseLatLon(storedStart) ||
       parseLatLon(cfg.start) ||
-      parseLatLon(KC_OSRM.defaultStart) ||
-      [40.73, -73.99];
+      parseLatLon(KC_OSRM.defaultStart) || [40.73, -73.99];
     var end = parseLatLon(cfg.end) || [40.78, -73.97];
 
     var parent = el.parentNode;
@@ -74,7 +72,8 @@
       btn.type = "button";
       btn.textContent = label;
       btn.className =
-        "button " + (priority === "primary" ? "button-primary" : "button-secondary");
+        "button " +
+        (priority === "primary" ? "button-primary" : "button-secondary");
       return btn;
     }
 
@@ -181,7 +180,10 @@
     var geocodeDelayMs = 1100;
 
     function pickVoice() {
-      if (!window.speechSynthesis || typeof window.speechSynthesis.getVoices !== "function") {
+      if (
+        !window.speechSynthesis ||
+        typeof window.speechSynthesis.getVoices !== "function"
+      ) {
         return null;
       }
       var voices = window.speechSynthesis.getVoices() || [];
@@ -195,7 +197,10 @@
           var voice = voices[j];
           var name = voice && voice.name ? voice.name : "";
           var lang = voice && voice.lang ? voice.lang : "";
-          if ((name && name.indexOf(target) !== -1) || (lang && lang === target)) {
+          if (
+            (name && name.indexOf(target) !== -1) ||
+            (lang && lang === target)
+          ) {
             return voice;
           }
         }
@@ -236,7 +241,10 @@
         } else {
           utterance.lang = "en-US";
         }
-        if (window.speechSynthesis && typeof window.speechSynthesis.cancel === "function") {
+        if (
+          window.speechSynthesis &&
+          typeof window.speechSynthesis.cancel === "function"
+        ) {
           window.speechSynthesis.cancel();
           window.speechSynthesis.speak(utterance);
           return true;
@@ -329,10 +337,16 @@
       ) {
         if (typeof window.speechSynthesis.addEventListener === "function") {
           var handleVoicesReady = function handleVoicesReady() {
-            window.speechSynthesis.removeEventListener("voiceschanged", handleVoicesReady);
+            window.speechSynthesis.removeEventListener(
+              "voiceschanged",
+              handleVoicesReady,
+            );
             refreshPreferredVoice();
           };
-          window.speechSynthesis.addEventListener("voiceschanged", handleVoicesReady);
+          window.speechSynthesis.addEventListener(
+            "voiceschanged",
+            handleVoicesReady,
+          );
         } else {
           var originalHandler = window.speechSynthesis.onvoiceschanged;
           window.speechSynthesis.onvoiceschanged = function (event) {
@@ -356,7 +370,10 @@
     if (window.speechSynthesis) {
       refreshPreferredVoice();
       if (typeof window.speechSynthesis.addEventListener === "function") {
-        window.speechSynthesis.addEventListener("voiceschanged", refreshPreferredVoice);
+        window.speechSynthesis.addEventListener(
+          "voiceschanged",
+          refreshPreferredVoice,
+        );
       } else {
         var oldHandler = window.speechSynthesis.onvoiceschanged;
         window.speechSynthesis.onvoiceschanged = function (event) {
@@ -371,7 +388,9 @@
     function nativeAvailable() {
       var cap =
         (typeof window !== "undefined" && window.Capacitor) ||
-        (typeof window !== "undefined" && window.capacitorExports && window.capacitorExports.Capacitor);
+        (typeof window !== "undefined" &&
+          window.capacitorExports &&
+          window.capacitorExports.Capacitor);
       if (!cap) {
         return false;
       }
@@ -442,8 +461,8 @@
               typeof entry.name === "string"
                 ? entry.name
                 : typeof entry.latLng.name === "string"
-                ? entry.latLng.name
-                : "";
+                  ? entry.latLng.name
+                  : "";
           } else if (
             typeof entry.lat === "number" &&
             typeof entry.lng === "number"
@@ -527,20 +546,22 @@
         applied = true;
       } else if (waypoints.length === 1) {
         var existing = waypoints[0];
-        setWaypointsLatLngs([
-          { latLng: here, name: "" },
-          existing,
-        ]);
+        setWaypointsLatLngs([{ latLng: here, name: "" }, existing]);
         routingControl.route();
         applied = true;
       } else {
         var currentStart = waypoints[0];
-        if (currentStart && currentStart.latLng && typeof here.distanceTo === "function") {
+        if (
+          currentStart &&
+          currentStart.latLng &&
+          typeof here.distanceTo === "function"
+        ) {
           var dist = here.distanceTo(currentStart.latLng);
           if (isFinite(dist) && dist > 50) {
             waypoints[0] = {
               latLng: here,
-              name: typeof currentStart.name === "string" ? currentStart.name : "",
+              name:
+                typeof currentStart.name === "string" ? currentStart.name : "",
             };
             setWaypointsLatLngs(waypoints);
             routingControl.route();
@@ -559,7 +580,9 @@
       }
       var count = importErrors.length;
       errorReportBtn.textContent =
-        count > 0 ? errorButtonBaseLabel + " (" + count + ")" : errorButtonBaseLabel;
+        count > 0
+          ? errorButtonBaseLabel + " (" + count + ")"
+          : errorButtonBaseLabel;
       errorReportBtn.disabled = count === 0;
       errorReportBtn.title = count
         ? "Download a report of " + count + " failed item(s)."
@@ -609,8 +632,6 @@
       setStatus("Downloaded import error report.", "success");
     }
 
-    
-
     async function geocodeAndAdd(item) {
       var address = item && item.value ? item.value : item;
       var displayLabel =
@@ -624,7 +645,8 @@
         return false;
       }
       try {
-        var base = (KC_OSRM && KC_OSRM.geocodeUrl) || "https://photon.komoot.io/api";
+        var base =
+          (KC_OSRM && KC_OSRM.geocodeUrl) || "https://photon.komoot.io/api";
         var url = base;
         if (url.indexOf("?") === -1) {
           url += "?";
@@ -690,8 +712,8 @@
           success === addresses.length
             ? "success"
             : success > 0
-            ? "warn"
-            : "error";
+              ? "warn"
+              : "error";
         setStatus(message, type);
       })();
     }
@@ -720,7 +742,10 @@
     }
 
     function normHeader(header) {
-      return String(header || "").trim().toLowerCase().replace(/[^a-z]/g, "");
+      return String(header || "")
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z]/g, "");
     }
 
     function sniffDelimiter(headerLine) {
@@ -842,7 +867,7 @@
       if (idxAddr === -1 && (idxLat === -1 || idxLon === -1)) {
         setStatus(
           'CSV needs an "address" column OR both "lat" and "lon" columns.',
-          "error"
+          "error",
         );
         updateErrorReportButton();
         return;
@@ -937,7 +962,11 @@
         }
       }
 
-      if (data && data.type === "FeatureCollection" && Array.isArray(data.features)) {
+      if (
+        data &&
+        data.type === "FeatureCollection" &&
+        Array.isArray(data.features)
+      ) {
         data.features.forEach(function (feature, index) {
           if (!feature || !feature.geometry) {
             recordImportError({
@@ -950,7 +979,8 @@
           if (geom.type === "Point") {
             var coords = geom.coordinates || [];
             var ll =
-              toLatLngMaybe(coords[1], coords[0]) || toLatLngMaybe(coords[0], coords[1]);
+              toLatLngMaybe(coords[1], coords[0]) ||
+              toLatLngMaybe(coords[0], coords[1]);
             if (ll) {
               addStopAt(ll);
               added += 1;
@@ -960,11 +990,15 @@
                 reason: "Invalid coordinates",
               });
             }
-          } else if (geom.type === "LineString" && Array.isArray(geom.coordinates)) {
+          } else if (
+            geom.type === "LineString" &&
+            Array.isArray(geom.coordinates)
+          ) {
             for (var i = 0; i < geom.coordinates.length; i++) {
               var pair = geom.coordinates[i] || [];
               var llLine =
-                toLatLngMaybe(pair[1], pair[0]) || toLatLngMaybe(pair[0], pair[1]);
+                toLatLngMaybe(pair[1], pair[0]) ||
+                toLatLngMaybe(pair[0], pair[1]);
               if (llLine) {
                 addStopAt(llLine);
                 added += 1;
@@ -1003,10 +1037,10 @@
               wp.lon != null
                 ? wp.lon
                 : wp.lng != null
-                ? wp.lng
-                : wp.long != null
-                ? wp.long
-                : wp.longitude;
+                  ? wp.lng
+                  : wp.long != null
+                    ? wp.long
+                    : wp.longitude;
             var ll = toLatLngMaybe(latVal, lonVal);
             if (ll) {
               addStopAt(ll);
@@ -1057,10 +1091,10 @@
               item.lon != null
                 ? item.lon
                 : item.lng != null
-                ? item.lng
-                : item.long != null
-                ? item.long
-                : item.longitude;
+                  ? item.lng
+                  : item.long != null
+                    ? item.long
+                    : item.longitude;
             var llObj = toLatLngMaybe(latValue, lonValue);
             if (llObj) {
               addStopAt(llObj);
@@ -1094,7 +1128,7 @@
 
       setStatus(
         "JSON format not recognized. Expect GeoJSON, {waypoints: []}, or an array.",
-        "error"
+        "error",
       );
       updateErrorReportButton();
     }
@@ -1148,7 +1182,9 @@
             } else if (type === "arrive") {
               text = "Arrive at destination";
             } else {
-              text = (modifier ? "Turn " + modifier : "Continue") + (name ? " onto " + name : "");
+              text =
+                (modifier ? "Turn " + modifier : "Continue") +
+                (name ? " onto " + name : "");
             }
             stepQueue.push({
               lat: loc[1],
@@ -1188,7 +1224,10 @@
       var sLat2 = toRad(b.lat);
       var h =
         Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-        Math.cos(sLat1) * Math.cos(sLat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        Math.cos(sLat1) *
+          Math.cos(sLat2) *
+          Math.sin(dLon / 2) *
+          Math.sin(dLon / 2);
       return 2 * R * Math.asin(Math.sqrt(h));
     }
 
@@ -1298,7 +1337,7 @@
         function (err) {
           console.warn("Geo error", err);
         },
-        { enableHighAccuracy: true, maximumAge: 2000, timeout: 10000 }
+        { enableHighAccuracy: true, maximumAge: 2000, timeout: 10000 },
       );
     }
 
@@ -1490,7 +1529,8 @@
       if (typeof index === "number" && index >= 0 && index <= wps.length) {
         wps.splice(index, 0, waypoint);
       } else {
-        var insertAt = wps.length <= 1 ? wps.length : Math.max(1, wps.length - 1);
+        var insertAt =
+          wps.length <= 1 ? wps.length : Math.max(1, wps.length - 1);
         wps.splice(insertAt, 0, waypoint);
       }
 
@@ -1586,7 +1626,9 @@
         })
         .then(function (data) {
           if (!data || data.code !== "Ok" || !data.waypoints) {
-            throw new Error(data && data.message ? data.message : "Unexpected response");
+            throw new Error(
+              data && data.message ? data.message : "Unexpected response",
+            );
           }
 
           var ordered = new Array(data.waypoints.length);
@@ -1600,7 +1642,11 @@
           });
 
           var cleaned = ordered.filter(function (item) {
-            return item && typeof item.lat === "number" && typeof item.lng === "number";
+            return (
+              item &&
+              typeof item.lat === "number" &&
+              typeof item.lng === "number"
+            );
           });
 
           if (!cleaned.length) {
@@ -1657,7 +1703,7 @@
             csvCell(""),
             csvCell(lat),
             csvCell(lon),
-          ].join(",")
+          ].join(","),
         );
       }
 
@@ -1667,7 +1713,9 @@
       var a = document.createElement("a");
       a.href = url;
       a.download =
-        "kerbcycle-stops-" + new Date().toISOString().replace(/[:.]/g, "-") + ".csv";
+        "kerbcycle-stops-" +
+        new Date().toISOString().replace(/[:.]/g, "-") +
+        ".csv";
       document.body.appendChild(a);
       a.click();
       setTimeout(function () {
@@ -1676,7 +1724,7 @@
       }, 0);
       setStatus(
         "Exported " + stops.length + " stop(s) to CSV (Start/Finish excluded).",
-        "success"
+        "success",
       );
     }
 
@@ -1728,7 +1776,7 @@
         box.style.boxShadow = "0 1px 3px rgba(0,0,0,.12)";
         box.style.maxWidth = "340px";
         box.innerHTML =
-          '' +
+          "" +
           '<div style="font-weight:600;margin-bottom:6px">Paste addresses (one per line)</div>' +
           '<textarea data-kc="paste-input" style="width:320px;height:120px"></textarea>' +
           '<div style="margin-top:6px;display:flex;gap:6px">' +
@@ -1778,7 +1826,7 @@
                     encodeURIComponent(query),
                   {
                     headers: { Accept: "application/json" },
-                  }
+                  },
                 );
                 var arr = await response.json();
                 if (arr && arr[0]) {
@@ -1851,7 +1899,7 @@
         if (cleared) {
           setStatus(
             "Per-user default cleared. Reload to use shortcode/site default.",
-            ""
+            "",
           );
         } else {
           setStatus("Unable to access browser storage.", "error");
@@ -1897,9 +1945,15 @@
     try {
       map = L.map(el).setView(start, cfg.zoom || 12);
       window._kcMap = map;
-      L.tileLayer(KC_OSRM.tileUrl, { attribution: KC_OSRM.tileAttrib }).addTo(map);
+      L.tileLayer(KC_OSRM.tileUrl, { attribution: KC_OSRM.tileAttrib }).addTo(
+        map,
+      );
 
-      if (L.Control && L.Control.Geocoder && typeof L.Control.geocoder === "function") {
+      if (
+        L.Control &&
+        L.Control.Geocoder &&
+        typeof L.Control.geocoder === "function"
+      ) {
         geocoderControl = L.Control.geocoder({
           defaultMarkGeocode: false,
           geocoder: L.Control.Geocoder.nominatim({
@@ -1972,7 +2026,7 @@
         }
 
         var altWrap = container.querySelector(
-          ".leaflet-routing-alternatives-container"
+          ".leaflet-routing-alternatives-container",
         );
         if (altWrap) {
           altWrap.innerHTML = "";
@@ -1994,7 +2048,7 @@
         }
 
         var customHost = document.querySelector(
-          ".kc-steps, #kc-steps, .kc-steps-list"
+          ".kc-steps, #kc-steps, .kc-steps-list",
         );
         if (customHost) {
           customHost.innerHTML = "";
@@ -2061,7 +2115,6 @@
           map.invalidateSize();
         }, 50);
       });
-
     } catch (err) {
       showMsg(el, "Map init error: " + err.message);
       return;

--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -591,14 +591,22 @@ function initKerbcycleScanner() {
   const assignBtn = document.getElementById("assign-qr-btn");
   const resetBtn = document.getElementById("reset-scan-btn");
   const reportExceptionBtn = document.getElementById("report-exception-btn");
-  const exceptionFormWrap = document.getElementById("scanner-exception-form-wrap");
+  const exceptionFormWrap = document.getElementById(
+    "scanner-exception-form-wrap",
+  );
   const exceptionQrField = document.getElementById("scanner-exception-qr-code");
   const exceptionCustomerField = document.getElementById(
     "scanner-exception-customer-id",
   );
-  const exceptionIssueField = document.getElementById("scanner-exception-issue");
-  const exceptionNotesField = document.getElementById("scanner-exception-notes");
-  const submitExceptionBtn = document.getElementById("scanner-submit-exception");
+  const exceptionIssueField = document.getElementById(
+    "scanner-exception-issue",
+  );
+  const exceptionNotesField = document.getElementById(
+    "scanner-exception-notes",
+  );
+  const submitExceptionBtn = document.getElementById(
+    "scanner-submit-exception",
+  );
   const exceptionStatus = document.getElementById("scanner-exception-status");
   const customerIdField = document.getElementById("customer-id");
   let scannedCode = "";
@@ -1022,7 +1030,10 @@ function initKerbcycleScanner() {
               data && data.data && data.data.message
                 ? data.data.message
                 : "Unable to submit pickup exception.";
-            setExceptionStatus("error", `<strong>❌ ${escapeHtml(msg)}</strong>`);
+            setExceptionStatus(
+              "error",
+              `<strong>❌ ${escapeHtml(msg)}</strong>`,
+            );
           }
         })
         .catch((error) => {

--- a/includes/Admin/Pages/AiSettingsPage.php
+++ b/includes/Admin/Pages/AiSettingsPage.php
@@ -56,9 +56,9 @@ class AiSettingsPage
             <form method="post" action="options.php">
                 <?php
                 settings_fields(self::OPTION_KEY);
-                do_settings_sections(self::OPTION_KEY);
-                submit_button(__('Save AI Settings', 'kerbcycle'));
-                ?>
+        do_settings_sections(self::OPTION_KEY);
+        submit_button(__('Save AI Settings', 'kerbcycle'));
+        ?>
             </form>
 
             <h2><?php esc_html_e('Active webhook', 'kerbcycle'); ?></h2>

--- a/includes/Admin/Pages/PickupExceptionsPage.php
+++ b/includes/Admin/Pages/PickupExceptionsPage.php
@@ -58,8 +58,8 @@ class PickupExceptionsPage
             <p>
                 <?php
                 $all_url = add_query_arg(['page' => 'kerbcycle-pickup-exceptions'], admin_url('admin.php'));
-                $failed_url = add_query_arg(['page' => 'kerbcycle-pickup-exceptions', 'status_filter' => 'failed'], admin_url('admin.php'));
-                ?>
+        $failed_url = add_query_arg(['page' => 'kerbcycle-pickup-exceptions', 'status_filter' => 'failed'], admin_url('admin.php'));
+        ?>
                 <a href="<?php echo esc_url($all_url); ?>" class="<?php echo esc_attr($status_filter === 'failed' ? '' : 'current'); ?>"><?php esc_html_e('All', 'kerbcycle'); ?></a>
                 |
                 <a href="<?php echo esc_url($failed_url); ?>" class="<?php echo esc_attr($status_filter === 'failed' ? 'current' : ''); ?>"><?php esc_html_e('Failed Only', 'kerbcycle'); ?></a>
@@ -138,15 +138,15 @@ class PickupExceptionsPage
                             <td><?php echo esc_html($record->ai_category); ?></td>
                             <td>
                                 <?php
-                                $status = isset($record->status) ? (string) $record->status : (((int) $record->webhook_sent) === 1 ? 'sent' : 'failed');
-                                if ($status === 'sent') {
-                                    echo '<span class="kerb-badge kerb-badge-success">Sent</span>';
-                                } elseif ($status === 'failed') {
-                                    echo '<span class="kerb-badge kerb-badge-error">Failed</span>';
-                                } else {
-                                    echo '<span class="kerb-badge kerb-badge-pending">Pending</span>';
-                                }
-                                ?>
+                        $status = isset($record->status) ? (string) $record->status : (((int) $record->webhook_sent) === 1 ? 'sent' : 'failed');
+                        if ($status === 'sent') {
+                            echo '<span class="kerb-badge kerb-badge-success">Sent</span>';
+                        } elseif ($status === 'failed') {
+                            echo '<span class="kerb-badge kerb-badge-error">Failed</span>';
+                        } else {
+                            echo '<span class="kerb-badge kerb-badge-pending">Pending</span>';
+                        }
+                        ?>
                             </td>
                             <td><?php echo esc_html((string) (isset($record->retry_count) ? (int) $record->retry_count : 0)); ?></td>
                             <td><?php echo esc_html(!empty($record->last_retry_at) ? (string) $record->last_retry_at : '—'); ?></td>
@@ -156,11 +156,11 @@ class PickupExceptionsPage
                                 <button type="button" class="button button-small kerbcycle-view-details" data-exception-id="<?php echo esc_attr((string) (int) $record->id); ?>" aria-expanded="false"><?php esc_html_e('View Details', 'kerbcycle'); ?></button>
                                 <?php if (((int) $record->webhook_sent) === 0) : ?>
                                     <?php
-                                    $retry_args = [
-                                        'page' => 'kerbcycle-pickup-exceptions',
-                                        'kerbcycle_action' => 'retry_pickup_exception',
-                                        'exception_id' => (int) $record->id,
-                                    ];
+                            $retry_args = [
+                                'page' => 'kerbcycle-pickup-exceptions',
+                                'kerbcycle_action' => 'retry_pickup_exception',
+                                'exception_id' => (int) $record->id,
+                            ];
                                     if ($status_filter === 'failed') {
                                         $retry_args['status_filter'] = 'failed';
                                     }

--- a/tests/security_boundary_characterization_test.php
+++ b/tests/security_boundary_characterization_test.php
@@ -230,11 +230,23 @@ namespace {
         return 'uuid-test';
     }
 
-    function wp_enqueue_style($handle) {}
-    function wp_enqueue_script($handle) {}
-    function wp_add_inline_script($handle, $data, $position = 'after') {}
-    function wp_json_encode($value) { return json_encode($value); }
-    function get_current_user_id() { return $GLOBALS['kc_current_role'] === 'anonymous' ? 0 : 1; }
+    function wp_enqueue_style($handle)
+    {
+    }
+    function wp_enqueue_script($handle)
+    {
+    }
+    function wp_add_inline_script($handle, $data, $position = 'after')
+    {
+    }
+    function wp_json_encode($value)
+    {
+        return json_encode($value);
+    }
+    function get_current_user_id()
+    {
+        return $GLOBALS['kc_current_role'] === 'anonymous' ? 0 : 1;
+    }
 
     function assert_true($condition, string $message)
     {
@@ -258,7 +270,7 @@ namespace {
     }
 
     // Minimal $wpdb double used by constructors and QR table renderer.
-    $GLOBALS['wpdb'] = new class {
+    $GLOBALS['wpdb'] = new class () {
         public $prefix = 'wp_';
 
         public function get_results($sql)

--- a/tests/security_boundary_characterization_test.php
+++ b/tests/security_boundary_characterization_test.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!defined('ABSPATH')) {
+        define('ABSPATH', __DIR__ . '/');
+    }
+
+    class TestAjaxResponse extends \RuntimeException
+    {
+        public $success;
+        public $data;
+        public $status;
+
+        public function __construct(bool $success, $data, int $status)
+        {
+            parent::__construct('ajax response');
+            $this->success = $success;
+            $this->data = $data;
+            $this->status = $status;
+        }
+    }
+
+    if (!class_exists('WP_Error')) {
+        class WP_Error
+        {
+            private $code;
+            private $message;
+            private $data;
+
+            public function __construct($code = '', $message = '', $data = null)
+            {
+                $this->code = $code;
+                $this->message = $message;
+                $this->data = $data;
+            }
+
+            public function get_error_code()
+            {
+                return $this->code;
+            }
+
+            public function get_error_message()
+            {
+                return $this->message;
+            }
+
+            public function get_error_data()
+            {
+                return $this->data;
+            }
+        }
+    }
+
+    if (!class_exists('WP_REST_Request')) {
+        class WP_REST_Request
+        {
+            private $params = [];
+            private $headers = [];
+
+            public function __construct(array $params = [], array $headers = [])
+            {
+                $this->params = $params;
+                $this->headers = $headers;
+            }
+
+            public function get_param($key)
+            {
+                return $this->params[$key] ?? null;
+            }
+
+            public function get_header($key)
+            {
+                return $this->headers[$key] ?? '';
+            }
+
+            public function offsetGet($offset)
+            {
+                return $this->params[$offset] ?? null;
+            }
+        }
+    }
+
+    if (!class_exists('WP_REST_Response')) {
+        class WP_REST_Response
+        {
+            private $data;
+            private $status;
+
+            public function __construct($data, int $status = 200)
+            {
+                $this->data = $data;
+                $this->status = $status;
+            }
+
+            public function get_data()
+            {
+                return $this->data;
+            }
+
+            public function get_status()
+            {
+                return $this->status;
+            }
+        }
+    }
+
+    // ---- WordPress function stubs used by code paths under test ----
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1)
+    {
+        // no-op
+    }
+
+    function add_shortcode($tag, $callback)
+    {
+        // no-op
+    }
+
+    function __($text, $domain = null)
+    {
+        return $text;
+    }
+
+    function esc_html_e($text, $domain = null)
+    {
+        echo $text;
+    }
+
+    function esc_attr_e($text, $domain = null)
+    {
+        echo $text;
+    }
+
+    function esc_html($text)
+    {
+        return (string) $text;
+    }
+
+    function esc_attr($text)
+    {
+        return (string) $text;
+    }
+
+    function esc_js($text)
+    {
+        return (string) $text;
+    }
+
+    function sanitize_text_field($value)
+    {
+        return is_string($value) ? trim($value) : $value;
+    }
+
+    function wp_unslash($value)
+    {
+        return $value;
+    }
+
+    function wp_verify_nonce($nonce, $action)
+    {
+        return is_string($nonce) && $nonce === 'nonce:' . $action;
+    }
+
+    function wp_create_nonce($action)
+    {
+        return 'nonce:' . $action;
+    }
+
+    function wp_doing_ajax()
+    {
+        return true;
+    }
+
+    function wp_send_json_error($data = null, $status_code = null)
+    {
+        throw new TestAjaxResponse(false, $data, (int) ($status_code ?? 200));
+    }
+
+    function wp_send_json_success($data = null, $status_code = null)
+    {
+        throw new TestAjaxResponse(true, $data, (int) ($status_code ?? 200));
+    }
+
+    function wp_die($message = '', $title = '', $status = 0)
+    {
+        throw new \RuntimeException('wp_die: ' . $message . '|' . $status);
+    }
+
+    function current_user_can($capability)
+    {
+        $role = $GLOBALS['kc_current_role'] ?? 'anonymous';
+        return $capability === 'manage_options' && $role === 'administrator';
+    }
+
+    function is_wp_error($thing)
+    {
+        return $thing instanceof WP_Error;
+    }
+
+    function rest_ensure_response($value)
+    {
+        return $value;
+    }
+
+    function wp_dropdown_users($args = [])
+    {
+        $users = $GLOBALS['kc_mock_users'] ?? [];
+        $id = $args['id'] ?? 'customer-id';
+        $name = $args['name'] ?? 'customer_id';
+        echo '<select id="' . $id . '" name="' . $name . '">';
+        foreach ($users as $user) {
+            echo '<option value="' . (int) $user['ID'] . '">' . $user['display_name'] . '</option>';
+        }
+        echo '</select>';
+    }
+
+    function selected($selected, $current, $echo = true)
+    {
+        return ((string) $selected === (string) $current) ? ' selected="selected"' : '';
+    }
+
+    function shortcode_atts($pairs, $atts, $shortcode = '')
+    {
+        return array_merge($pairs, is_array($atts) ? $atts : []);
+    }
+
+    function wp_generate_uuid4()
+    {
+        return 'uuid-test';
+    }
+
+    function wp_enqueue_style($handle) {}
+    function wp_enqueue_script($handle) {}
+    function wp_add_inline_script($handle, $data, $position = 'after') {}
+    function wp_json_encode($value) { return json_encode($value); }
+    function get_current_user_id() { return $GLOBALS['kc_current_role'] === 'anonymous' ? 0 : 1; }
+
+    function assert_true($condition, string $message)
+    {
+        if (!$condition) {
+            throw new \RuntimeException('Assertion failed: ' . $message);
+        }
+    }
+
+    function assert_equals($expected, $actual, string $message)
+    {
+        if ($expected !== $actual) {
+            throw new \RuntimeException('Assertion failed: ' . $message . ' expected=' . var_export($expected, true) . ' actual=' . var_export($actual, true));
+        }
+    }
+
+    function assert_contains(string $needle, string $haystack, string $message)
+    {
+        if (strpos($haystack, $needle) === false) {
+            throw new \RuntimeException('Assertion failed: ' . $message . ' missing=' . $needle);
+        }
+    }
+
+    // Minimal $wpdb double used by constructors and QR table renderer.
+    $GLOBALS['wpdb'] = new class {
+        public $prefix = 'wp_';
+
+        public function get_results($sql)
+        {
+            return $GLOBALS['kc_mock_qr_rows'] ?? [];
+        }
+    };
+
+    require_once __DIR__ . '/../includes/Autoloader.php';
+    \Kerbcycle\QrCode\Autoloader::run();
+
+    // ---- Test 1: AJAX assign denied for low privilege ----
+    $GLOBALS['kc_current_role'] = 'subscriber';
+    $_POST = [
+        'qr_code' => 'QR-LOW-1',
+        'customer_id' => '123',
+        'security' => wp_create_nonce('kerbcycle_qr_nonce'),
+    ];
+    $_REQUEST = $_POST;
+
+    try {
+        $ajax = new \Kerbcycle\QrCode\Admin\Ajax\AdminAjax();
+        $ajax->assign_qr_code();
+        throw new \RuntimeException('Expected unauthorized AJAX response was not thrown.');
+    } catch (TestAjaxResponse $response) {
+        assert_equals(false, $response->success, 'Low-priv assign must fail');
+        assert_equals(403, $response->status, 'Low-priv assign must return 403');
+        assert_true(isset($response->data['message']), 'Low-priv error must include message');
+    }
+
+    // ---- Test 2: AJAX assign missing/invalid nonce ----
+    $GLOBALS['kc_current_role'] = 'administrator';
+    $_POST = [
+        'qr_code' => 'QR-ADMIN-1',
+        'customer_id' => '123',
+        'security' => 'bad-nonce',
+    ];
+    $_REQUEST = $_POST;
+
+    try {
+        $ajax = new \Kerbcycle\QrCode\Admin\Ajax\AdminAjax();
+        $ajax->assign_qr_code();
+        throw new \RuntimeException('Expected nonce failure AJAX response was not thrown.');
+    } catch (TestAjaxResponse $response) {
+        assert_equals(false, $response->success, 'Invalid nonce assign must fail');
+        assert_equals(403, $response->status, 'Invalid nonce assign must return 403');
+        assert_true(isset($response->data['message']), 'Nonce error must include message');
+    }
+
+    // ---- Test 3: REST AI endpoint rejects missing X-WP-Nonce ----
+    $GLOBALS['kc_current_role'] = 'administrator';
+    $ai_controller = new \Kerbcycle\QrCode\Api\Controllers\AiController();
+    $ai_request = new WP_REST_Request(['action' => 'draft_template'], []); // no X-WP-Nonce
+    $ai_permission_result = $ai_controller->permissions($ai_request);
+
+    assert_true(is_wp_error($ai_permission_result), 'AI permission without X-WP-Nonce must return WP_Error');
+    assert_equals('rest_nonce_invalid', $ai_permission_result->get_error_code(), 'AI missing nonce error code mismatch');
+
+    // ---- Test 4: REST QR status route denies non-admin ----
+    $GLOBALS['kc_current_role'] = 'subscriber';
+    $qr_controller = new \Kerbcycle\QrCode\Api\Controllers\QrController();
+    $qr_request = new WP_REST_Request(['qr_code' => 'QR-LOW-1'], []);
+    $qr_status_result = $qr_controller->get_qr_status($qr_request);
+
+    assert_true(is_wp_error($qr_status_result), 'QR status for non-admin must return WP_Error');
+    assert_equals('rest_forbidden', $qr_status_result->get_error_code(), 'QR status non-admin error code mismatch');
+
+    // ---- Test 5: Public shortcode anonymous exposure characterization ----
+    $GLOBALS['kc_current_role'] = 'anonymous';
+    $GLOBALS['kc_mock_users'] = [
+        ['ID' => 77, 'display_name' => 'Alice Customer'],
+    ];
+    $GLOBALS['kc_mock_qr_rows'] = [
+        (object) [
+            'id' => 1,
+            'qr_code' => 'QR-EXPOSED-1',
+            'user_id' => 77,
+            'display_name' => 'Alice Customer',
+            'status' => 'assigned',
+            'assigned_at' => '2026-04-01 10:00:00',
+        ],
+    ];
+
+    $shortcodes = new \Kerbcycle\QrCode\Public\Shortcodes();
+    $scanner_html = $shortcodes->generate_frontend_scanner();
+    $table_html = $shortcodes->generate_qr_table();
+
+    // Characterization assertions: capture current anonymous-visible output.
+    assert_contains('Select Customer', $scanner_html, 'Scanner shortcode should render customer selector text for anonymous users');
+    assert_contains('Alice Customer', $scanner_html, 'Scanner shortcode currently exposes user display name to anonymous users');
+
+    assert_contains('QR-EXPOSED-1', $table_html, 'QR table shortcode currently exposes QR code row to anonymous users');
+    assert_contains('Alice Customer', $table_html, 'QR table shortcode currently exposes assigned display name to anonymous users');
+    assert_contains('Assigned', $table_html, 'QR table shortcode currently exposes assignment status to anonymous users');
+
+    echo "security_boundary_characterization tests passed\n";
+}


### PR DESCRIPTION
### Motivation

- Add a focused characterization test to document and detect current security boundaries for AJAX, REST and public shortcodes.
- Provide lightweight WordPress runtime stubs so the plugin behavior can be exercised in isolation without a full WP install.

### Description

- Add `tests/security_boundary_characterization_test.php` which provides test doubles and function stubs for `WP_Error`, `WP_REST_Request`, `WP_REST_Response`, `wp_send_json_*`, `wp_verify_nonce`, and other minimal WP APIs used by the code under test.
- Instantiate plugin controllers and admin AJAX handler to exercise the following code paths: denied AJAX assign for low-privilege users, AJAX assign failure for invalid nonce, REST AI permission rejection when `X-WP-Nonce` is missing, and REST QR status denial for non-admin users.
- Render public shortcodes via `Public\Shortcodes` to capture and assert current anonymous-visible output (customer selector, exposed display names, QR rows and statuses) as a characterization of the existing exposure.
- Load the plugin autoloader with `require_once __DIR__ . '/../includes/Autoloader.php'` and run the assertions by throwing and catching `TestAjaxResponse` exceptions to inspect JSON responses.

### Testing

- Ran the new test file `tests/security_boundary_characterization_test.php` which executes all assertions in-process using the provided stubs; the script completed and printed `security_boundary_characterization tests passed` indicating success.
- The test asserts AJAX failure modes (permission and nonce) and REST permission checks and all such assertions passed.
- The test asserts current anonymous shortcode output exposures and those assertions passed, producing a deterministic characterization snapshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f368ae6c832d806aae01cf9addb1)