### PR TITLE
Add pickup exception source tracking and display in admin list

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -724,7 +724,7 @@ function initKerbcycleAdmin() {
         const rows = data.data.rows;
         if (!rows.length) {
           pickupExceptionsTbody.innerHTML =
-            '<tr><td colspan="13">No pickup exceptions found.</td></tr>';
+            '<tr><td colspan="14">No pickup exceptions found.</td></tr>';
           return;
         }
 
@@ -741,6 +741,7 @@ function initKerbcycleAdmin() {
               <td>${escapeHtml(row.qr_code || "")}</td>
               <td>${escapeHtml(row.customer_id || "")}</td>
               <td>${escapeHtml(row.issue || "")}</td>
+              <td>${escapeHtml(row.source || "—")}</td>
               <td>${escapeHtml(row.ai_severity || "")}</td>
               <td>${escapeHtml(row.ai_category || "")}</td>
               <td>${buildPickupExceptionStatusBadge(row.status || "pending")}</td>
@@ -754,7 +755,7 @@ function initKerbcycleAdmin() {
               </td>
             </tr>
             <tr class="kerbcycle-pickup-details-row" data-exception-id="${escapeHtml(row.id)}" style="display:none;">
-              <td colspan="13">
+              <td colspan="14">
                 <div class="kerbcycle-pickup-details-content">
                   <p><strong>Issue:</strong><br>${pickupDetailText(row.issue)}</p>
                   <p><strong>Notes:</strong><br>${pickupDetailText(row.notes)}</p>
@@ -769,6 +770,7 @@ function initKerbcycleAdmin() {
                   <p><strong>Last Retry:</strong> ${pickupDetailText(row.last_retry_at || "—")}</p>
                   <p><strong>Customer ID:</strong> ${pickupDetailText(row.customer_id)}</p>
                   <p><strong>QR Code:</strong> ${pickupDetailText(row.qr_code)}</p>
+                  <p><strong>Source:</strong> ${pickupDetailText(row.source)}</p>
                 </div>
               </td>
             </tr>`;
@@ -936,6 +938,7 @@ function initKerbcycleAdmin() {
         "notes",
         pickupExceptionNotes ? pickupExceptionNotes.value : "",
       );
+      params.append("source", "admin");
 
       fetch(kerbcycle_ajax.ajax_url, {
         method: "POST",

--- a/assets/js/dashboard-scanner.js
+++ b/assets/js/dashboard-scanner.js
@@ -397,6 +397,7 @@ function initDashboardScanner() {
         "notes",
         scannerExceptionNotesField ? scannerExceptionNotesField.value : "",
       );
+      params.append("source", "scanner");
 
       fetch(kerbcycle_ajax.ajax_url, {
         method: "POST",

--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -1001,6 +1001,7 @@ function initKerbcycleScanner() {
       params.append("customer_id", customerId);
       params.append("issue", issue);
       params.append("notes", notes);
+      params.append("source", "scanner");
 
       fetch(kerbcycle_ajax.ajax_url, {
         method: "POST",

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -452,6 +452,11 @@ class AdminAjax
         $issue = sanitize_text_field($issue_raw);
         $notes = sanitize_textarea_field($notes_raw);
         $timestamp = sanitize_text_field($timestamp_raw);
+        $source_raw = isset($_POST['source']) ? wp_unslash($_POST['source']) : '';
+        $source = sanitize_key($source_raw);
+        if (!in_array($source, ['admin', 'scanner'], true)) {
+            $source = 'admin';
+        }
         if ($timestamp === '') {
             $timestamp = gmdate('c');
         }
@@ -503,6 +508,7 @@ class AdminAjax
             'submitted_at' => $timestamp,
             'webhook_sent' => 0,
             'status'       => 'pending',
+            'source'       => $source,
             'retry_count'  => 0,
             'last_retry_at' => null,
             'created_at'   => $now_utc_mysql,
@@ -672,7 +678,7 @@ class AdminAjax
         $status_filter = isset($_POST['status_filter']) ? sanitize_key(wp_unslash($_POST['status_filter'])) : '';
         if ($status_filter === 'failed') {
             $sql = $wpdb->prepare(
-                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
+                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, source, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
                 FROM {$table_name}
                 WHERE status = %s
                 ORDER BY id DESC
@@ -682,7 +688,7 @@ class AdminAjax
             );
         } else {
             $sql = $wpdb->prepare(
-                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
+                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, source, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
                 FROM {$table_name}
                 ORDER BY id DESC
                 LIMIT %d",
@@ -722,6 +728,7 @@ class AdminAjax
                 'issue' => isset($record->issue) ? (string) $record->issue : '',
                 'notes' => isset($record->notes) ? (string) $record->notes : '',
                 'status' => $status,
+                'source' => isset($record->source) && $record->source !== '' ? (string) $record->source : '',
                 'ai_severity' => isset($record->ai_severity) ? (string) $record->ai_severity : '',
                 'ai_category' => isset($record->ai_category) ? (string) $record->ai_category : '',
                 'ai_recommended_action' => isset($record->ai_recommended_action) ? (string) $record->ai_recommended_action : '',

--- a/includes/Admin/Pages/PickupExceptionsPage.php
+++ b/includes/Admin/Pages/PickupExceptionsPage.php
@@ -32,7 +32,7 @@ class PickupExceptionsPage
         $status_filter = isset($_GET['status_filter']) ? sanitize_key(wp_unslash($_GET['status_filter'])) : '';
         if ($status_filter === 'failed') {
             $sql = $wpdb->prepare(
-                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
+                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, source, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
                 FROM {$table_name}
                 WHERE status = %s
                 ORDER BY id DESC
@@ -42,7 +42,7 @@ class PickupExceptionsPage
             );
         } else {
             $sql = $wpdb->prepare(
-                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
+                "SELECT id, submitted_at, updated_at, qr_code, customer_id, issue, notes, source, ai_severity, ai_category, webhook_sent, status, ai_recommended_action, ai_summary, webhook_status_code, webhook_response_body, retry_count, last_retry_at
                 FROM {$table_name}
                 ORDER BY id DESC
                 LIMIT %d",
@@ -111,6 +111,7 @@ class PickupExceptionsPage
                         <th><?php esc_html_e('QR Code', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Customer ID', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Issue', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e('Source', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Severity', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Category', 'kerbcycle'); ?></th>
                         <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
@@ -124,7 +125,7 @@ class PickupExceptionsPage
                 <tbody id="kerbcycle-pickup-exceptions-tbody">
                 <?php if (empty($records)) : ?>
                     <tr>
-                        <td colspan="13"><?php esc_html_e('No pickup exceptions found.', 'kerbcycle'); ?></td>
+                        <td colspan="14"><?php esc_html_e('No pickup exceptions found.', 'kerbcycle'); ?></td>
                     </tr>
                 <?php else : ?>
                     <?php foreach ($records as $record) : ?>
@@ -134,6 +135,7 @@ class PickupExceptionsPage
                             <td><?php echo esc_html($record->qr_code); ?></td>
                             <td><?php echo esc_html($record->customer_id); ?></td>
                             <td><?php echo esc_html($record->issue); ?></td>
+                            <td><?php echo esc_html(!empty($record->source) ? (string) $record->source : '—'); ?></td>
                             <td><?php echo esc_html($record->ai_severity); ?></td>
                             <td><?php echo esc_html($record->ai_category); ?></td>
                             <td>
@@ -177,7 +179,7 @@ class PickupExceptionsPage
                             </td>
                         </tr>
                         <tr class="kerbcycle-pickup-details-row" data-exception-id="<?php echo esc_attr((string) (int) $record->id); ?>">
-                            <td colspan="13">
+                            <td colspan="14">
                                 <div class="kerbcycle-pickup-details-content">
                                     <p><strong><?php esc_html_e('Issue', 'kerbcycle'); ?>:</strong><br><?php echo nl2br(esc_html((string) $record->issue)); ?></p>
                                     <p><strong><?php esc_html_e('Notes', 'kerbcycle'); ?>:</strong><br><?php echo nl2br(esc_html((string) $record->notes)); ?></p>
@@ -192,6 +194,7 @@ class PickupExceptionsPage
                                     <p><strong><?php esc_html_e('Last Retry', 'kerbcycle'); ?>:</strong> <?php echo esc_html(!empty($record->last_retry_at) ? (string) $record->last_retry_at : '—'); ?></p>
                                     <p><strong><?php esc_html_e('Customer ID', 'kerbcycle'); ?>:</strong> <?php echo esc_html((string) $record->customer_id); ?></p>
                                     <p><strong><?php esc_html_e('QR Code', 'kerbcycle'); ?>:</strong> <?php echo esc_html((string) $record->qr_code); ?></p>
+                                    <p><strong><?php esc_html_e('Source', 'kerbcycle'); ?>:</strong> <?php echo esc_html(!empty($record->source) ? (string) $record->source : '—'); ?></p>
                                 </div>
                             </td>
                         </tr>

--- a/includes/Data/Repositories/PickupExceptionRepository.php
+++ b/includes/Data/Repositories/PickupExceptionRepository.php
@@ -21,6 +21,7 @@ class PickupExceptionRepository
             '%s', // submitted_at
             '%d', // webhook_sent
             '%s', // status
+            '%s', // source
             '%d', // retry_count
             '%s', // last_retry_at
             '%s', // created_at

--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -131,6 +131,7 @@ class Activator
             status VARCHAR(20) DEFAULT 'pending',
             webhook_status_code INT DEFAULT NULL,
             webhook_response_body LONGTEXT,
+            source VARCHAR(20) DEFAULT '',
             retry_count INT NOT NULL DEFAULT 0,
             last_retry_at DATETIME NULL,
             ai_severity VARCHAR(100) DEFAULT '',


### PR DESCRIPTION
### Motivation

- Records created by the admin tool and the front-end scanner are indistinguishable, making operational debugging and analytics harder. The change adds a minimal `source` metadata field to record origin without changing the existing pipeline.

### Description

- Add a `source VARCHAR(20) DEFAULT ''` column to the pickup exceptions table used by the existing activation/migration path so `dbDelta` can add it on activate/migration. (changed: `includes/Install/Activator.php`)
- Persist `source` at creation time by extending the repository insert format and create call to include `source` so it is only set on record creation. (changed: `includes/Data/Repositories/PickupExceptionRepository.php`, `includes/Admin/Ajax/AdminAjax.php`)
- Sanitize/whitelist source values in the shared submit handler (`test_pickup_exception`) and default to `admin` when missing/invalid; do not modify `source` on retry. (changed: `includes/Admin/Ajax/AdminAjax.php`)
- Return `source` in the pickup exceptions AJAX list and render a new `Source` column in the server-rendered admin page and details row, with safe fallback (`—`) for legacy rows. (changed: `includes/Admin/Ajax/AdminAjax.php`, `includes/Admin/Pages/PickupExceptionsPage.php`, `assets/js/admin.js`)
- Ensure submit entry points send the appropriate source: admin tool sends `source=admin`, front-end scanner and dashboard scanner send `source=scanner`. (changed: `assets/js/admin.js`, `assets/js/qr-scanner.js`, `assets/js/dashboard-scanner.js`)

### Testing

- Ran PHP lint (`php -l`) on modified PHP files: `includes/Install/Activator.php`, `includes/Data/Repositories/PickupExceptionRepository.php`, `includes/Admin/Ajax/AdminAjax.php`, and `includes/Admin/Pages/PickupExceptionsPage.php`; all reported no syntax errors. (passed)
- Verified modified JS is updated to send `source` in the three submit flows and admin polling renders and falls back to `—` for empty values by inspecting the client-side output. (static verification)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e44c93bbc8832dbd3b81c0511fc7a9)