### PR TITLE
Refactor permission check in get_pickup_exceptions

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -679,7 +679,7 @@ class AdminAjax
     public function get_pickup_exceptions()
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
-        if (!current_user_can('manage_options')) {
+        if (!Capabilities::can(Capabilities::manage_operations())) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
         \Kerbcycle\QrCode\Install\Activator::activate();


### PR DESCRIPTION
Why

- retry is an operational action, not a settings action
- should be usable by staff in future
- keeps capability model consistent