### PR TITLE
Add kerbcycle_operator role with minimal scanner capability

### DIFF
--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -157,18 +157,30 @@ class Activator
     private static function grant_capabilities()
     {
         $administrator = get_role('administrator');
-        if (!$administrator) {
-            return;
-        }
-
         $caps = [
             \Kerbcycle\QrCode\Helpers\Capabilities::manage_operations(),
             \Kerbcycle\QrCode\Helpers\Capabilities::manage_settings(),
             \Kerbcycle\QrCode\Helpers\Capabilities::view_logs(),
         ];
 
-        foreach ($caps as $capability) {
-            $administrator->add_cap($capability);
+        if ($administrator) {
+            foreach ($caps as $capability) {
+                $administrator->add_cap($capability);
+            }
+        }
+
+        $operator_caps = [
+            'read' => true,
+            \Kerbcycle\QrCode\Helpers\Capabilities::manage_operations() => true,
+        ];
+
+        add_role('kerbcycle_operator', __('KerbCycle Operator', 'kerbcycle'), $operator_caps);
+
+        $operator = get_role('kerbcycle_operator');
+        if ($operator) {
+            foreach (array_keys($operator_caps) as $capability) {
+                $operator->add_cap($capability);
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a dedicated, minimal WordPress role for scanner/operator staff so the scanner-safe pickup exception flow can be used without granting plugin capabilities to unrelated default roles.

### Description
- Modified `includes/Install/Activator.php` to create/maintain a `kerbcycle_operator` role and assign only `read` and `kerbcycle_manage_operations` to it, preserving existing administrator capability grants as before.
- Activation logic is guarded and idempotent so it is safe if the role or capabilities already exist and does not grant `manage_options` or other admin settings capabilities.

### Testing
- Ran PHP lint on the modified file with `php -l includes/Install/Activator.php`, which succeeded (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e70b77a250832d919cc08912f9c358)