### PR TITLE
Add characterization tests for QR state/idempotency and security boundaries

### DIFF
--- a/tests/qr_state_and_idempotency_test.php
+++ b/tests/qr_state_and_idempotency_test.php
@@ -278,7 +278,9 @@ namespace {
                 if (!$rows) {
                     return null;
                 }
-                usort($rows, static function ($a, $b) { return (int) $b['id'] <=> (int) $a['id']; });
+                usort($rows, static function ($a, $b) {
+                    return (int) $b['id'] <=> (int) $a['id'];
+                });
                 return (object) $rows[0];
             }
 
@@ -291,7 +293,9 @@ namespace {
                 if (!$rows) {
                     return null;
                 }
-                usort($rows, static function ($a, $b) { return (int) $b['id'] <=> (int) $a['id']; });
+                usort($rows, static function ($a, $b) {
+                    return (int) $b['id'] <=> (int) $a['id'];
+                });
                 return (object) $rows[0];
             }
 

--- a/tests/qr_state_and_idempotency_test.php
+++ b/tests/qr_state_and_idempotency_test.php
@@ -1,0 +1,448 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!defined('ABSPATH')) {
+        define('ABSPATH', __DIR__ . '/');
+    }
+
+    class TestAjaxResponse extends \RuntimeException
+    {
+        public $success;
+        public $data;
+        public $status;
+
+        public function __construct(bool $success, $data, int $status)
+        {
+            parent::__construct('ajax response');
+            $this->success = $success;
+            $this->data = $data;
+            $this->status = $status;
+        }
+    }
+
+    if (!class_exists('WP_Error')) {
+        class WP_Error
+        {
+            private $code;
+            private $message;
+            private $data;
+
+            public function __construct($code = '', $message = '', $data = null)
+            {
+                $this->code = $code;
+                $this->message = $message;
+                $this->data = $data;
+            }
+
+            public function get_error_code()
+            {
+                return $this->code;
+            }
+
+            public function get_error_message()
+            {
+                return $this->message;
+            }
+
+            public function get_error_data()
+            {
+                return $this->data;
+            }
+        }
+    }
+
+    function __($text, $domain = null)
+    {
+        return $text;
+    }
+
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1)
+    {
+        // no-op
+    }
+
+    function wp_doing_ajax()
+    {
+        return true;
+    }
+
+    function wp_send_json_error($data = null, $status_code = null)
+    {
+        throw new TestAjaxResponse(false, $data, (int) ($status_code ?? 200));
+    }
+
+    function wp_send_json_success($data = null, $status_code = null)
+    {
+        throw new TestAjaxResponse(true, $data, (int) ($status_code ?? 200));
+    }
+
+    function wp_die($message = '', $title = '', $status = 0)
+    {
+        throw new \RuntimeException('wp_die: ' . $message . '|' . $status);
+    }
+
+    function sanitize_text_field($value)
+    {
+        return is_string($value) ? trim($value) : $value;
+    }
+
+    function sanitize_textarea_field($value)
+    {
+        return is_string($value) ? trim($value) : $value;
+    }
+
+    function sanitize_key($value)
+    {
+        return preg_replace('/[^a-z0-9_\-]/', '', strtolower((string) $value));
+    }
+
+    function wp_unslash($value)
+    {
+        return $value;
+    }
+
+    function absint($value)
+    {
+        return abs((int) $value);
+    }
+
+    function get_userdata($user_id)
+    {
+        $users = $GLOBALS['kc_mock_users'] ?? [];
+        if (!isset($users[$user_id])) {
+            return false;
+        }
+        return (object) $users[$user_id];
+    }
+
+    function current_user_can($cap)
+    {
+        return $cap === 'manage_options' && (($GLOBALS['kc_current_role'] ?? 'anonymous') === 'administrator');
+    }
+
+    function get_option($key, $default = false)
+    {
+        $options = $GLOBALS['kc_mock_options'] ?? [];
+        return array_key_exists($key, $options) ? $options[$key] : $default;
+    }
+
+    function wp_create_nonce($action)
+    {
+        return 'nonce:' . $action;
+    }
+
+    function wp_verify_nonce($nonce, $action)
+    {
+        return is_string($nonce) && $nonce === 'nonce:' . $action;
+    }
+
+    function is_wp_error($thing)
+    {
+        return $thing instanceof WP_Error;
+    }
+
+    function current_time($type, $gmt = false)
+    {
+        if ($type === 'mysql') {
+            return '2026-04-09 12:00:00';
+        }
+        return '2026-04-09T12:00:00Z';
+    }
+
+    function wp_json_encode($value)
+    {
+        return json_encode($value);
+    }
+
+    function wp_parse_args($args, $defaults = [])
+    {
+        if (!is_array($args)) {
+            $args = [];
+        }
+        return array_merge($defaults, $args);
+    }
+
+    function wp_kses_post($text)
+    {
+        return (string) $text;
+    }
+
+    function apply_filters($hook, $value)
+    {
+        return $value;
+    }
+
+    function wp_remote_post($url, $args = [])
+    {
+        $GLOBALS['kc_webhook_call_count'] = (int) ($GLOBALS['kc_webhook_call_count'] ?? 0) + 1;
+        return [
+            'response' => ['code' => 200],
+            'body' => '{"summary":"ok","category":"ops","severity":"low","recommended_action":"none"}',
+        ];
+    }
+
+    function wp_remote_retrieve_response_code($response)
+    {
+        return isset($response['response']['code']) ? (int) $response['response']['code'] : 0;
+    }
+
+    function wp_remote_retrieve_body($response)
+    {
+        return isset($response['body']) ? (string) $response['body'] : '';
+    }
+
+    class FakeWpdb
+    {
+        public $prefix = 'wp_';
+        public $insert_id = 0;
+        public $tables = [
+            'wp_kerbcycle_qr_codes' => [],
+            'wp_kerbcycle_qr_code_history' => [],
+            'wp_kerbcycle_pickup_exceptions' => [],
+            'wp_kerbcycle_error_logs' => [],
+        ];
+        private $ids = [
+            'wp_kerbcycle_qr_codes' => 0,
+            'wp_kerbcycle_qr_code_history' => 0,
+            'wp_kerbcycle_pickup_exceptions' => 0,
+            'wp_kerbcycle_error_logs' => 0,
+        ];
+
+        public function prepare($query, ...$args)
+        {
+            if (count($args) === 1 && is_array($args[0])) {
+                $args = $args[0];
+            }
+            foreach ($args as $arg) {
+                $posS = strpos($query, '%s');
+                $posD = strpos($query, '%d');
+                if ($posS !== false && ($posD === false || $posS < $posD)) {
+                    $query = substr_replace($query, "'" . addslashes((string) $arg) . "'", $posS, 2);
+                } else {
+                    $query = substr_replace($query, (string) (int) $arg, $posD, 2);
+                }
+            }
+            return $query;
+        }
+
+        public function insert($table, $data, $format = [])
+        {
+            if (!isset($this->tables[$table])) {
+                $this->tables[$table] = [];
+                $this->ids[$table] = 0;
+            }
+            $this->ids[$table]++;
+            $row = $data;
+            $row['id'] = $this->ids[$table];
+            $this->tables[$table][] = $row;
+            $this->insert_id = $row['id'];
+            return 1;
+        }
+
+        public function update($table, $data, $where, $format = [], $where_format = [])
+        {
+            if (!isset($this->tables[$table])) {
+                return 0;
+            }
+            $updated = 0;
+            foreach ($this->tables[$table] as &$row) {
+                $match = true;
+                foreach ($where as $k => $v) {
+                    if (!array_key_exists($k, $row) || (string) $row[$k] !== (string) $v) {
+                        $match = false;
+                        break;
+                    }
+                }
+                if (!$match) {
+                    continue;
+                }
+                foreach ($data as $k => $v) {
+                    $row[$k] = $v;
+                }
+                $updated++;
+            }
+            unset($row);
+            return $updated;
+        }
+
+        public function get_row($query)
+        {
+            if (preg_match("/FROM\s+(\w+)\s+WHERE\s+qr_code\s*=\s*'([^']+)'\s+AND\s+status\s*=\s*'assigned'\s+ORDER BY id DESC LIMIT 1/i", $query, $m)) {
+                $table = $m[1];
+                $code = stripslashes($m[2]);
+                $rows = array_values(array_filter($this->tables[$table] ?? [], static function ($r) use ($code) {
+                    return ($r['qr_code'] ?? '') === $code && ($r['status'] ?? '') === 'assigned';
+                }));
+                if (!$rows) {
+                    return null;
+                }
+                usort($rows, static function ($a, $b) { return (int) $b['id'] <=> (int) $a['id']; });
+                return (object) $rows[0];
+            }
+
+            if (preg_match("/FROM\s+(\w+)\s+WHERE\s+qr_code\s*=\s*'([^']+)'\s+ORDER BY id DESC LIMIT 1/i", $query, $m)) {
+                $table = $m[1];
+                $code = stripslashes($m[2]);
+                $rows = array_values(array_filter($this->tables[$table] ?? [], static function ($r) use ($code) {
+                    return ($r['qr_code'] ?? '') === $code;
+                }));
+                if (!$rows) {
+                    return null;
+                }
+                usort($rows, static function ($a, $b) { return (int) $b['id'] <=> (int) $a['id']; });
+                return (object) $rows[0];
+            }
+
+            if (preg_match('/FROM\s+(\w+)\s+WHERE\s+id\s*=\s*(\d+)/i', $query, $m)) {
+                $table = $m[1];
+                $id = (int) $m[2];
+                foreach ($this->tables[$table] ?? [] as $row) {
+                    if ((int) ($row['id'] ?? 0) === $id) {
+                        return (object) $row;
+                    }
+                }
+                return null;
+            }
+
+            return null;
+        }
+
+        public function get_var($query)
+        {
+            if (preg_match("/FROM\s+(\w+)\s+WHERE\s+qr_code\s*=\s*'([^']+)'\s+AND\s+status\s*=\s*'available'/i", $query, $m)) {
+                $table = $m[1];
+                $code = stripslashes($m[2]);
+                $count = 0;
+                foreach ($this->tables[$table] ?? [] as $row) {
+                    if (($row['qr_code'] ?? '') === $code && ($row['status'] ?? '') === 'available') {
+                        $count++;
+                    }
+                }
+                return $count;
+            }
+            return 0;
+        }
+
+        public function query($query)
+        {
+            return 0;
+        }
+    }
+
+    function assert_true($condition, string $message)
+    {
+        if (!$condition) {
+            throw new \RuntimeException('Assertion failed: ' . $message);
+        }
+    }
+
+    function assert_equals($expected, $actual, string $message)
+    {
+        if ($expected !== $actual) {
+            throw new \RuntimeException('Assertion failed: ' . $message . ' expected=' . var_export($expected, true) . ' actual=' . var_export($actual, true));
+        }
+    }
+
+    // install fake db and autoloader
+    $GLOBALS['wpdb'] = new FakeWpdb();
+    $GLOBALS['kc_mock_users'] = [
+        101 => ['ID' => 101, 'display_name' => 'User One', 'user_login' => 'user1', 'user_email' => 'u1@example.com'],
+        202 => ['ID' => 202, 'display_name' => 'User Two', 'user_login' => 'user2', 'user_email' => 'u2@example.com'],
+    ];
+    $GLOBALS['kc_mock_options'] = [
+        'kerbcycle_ai_webhook_options' => [
+            'env' => 'dev',
+            'webhook_url_dev' => 'https://example.test/webhook',
+            'webhook_url_stage' => '',
+            'webhook_url_prod' => '',
+            'timeout' => 20,
+        ],
+    ];
+
+    require_once __DIR__ . '/../includes/Autoloader.php';
+    \Kerbcycle\QrCode\Autoloader::run();
+
+    // ---- Test 1: available -> assigned succeeds ----
+    $repo = new \Kerbcycle\QrCode\Data\Repositories\QrCodeRepository();
+    $repo->insert_available('QR-STATE-1');
+
+    $service = new \Kerbcycle\QrCode\Services\QrService();
+    $assign_result = $service->assign('QR-STATE-1', 101, false, false, false);
+
+    assert_true(!is_wp_error($assign_result), 'Assign from available should succeed');
+    $latest_qr_state_1 = $repo->find_by_qr_code('QR-STATE-1');
+    assert_equals('assigned', $latest_qr_state_1->status, 'QR status should be assigned');
+    assert_equals('101', (string) $latest_qr_state_1->user_id, 'Assigned user_id should match');
+
+    // ---- Test 2: assigned -> assigned different user fails ----
+    $assign_again = $service->assign('QR-STATE-1', 202, false, false, false);
+    assert_true(is_wp_error($assign_again), 'Reassigning assigned QR to different user should fail');
+    assert_equals('qr_code_already_assigned', $assign_again->get_error_code(), 'Expected qr_code_already_assigned code');
+
+    // ---- Test 3: release from non-assigned fails ----
+    $repo->insert_available('QR-STATE-2');
+    $release_non_assigned = $service->release('QR-STATE-2', false, false);
+    assert_true(is_wp_error($release_non_assigned), 'Releasing available QR should fail');
+    assert_equals('invalid_state', $release_non_assigned->get_error_code(), 'Expected invalid_state code');
+
+    // ---- Test 4: parallel assignment characterization (sequential approximation) ----
+    $repo->insert_available('QR-RACE-1');
+    $first_assign = $service->assign('QR-RACE-1', 101, false, false, false);
+    $second_assign = $service->assign('QR-RACE-1', 202, false, false, false);
+
+    assert_true(!is_wp_error($first_assign), 'First sequential assign should succeed in race characterization');
+    assert_true(is_wp_error($second_assign), 'Second sequential assign should fail in current observed behavior');
+    $race_rows = array_values(array_filter($GLOBALS['wpdb']->tables['wp_kerbcycle_qr_codes'], static function ($row) {
+        return ($row['qr_code'] ?? '') === 'QR-RACE-1';
+    }));
+    assert_equals(1, count($race_rows), 'Characterization: sequential approximation currently leaves one QR row');
+
+    // ---- Test 5: pickup exception duplicate submission characterization ----
+    $GLOBALS['kc_current_role'] = 'administrator';
+    $GLOBALS['kc_webhook_call_count'] = 0;
+
+    $ajax = new \Kerbcycle\QrCode\Admin\Ajax\AdminAjax();
+
+    $payload = [
+        'security' => wp_create_nonce('kerbcycle_qr_nonce'),
+        'qr_code' => 'QR-EXC-1',
+        'customer_id' => '101',
+        'issue' => 'Missed pickup',
+        'notes' => 'Same payload duplicate characterization',
+    ];
+
+    $_POST = $payload;
+    $_REQUEST = $payload;
+    try {
+        $ajax->test_pickup_exception();
+    } catch (TestAjaxResponse $response_one) {
+        assert_true($response_one->success, 'First duplicate submission should complete with JSON success envelope');
+    }
+
+    $_POST = $payload;
+    $_REQUEST = $payload;
+    try {
+        $ajax->test_pickup_exception();
+    } catch (TestAjaxResponse $response_two) {
+        assert_true($response_two->success, 'Second duplicate submission should complete with JSON success envelope');
+    }
+
+    $exception_rows = $GLOBALS['wpdb']->tables['wp_kerbcycle_pickup_exceptions'];
+    assert_equals(2, count($exception_rows), 'Characterization: duplicate submissions currently create two rows');
+    assert_equals(2, (int) $GLOBALS['kc_webhook_call_count'], 'Characterization: duplicate submissions currently trigger two webhook attempts');
+
+    echo "qr_state_and_idempotency tests passed\n";
+}
+
+namespace Kerbcycle\QrCode\Install {
+    // Minimal no-op seam to avoid activation DDL side effects in unit-style execution.
+    class Activator
+    {
+        public static function activate()
+        {
+            return;
+        }
+    }
+}

--- a/tests/security_boundary_characterization_test.php
+++ b/tests/security_boundary_characterization_test.php
@@ -230,11 +230,23 @@ namespace {
         return 'uuid-test';
     }
 
-    function wp_enqueue_style($handle) {}
-    function wp_enqueue_script($handle) {}
-    function wp_add_inline_script($handle, $data, $position = 'after') {}
-    function wp_json_encode($value) { return json_encode($value); }
-    function get_current_user_id() { return $GLOBALS['kc_current_role'] === 'anonymous' ? 0 : 1; }
+    function wp_enqueue_style($handle)
+    {
+    }
+    function wp_enqueue_script($handle)
+    {
+    }
+    function wp_add_inline_script($handle, $data, $position = 'after')
+    {
+    }
+    function wp_json_encode($value)
+    {
+        return json_encode($value);
+    }
+    function get_current_user_id()
+    {
+        return $GLOBALS['kc_current_role'] === 'anonymous' ? 0 : 1;
+    }
 
     function assert_true($condition, string $message)
     {
@@ -258,7 +270,7 @@ namespace {
     }
 
     // Minimal $wpdb double used by constructors and QR table renderer.
-    $GLOBALS['wpdb'] = new class {
+    $GLOBALS['wpdb'] = new class () {
         public $prefix = 'wp_';
 
         public function get_results($sql)

--- a/tests/security_boundary_characterization_test.php
+++ b/tests/security_boundary_characterization_test.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!defined('ABSPATH')) {
+        define('ABSPATH', __DIR__ . '/');
+    }
+
+    class TestAjaxResponse extends \RuntimeException
+    {
+        public $success;
+        public $data;
+        public $status;
+
+        public function __construct(bool $success, $data, int $status)
+        {
+            parent::__construct('ajax response');
+            $this->success = $success;
+            $this->data = $data;
+            $this->status = $status;
+        }
+    }
+
+    if (!class_exists('WP_Error')) {
+        class WP_Error
+        {
+            private $code;
+            private $message;
+            private $data;
+
+            public function __construct($code = '', $message = '', $data = null)
+            {
+                $this->code = $code;
+                $this->message = $message;
+                $this->data = $data;
+            }
+
+            public function get_error_code()
+            {
+                return $this->code;
+            }
+
+            public function get_error_message()
+            {
+                return $this->message;
+            }
+
+            public function get_error_data()
+            {
+                return $this->data;
+            }
+        }
+    }
+
+    if (!class_exists('WP_REST_Request')) {
+        class WP_REST_Request
+        {
+            private $params = [];
+            private $headers = [];
+
+            public function __construct(array $params = [], array $headers = [])
+            {
+                $this->params = $params;
+                $this->headers = $headers;
+            }
+
+            public function get_param($key)
+            {
+                return $this->params[$key] ?? null;
+            }
+
+            public function get_header($key)
+            {
+                return $this->headers[$key] ?? '';
+            }
+
+            public function offsetGet($offset)
+            {
+                return $this->params[$offset] ?? null;
+            }
+        }
+    }
+
+    if (!class_exists('WP_REST_Response')) {
+        class WP_REST_Response
+        {
+            private $data;
+            private $status;
+
+            public function __construct($data, int $status = 200)
+            {
+                $this->data = $data;
+                $this->status = $status;
+            }
+
+            public function get_data()
+            {
+                return $this->data;
+            }
+
+            public function get_status()
+            {
+                return $this->status;
+            }
+        }
+    }
+
+    // ---- WordPress function stubs used by code paths under test ----
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1)
+    {
+        // no-op
+    }
+
+    function add_shortcode($tag, $callback)
+    {
+        // no-op
+    }
+
+    function __($text, $domain = null)
+    {
+        return $text;
+    }
+
+    function esc_html_e($text, $domain = null)
+    {
+        echo $text;
+    }
+
+    function esc_attr_e($text, $domain = null)
+    {
+        echo $text;
+    }
+
+    function esc_html($text)
+    {
+        return (string) $text;
+    }
+
+    function esc_attr($text)
+    {
+        return (string) $text;
+    }
+
+    function esc_js($text)
+    {
+        return (string) $text;
+    }
+
+    function sanitize_text_field($value)
+    {
+        return is_string($value) ? trim($value) : $value;
+    }
+
+    function wp_unslash($value)
+    {
+        return $value;
+    }
+
+    function wp_verify_nonce($nonce, $action)
+    {
+        return is_string($nonce) && $nonce === 'nonce:' . $action;
+    }
+
+    function wp_create_nonce($action)
+    {
+        return 'nonce:' . $action;
+    }
+
+    function wp_doing_ajax()
+    {
+        return true;
+    }
+
+    function wp_send_json_error($data = null, $status_code = null)
+    {
+        throw new TestAjaxResponse(false, $data, (int) ($status_code ?? 200));
+    }
+
+    function wp_send_json_success($data = null, $status_code = null)
+    {
+        throw new TestAjaxResponse(true, $data, (int) ($status_code ?? 200));
+    }
+
+    function wp_die($message = '', $title = '', $status = 0)
+    {
+        throw new \RuntimeException('wp_die: ' . $message . '|' . $status);
+    }
+
+    function current_user_can($capability)
+    {
+        $role = $GLOBALS['kc_current_role'] ?? 'anonymous';
+        return $capability === 'manage_options' && $role === 'administrator';
+    }
+
+    function is_wp_error($thing)
+    {
+        return $thing instanceof WP_Error;
+    }
+
+    function rest_ensure_response($value)
+    {
+        return $value;
+    }
+
+    function wp_dropdown_users($args = [])
+    {
+        $users = $GLOBALS['kc_mock_users'] ?? [];
+        $id = $args['id'] ?? 'customer-id';
+        $name = $args['name'] ?? 'customer_id';
+        echo '<select id="' . $id . '" name="' . $name . '">';
+        foreach ($users as $user) {
+            echo '<option value="' . (int) $user['ID'] . '">' . $user['display_name'] . '</option>';
+        }
+        echo '</select>';
+    }
+
+    function selected($selected, $current, $echo = true)
+    {
+        return ((string) $selected === (string) $current) ? ' selected="selected"' : '';
+    }
+
+    function shortcode_atts($pairs, $atts, $shortcode = '')
+    {
+        return array_merge($pairs, is_array($atts) ? $atts : []);
+    }
+
+    function wp_generate_uuid4()
+    {
+        return 'uuid-test';
+    }
+
+    function wp_enqueue_style($handle) {}
+    function wp_enqueue_script($handle) {}
+    function wp_add_inline_script($handle, $data, $position = 'after') {}
+    function wp_json_encode($value) { return json_encode($value); }
+    function get_current_user_id() { return $GLOBALS['kc_current_role'] === 'anonymous' ? 0 : 1; }
+
+    function assert_true($condition, string $message)
+    {
+        if (!$condition) {
+            throw new \RuntimeException('Assertion failed: ' . $message);
+        }
+    }
+
+    function assert_equals($expected, $actual, string $message)
+    {
+        if ($expected !== $actual) {
+            throw new \RuntimeException('Assertion failed: ' . $message . ' expected=' . var_export($expected, true) . ' actual=' . var_export($actual, true));
+        }
+    }
+
+    function assert_contains(string $needle, string $haystack, string $message)
+    {
+        if (strpos($haystack, $needle) === false) {
+            throw new \RuntimeException('Assertion failed: ' . $message . ' missing=' . $needle);
+        }
+    }
+
+    // Minimal $wpdb double used by constructors and QR table renderer.
+    $GLOBALS['wpdb'] = new class {
+        public $prefix = 'wp_';
+
+        public function get_results($sql)
+        {
+            return $GLOBALS['kc_mock_qr_rows'] ?? [];
+        }
+    };
+
+    require_once __DIR__ . '/../includes/Autoloader.php';
+    \Kerbcycle\QrCode\Autoloader::run();
+
+    // ---- Test 1: AJAX assign denied for low privilege ----
+    $GLOBALS['kc_current_role'] = 'subscriber';
+    $_POST = [
+        'qr_code' => 'QR-LOW-1',
+        'customer_id' => '123',
+        'security' => wp_create_nonce('kerbcycle_qr_nonce'),
+    ];
+    $_REQUEST = $_POST;
+
+    try {
+        $ajax = new \Kerbcycle\QrCode\Admin\Ajax\AdminAjax();
+        $ajax->assign_qr_code();
+        throw new \RuntimeException('Expected unauthorized AJAX response was not thrown.');
+    } catch (TestAjaxResponse $response) {
+        assert_equals(false, $response->success, 'Low-priv assign must fail');
+        assert_equals(403, $response->status, 'Low-priv assign must return 403');
+        assert_true(isset($response->data['message']), 'Low-priv error must include message');
+    }
+
+    // ---- Test 2: AJAX assign missing/invalid nonce ----
+    $GLOBALS['kc_current_role'] = 'administrator';
+    $_POST = [
+        'qr_code' => 'QR-ADMIN-1',
+        'customer_id' => '123',
+        'security' => 'bad-nonce',
+    ];
+    $_REQUEST = $_POST;
+
+    try {
+        $ajax = new \Kerbcycle\QrCode\Admin\Ajax\AdminAjax();
+        $ajax->assign_qr_code();
+        throw new \RuntimeException('Expected nonce failure AJAX response was not thrown.');
+    } catch (TestAjaxResponse $response) {
+        assert_equals(false, $response->success, 'Invalid nonce assign must fail');
+        assert_equals(403, $response->status, 'Invalid nonce assign must return 403');
+        assert_true(isset($response->data['message']), 'Nonce error must include message');
+    }
+
+    // ---- Test 3: REST AI endpoint rejects missing X-WP-Nonce ----
+    $GLOBALS['kc_current_role'] = 'administrator';
+    $ai_controller = new \Kerbcycle\QrCode\Api\Controllers\AiController();
+    $ai_request = new WP_REST_Request(['action' => 'draft_template'], []); // no X-WP-Nonce
+    $ai_permission_result = $ai_controller->permissions($ai_request);
+
+    assert_true(is_wp_error($ai_permission_result), 'AI permission without X-WP-Nonce must return WP_Error');
+    assert_equals('rest_nonce_invalid', $ai_permission_result->get_error_code(), 'AI missing nonce error code mismatch');
+
+    // ---- Test 4: REST QR status route denies non-admin ----
+    $GLOBALS['kc_current_role'] = 'subscriber';
+    $qr_controller = new \Kerbcycle\QrCode\Api\Controllers\QrController();
+    $qr_request = new WP_REST_Request(['qr_code' => 'QR-LOW-1'], []);
+    $qr_status_result = $qr_controller->get_qr_status($qr_request);
+
+    assert_true(is_wp_error($qr_status_result), 'QR status for non-admin must return WP_Error');
+    assert_equals('rest_forbidden', $qr_status_result->get_error_code(), 'QR status non-admin error code mismatch');
+
+    // ---- Test 5: Public shortcode anonymous exposure characterization ----
+    $GLOBALS['kc_current_role'] = 'anonymous';
+    $GLOBALS['kc_mock_users'] = [
+        ['ID' => 77, 'display_name' => 'Alice Customer'],
+    ];
+    $GLOBALS['kc_mock_qr_rows'] = [
+        (object) [
+            'id' => 1,
+            'qr_code' => 'QR-EXPOSED-1',
+            'user_id' => 77,
+            'display_name' => 'Alice Customer',
+            'status' => 'assigned',
+            'assigned_at' => '2026-04-01 10:00:00',
+        ],
+    ];
+
+    $shortcodes = new \Kerbcycle\QrCode\Public\Shortcodes();
+    $scanner_html = $shortcodes->generate_frontend_scanner();
+    $table_html = $shortcodes->generate_qr_table();
+
+    // Characterization assertions: capture current anonymous-visible output.
+    assert_contains('Select Customer', $scanner_html, 'Scanner shortcode should render customer selector text for anonymous users');
+    assert_contains('Alice Customer', $scanner_html, 'Scanner shortcode currently exposes user display name to anonymous users');
+
+    assert_contains('QR-EXPOSED-1', $table_html, 'QR table shortcode currently exposes QR code row to anonymous users');
+    assert_contains('Alice Customer', $table_html, 'QR table shortcode currently exposes assigned display name to anonymous users');
+    assert_contains('Assigned', $table_html, 'QR table shortcode currently exposes assignment status to anonymous users');
+
+    echo "security_boundary_characterization tests passed\n";
+}


### PR DESCRIPTION
### Motivation

- Add automated characterization tests to document current behavior and surface non-atomic idempotency and security boundary issues in the QR code subsystem. 

### Description

- Add `tests/qr_state_and_idempotency_test.php` which seeds a fake WP environment and `FakeWpdb`, stubs WordPress functions and types, exercises `QrService` assign/release flows, and invokes admin AJAX `test_pickup_exception` to record webhook and duplicate-submission behavior. 
- Add `tests/security_boundary_characterization_test.php` which stubs WP REST classes and functions, exercises admin AJAX `assign_qr_code`, REST `AiController` permissions, `QrController` status endpoint, and public shortcodes to characterize capability/nonce checks and anonymous data exposure. 
- Both tests include small test harness types such as `TestAjaxResponse`, `WP_Error`, `WP_REST_Request`, `WP_REST_Response`, and assertion helpers (`assert_true`, `assert_equals`, `assert_contains`) and load the plugin `Autoloader` to exercise real code paths.

### Testing

- Ran `tests/qr_state_and_idempotency_test.php` which executed state transition and idempotency characterization assertions and reported success: `qr_state_and_idempotency tests passed`.
- Ran `tests/security_boundary_characterization_test.php` which executed security boundary assertions and reported success: `security_boundary_characterization tests passed`.
- All automated assertions in both test files completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f368ae6c832d806aae01cf9addb1)