### PR TITLE
Add GitHub Actions workflow to run PHPUnit smoke tests

### DIFF
--- a/.github/workflows/phpunit-smoke.yml
+++ b/.github/workflows/phpunit-smoke.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: '8.3'
           tools: composer:v2

--- a/.github/workflows/phpunit-smoke.yml
+++ b/.github/workflows/phpunit-smoke.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   phpunit-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/phpunit-smoke.yml
+++ b/.github/workflows/phpunit-smoke.yml
@@ -1,0 +1,60 @@
+name: PHPUnit Smoke Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  phpunit-smoke:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: wordpress_test
+          MYSQL_USER: wordpress
+          MYSQL_PASSWORD: wordpress
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      WP_TESTS_DIR: /tmp/wordpress-tests-lib
+      WP_CORE_DIR: /tmp/wordpress
+      DB_HOST: 127.0.0.1
+      DB_NAME: wordpress_test
+      DB_USER: wordpress
+      DB_PASS: wordpress
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+
+      - name: Show PHP version
+        run: php -v
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Install WordPress test suite
+        run: |
+          curl -fsSL -o /tmp/install-wp-tests.sh https://raw.githubusercontent.com/wp-cli/scaffold-command/master/templates/install-wp-tests.sh
+          chmod +x /tmp/install-wp-tests.sh
+          /tmp/install-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" latest
+
+      - name: Run PHPUnit smoke tests
+        run: vendor/bin/phpunit -c phpunit.xml.dist

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+  "name": "kerbcycle/qr-code-manager",
+  "description": "KerbCycle QR Code Manager test dependencies",
+  "type": "project",
+  "require-dev": {
+    "phpunit/phpunit": "^9.6",
+    "yoast/phpunit-polyfills": "^2.0"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide an automated, reproducible CI environment for the existing KerbCycle PHPUnit smoke tests so PRs are validated without slow local setup.
- Keep changes minimal and avoid modifying plugin runtime code while ensuring the WordPress test framework and a disposable DB are available in CI.

### Description
- Add `.github/workflows/phpunit-smoke.yml` to run on `pull_request` and `push` to `main`, set up PHP 8.3, start a MySQL 8 service, install Composer deps, install the WordPress test suite into `/tmp/wordpress-tests-lib`, and run the smoke tests with `vendor/bin/phpunit -c phpunit.xml.dist`.
- Add a minimal `composer.json` with `require-dev` entries for `phpunit/phpunit:^9.6` and `yoast/phpunit-polyfills:^2.0` to provide CI test dependencies without touching plugin runtime files.
- No plugin runtime files were modified and the workflow uses disposable DB credentials; WordPress test bootstrap (`tests/phpunit/bootstrap.php`) is left intact and relies on `WP_TESTS_DIR`.

### Testing
- Ran `composer validate --no-check-publish` which succeeded with warnings about metadata only.
- Ran PHP lint on `tests/phpunit/bootstrap.php` and `tests/phpunit/TestCase.php`, both with no syntax errors.
- Attempted `composer install` in this environment but it failed due to outbound Packagist connectivity (`CONNECT tunnel failed, response 403`); the workflow is configured to perform `composer install` on GitHub Actions where network access is expected.
- The workflow’s test step executes `vendor/bin/phpunit -c phpunit.xml.dist` and will fail the job if tests fail when run in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1dbbed7c832d824a9c89ff4dc274)