### PR TITLE
Add scanner pickup-exception AJAX endpoint and centralize handler

### DIFF
--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -995,7 +995,7 @@ function initKerbcycleScanner() {
       setExceptionStatus("success", "Saving and sending pickup exception...");
 
       const params = new URLSearchParams();
-      params.append("action", "kerbcycle_test_pickup_exception");
+      params.append("action", "kerbcycle_submit_scanner_pickup_exception");
       params.append("security", kerbcycle_ajax.nonce);
       params.append("qr_code", qrCode);
       params.append("customer_id", customerId);

--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -49,6 +49,7 @@ class AdminAjax
         add_action('wp_ajax_kerbcycle_qr_report_data', [$this, 'ajax_report_data']);
         add_action('wp_ajax_kerbcycle_delete_logs', [$this, 'delete_logs']);
         add_action('wp_ajax_kerbcycle_test_pickup_exception', [$this, 'test_pickup_exception']);
+        add_action('wp_ajax_kerbcycle_submit_scanner_pickup_exception', [$this, 'submit_scanner_pickup_exception']);
         add_action('wp_ajax_kerbcycle_get_pickup_exceptions', [$this, 'get_pickup_exceptions']);
         add_action('wp_ajax_kerbcycle_retry_pickup_exception', [$this, 'retry_pickup_exception']);
     }
@@ -439,6 +440,20 @@ class AdminAjax
         if (!current_user_can('manage_options')) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
+        $this->handle_pickup_exception_submission('admin');
+    }
+
+    public function submit_scanner_pickup_exception()
+    {
+        Nonces::verify('kerbcycle_qr_nonce', 'security');
+        if (!Capabilities::can(Capabilities::manage_operations())) {
+            wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
+        }
+        $this->handle_pickup_exception_submission('scanner');
+    }
+
+    private function handle_pickup_exception_submission($source)
+    {
         \Kerbcycle\QrCode\Install\Activator::activate();
 
         $qr_code_raw = isset($_POST['qr_code']) ? wp_unslash($_POST['qr_code']) : '';
@@ -452,8 +467,8 @@ class AdminAjax
         $issue = sanitize_text_field($issue_raw);
         $notes = sanitize_textarea_field($notes_raw);
         $timestamp = sanitize_text_field($timestamp_raw);
-        // This admin-side handler must not trust client-posted source.
-        $source = 'admin';
+        // Server-side source is fixed by handler context; do not trust client-posted source.
+        $source = $source === 'scanner' ? 'scanner' : 'admin';
         if ($timestamp === '') {
             $timestamp = gmdate('c');
         }


### PR DESCRIPTION
### Motivation

- Allow the scanner UI to submit pickup exceptions via AJAX with appropriate capability checks and a distinct `source` value.
- Eliminate duplicated server-side logic by centralizing pickup-exception handling in a single method.

### Description

- Changed the scanner JavaScript to call `action=kerbcycle_submit_scanner_pickup_exception` instead of the admin-only action.
- Added a new AJAX hook `wp_ajax_kerbcycle_submit_scanner_pickup_exception` handled by `submit_scanner_pickup_exception` and kept `test_pickup_exception` for admin use.
- Introduced a private `handle_pickup_exception_submission($source)` method that contains the shared submission logic and sets the server-side `source` to either `scanner` or `admin` based on the handler context.
- Enforced appropriate nonce and capability checks for the scanner handler (`Capabilities::manage_operations()`), and retained existing sanitization, timestamp defaulting, and deduplication behavior.

### Testing

- Ran the project's existing PHPUnit test suite and all tests passed.
- Performed the JavaScript build and lint steps and they completed without errors.
- Exercised the AJAX endpoint in an automated integration check to verify the scanner action now routes to `kerbcycle_submit_scanner_pickup_exception` and returned expected responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ed4a2ffc832d8508df9fc62ef9df)