### PR TITLE
Force admin pickup exception source server-side

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -452,11 +452,8 @@ class AdminAjax
         $issue = sanitize_text_field($issue_raw);
         $notes = sanitize_textarea_field($notes_raw);
         $timestamp = sanitize_text_field($timestamp_raw);
-        $source_raw = isset($_POST['source']) ? wp_unslash($_POST['source']) : '';
-        $source = sanitize_key($source_raw);
-        if (!in_array($source, ['admin', 'scanner'], true)) {
-            $source = 'admin';
-        }
+        // This admin-side handler must not trust client-posted source.
+        $source = 'admin';
         if ($timestamp === '') {
             $timestamp = gmdate('c');
         }


### PR DESCRIPTION
### Motivation
- Fix incorrect source attribution where admin-created pickup exceptions were being saved as `scanner` because the admin handler trusted client-posted `source`, and ensure admin-side submissions always persist with `source = admin`.

### Description
- Changed `includes/Admin/Ajax/AdminAjax.php` so the `test_pickup_exception()` handler no longer reads `$_POST['source']` and instead unconditionally sets `$source = 'admin'` before persisting; no other files were modified. 
- Exact behavior change: admin-side create requests now always store `source = 'admin'` server-side, while scanner flows remain unchanged and continue to post `source=scanner` from client code. 
- Edge cases/risks: because admin and scanner currently share the same AJAX action, any client still posting to this endpoint may be recorded as `admin` if hitting this handler; this is the minimal, intentional fix to correct admin-side attribution without redesigning endpoints.

### Testing
- Ran `php -l includes/Admin/Ajax/AdminAjax.php` to verify syntax and it reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6eab3ef10832daf40bee41c9d91b1)