### PR TITLE
Add initial PHPUnit smoke test scaffold for KerbCycle

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    bootstrap="tests/phpunit/bootstrap.php"
+    colors="true"
+    verbose="true"
+>
+    <testsuites>
+        <testsuite name="KerbCycle Smoke Tests">
+            <directory suffix="Test.php">tests/phpunit/Smoke</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/phpunit/Smoke/ActivationSmokeTest.php
+++ b/tests/phpunit/Smoke/ActivationSmokeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KerbCycle\Tests\PhpUnit\Smoke;
+
+use KerbCycle\Tests\PhpUnit\TestCase;
+use Kerbcycle\QrCode\Install\Activator;
+
+final class ActivationSmokeTest extends TestCase
+{
+    public function test_activation_creates_qr_codes_table(): void
+    {
+        global $wpdb;
+
+        Activator::activate();
+
+        $table = $wpdb->prefix . 'kerbcycle_qr_codes';
+        $found = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
+
+        $this->assertSame($table, $found, 'Activation should create the kerbcycle QR table.');
+    }
+
+    public function test_activation_sets_default_qr_options_if_defined(): void
+    {
+        $activatorSource = file_get_contents(dirname(__DIR__, 4) . '/includes/Install/Activator.php');
+        $this->assertNotFalse($activatorSource);
+
+        if (strpos($activatorSource, 'update_option(') === false) {
+            $this->assertTrue(true, 'No activation defaults currently defined in Activator::activate().');
+            return;
+        }
+
+        $expectedDefaults = [
+            'kerbcycle_qr_enable_email' => 1,
+            'kerbcycle_qr_enable_sms' => 0,
+            'kerbcycle_qr_enable_reminders' => 0,
+        ];
+
+        Activator::activate();
+
+        foreach ($expectedDefaults as $option => $expectedValue) {
+            if (get_option($option, null) !== null) {
+                $this->assertSame($expectedValue, get_option($option));
+            }
+        }
+    }
+}

--- a/tests/phpunit/Smoke/QrLifecycleSmokeTest.php
+++ b/tests/phpunit/Smoke/QrLifecycleSmokeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KerbCycle\Tests\PhpUnit\Smoke;
+
+use KerbCycle\Tests\PhpUnit\TestCase;
+use Kerbcycle\QrCode\Admin\Ajax\AdminAjax;
+
+final class QrLifecycleSmokeTest extends TestCase
+{
+    public function test_assign_qr_code_via_real_admin_ajax_handler(): void
+    {
+        $adminId = $this->create_admin_user();
+        $customerId = self::factory()->user->create(['role' => 'subscriber', 'display_name' => 'Customer One']);
+        $qrCode = 'SMOKE-ASSIGN-001';
+
+        $this->insert_available_qr($qrCode);
+
+        $response = $this->call_admin_ajax(new AdminAjax(), 'assign_qr_code', $adminId, [
+            'action' => 'assign_qr_code',
+            'qr_code' => $qrCode,
+            'customer_id' => (string) $customerId,
+        ]);
+
+        $this->assertTrue($response['success']);
+
+        $row = $this->get_qr_row($qrCode);
+        $this->assertNotNull($row);
+        $this->assertSame('assigned', $row->status);
+        $this->assertSame($customerId, (int) $row->user_id);
+        $this->assertNotEmpty($row->assigned_at);
+    }
+
+    public function test_release_qr_code_via_real_admin_ajax_handler(): void
+    {
+        $adminId = $this->create_admin_user();
+        $customerId = self::factory()->user->create(['role' => 'subscriber', 'display_name' => 'Customer Two']);
+        $qrCode = 'SMOKE-RELEASE-001';
+
+        $this->insert_available_qr($qrCode);
+
+        $ajax = new AdminAjax();
+        $assign = $this->call_admin_ajax($ajax, 'assign_qr_code', $adminId, [
+            'action' => 'assign_qr_code',
+            'qr_code' => $qrCode,
+            'customer_id' => (string) $customerId,
+        ]);
+        $this->assertTrue($assign['success']);
+
+        $release = $this->call_admin_ajax($ajax, 'release_qr_code', $adminId, [
+            'action' => 'release_qr_code',
+            'qr_code' => $qrCode,
+        ]);
+
+        $this->assertTrue($release['success']);
+
+        $row = $this->get_qr_row($qrCode);
+        $this->assertNotNull($row);
+        $this->assertSame('available', $row->status);
+        $this->assertNull($row->user_id);
+        $this->assertNull($row->assigned_at);
+        $this->assertNull($row->display_name);
+    }
+
+    public function test_assigning_already_assigned_qr_fails_without_overwriting_original_assignment(): void
+    {
+        $adminId = $this->create_admin_user();
+        $firstCustomerId = self::factory()->user->create(['role' => 'subscriber', 'display_name' => 'Customer First']);
+        $secondCustomerId = self::factory()->user->create(['role' => 'subscriber', 'display_name' => 'Customer Second']);
+        $qrCode = 'SMOKE-CONFLICT-001';
+
+        $this->insert_available_qr($qrCode);
+
+        $ajax = new AdminAjax();
+
+        $firstAssign = $this->call_admin_ajax($ajax, 'assign_qr_code', $adminId, [
+            'action' => 'assign_qr_code',
+            'qr_code' => $qrCode,
+            'customer_id' => (string) $firstCustomerId,
+        ]);
+        $this->assertTrue($firstAssign['success']);
+
+        $secondAssign = $this->call_admin_ajax($ajax, 'assign_qr_code', $adminId, [
+            'action' => 'assign_qr_code',
+            'qr_code' => $qrCode,
+            'customer_id' => (string) $secondCustomerId,
+        ]);
+
+        $this->assertFalse($secondAssign['success']);
+
+        $row = $this->get_qr_row($qrCode);
+        $this->assertNotNull($row);
+        $this->assertSame('assigned', $row->status);
+        $this->assertSame($firstCustomerId, (int) $row->user_id, 'Second assignment attempt must not overwrite original owner.');
+    }
+}

--- a/tests/phpunit/Smoke/SecurityBoundarySmokeTest.php
+++ b/tests/phpunit/Smoke/SecurityBoundarySmokeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KerbCycle\Tests\PhpUnit\Smoke;
+
+use KerbCycle\Tests\PhpUnit\TestCase;
+use Kerbcycle\QrCode\Admin\Ajax\AdminAjax;
+use WP_REST_Request;
+
+final class SecurityBoundarySmokeTest extends TestCase
+{
+    public function test_low_privilege_user_cannot_call_pickup_exception_test_ajax_handler(): void
+    {
+        $subscriberId = $this->create_subscriber_user();
+
+        $response = $this->call_admin_ajax(new AdminAjax(), 'test_pickup_exception', $subscriberId, [
+            'action' => 'kerbcycle_test_pickup_exception',
+            'qr_code' => 'SMOKE-PICKUP-001',
+            'customer_id' => '1',
+            'issue' => 'Missed pickup',
+            'notes' => 'Smoke test',
+        ]);
+
+        $this->assertFalse($response['success']);
+        $this->assertSame('Unauthorized', $response['data']['message'] ?? null);
+    }
+
+    public function test_qr_status_rest_route_denies_low_privilege_user(): void
+    {
+        $subscriberId = $this->create_subscriber_user();
+        wp_set_current_user($subscriberId);
+
+        $request = new WP_REST_Request('GET', '/kerbcycle/v1/qr-status/SMOKE-REST-001');
+        $response = rest_get_server()->dispatch($request);
+
+        $this->assertSame(403, $response->get_status());
+    }
+
+    public function test_qr_status_rest_route_allows_administrator(): void
+    {
+        global $wpdb;
+
+        $adminId = $this->create_admin_user();
+        wp_set_current_user($adminId);
+
+        $qrCode = 'SMOKE-REST-ADMIN-001';
+
+        $wpdb->insert(
+            $this->qr_table_name(),
+            [
+                'qr_code' => $qrCode,
+                'status' => 'available',
+            ],
+            ['%s', '%s']
+        );
+
+        $request = new WP_REST_Request('GET', '/kerbcycle/v1/qr-status/' . $qrCode);
+        $response = rest_get_server()->dispatch($request);
+
+        $this->assertSame(200, $response->get_status());
+        $data = $response->get_data();
+        $this->assertSame($qrCode, $data['qr_code'] ?? null);
+    }
+}

--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -98,7 +98,7 @@ abstract class TestCase extends \WP_UnitTestCase
 
     public function ajax_die_handler(): callable
     {
-        return static function () : void {
+        return static function (): void {
             throw new AjaxDieException('AJAX die captured');
         };
     }

--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KerbCycle\Tests\PhpUnit;
+
+use Kerbcycle\QrCode\Admin\Ajax\AdminAjax;
+use Kerbcycle\QrCode\Install\Activator;
+
+class AjaxDieException extends \RuntimeException
+{
+}
+
+abstract class TestCase extends \WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Activator::activate();
+    }
+
+    protected function qr_table_name(): string
+    {
+        global $wpdb;
+        return $wpdb->prefix . 'kerbcycle_qr_codes';
+    }
+
+    protected function create_admin_user(): int
+    {
+        return self::factory()->user->create(['role' => 'administrator']);
+    }
+
+    protected function create_subscriber_user(): int
+    {
+        return self::factory()->user->create(['role' => 'subscriber']);
+    }
+
+    protected function insert_available_qr(string $qrCode): void
+    {
+        global $wpdb;
+
+        $wpdb->insert(
+            $this->qr_table_name(),
+            [
+                'qr_code' => $qrCode,
+                'status' => 'available',
+            ],
+            ['%s', '%s']
+        );
+    }
+
+    protected function get_qr_row(string $qrCode)
+    {
+        global $wpdb;
+
+        return $wpdb->get_row(
+            $wpdb->prepare(
+                'SELECT * FROM ' . $this->qr_table_name() . ' WHERE qr_code = %s ORDER BY id DESC LIMIT 1',
+                $qrCode
+            )
+        );
+    }
+
+    protected function call_admin_ajax(AdminAjax $ajax, string $method, int $userId, array $post = []): array
+    {
+        wp_set_current_user($userId);
+
+        $_POST = array_merge(
+            [
+                'security' => wp_create_nonce('kerbcycle_qr_nonce'),
+            ],
+            $post
+        );
+        $_REQUEST = $_POST;
+
+        add_filter('wp_die_ajax_handler', [$this, 'ajax_die_handler']);
+
+        $json = '';
+        ob_start();
+
+        try {
+            $ajax->{$method}();
+        } catch (AjaxDieException $e) {
+            // expected for wp_send_json_* in ajax handlers
+        }
+
+        $json = (string) ob_get_clean();
+
+        remove_filter('wp_die_ajax_handler', [$this, 'ajax_die_handler']);
+
+        $decoded = json_decode($json, true);
+
+        $this->assertIsArray($decoded, 'Expected a JSON response from AJAX handler.');
+        $this->assertArrayHasKey('success', $decoded, 'Expected standard WP AJAX response payload.');
+
+        return $decoded;
+    }
+
+    public function ajax_die_handler(): callable
+    {
+        return static function () : void {
+            throw new AjaxDieException('AJAX die captured');
+        };
+    }
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+$_tests_dir = getenv('WP_TESTS_DIR');
+if (!$_tests_dir) {
+    $_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+if (!file_exists($_tests_dir . '/includes/functions.php')) {
+    fwrite(STDERR, "Could not find WordPress tests bootstrap in {$_tests_dir}.\n");
+    fwrite(STDERR, "Set WP_TESTS_DIR to your wordpress-tests-lib path.\n");
+    exit(1);
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+tests_add_filter('muplugins_loaded', static function (): void {
+    require dirname(__DIR__, 2) . '/kerbcycle-qr-code-manager.php';
+});
+
+require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
### Motivation
- Add a minimal, conservative PHPUnit smoke test suite to detect regressions in core KerbCycle behaviors (activation, QR assign/release, and security boundaries) without changing plugin runtime code.

### Description
- Added test scaffolding and configuration: `phpunit.xml.dist`, `tests/phpunit/bootstrap.php`, and a shared base `tests/phpunit/TestCase.php` that activates the plugin and provides DB/AJAX helpers.
- Added smoke tests under `tests/phpunit/Smoke`: `ActivationSmokeTest.php`, `QrLifecycleSmokeTest.php`, and `SecurityBoundarySmokeTest.php` which exercise `\Kerbcycle\QrCode\Install\Activator::activate()`, the real `\Kerbcycle\QrCode\Admin\Ajax\AdminAjax::assign_qr_code()` and `::release_qr_code()` handlers, the `kerbcycle_test_pickup_exception` AJAX action, and the REST path `/kerbcycle/v1/qr-status/{qr_code}` while using the nonce `kerbcycle_qr_nonce`.
- Tests reuse existing plugin classes and DB helpers only and do not modify any runtime plugin files or external integrations.

### Testing
- Ran PHP syntax checks with `php -l` on the new files and all checks passed successfully.
- Attempted to run the test suite with `phpunit -c phpunit.xml.dist` but the `phpunit` binary is not available in this environment, so the full suite was not executed.
- Verified files were created and committed; no existing runtime files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadf1d9840832d8c8c8dd6630cc9e5)