### PR TITLE
Fix PHPUnit smoke bootstrap order for custom TestCase loading

### DIFF
--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -13,6 +13,8 @@ if (!file_exists($_tests_dir . '/includes/functions.php')) {
     exit(1);
 }
 
+require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+
 require_once $_tests_dir . '/includes/functions.php';
 
 tests_add_filter('muplugins_loaded', static function (): void {
@@ -20,3 +22,5 @@ tests_add_filter('muplugins_loaded', static function (): void {
 });
 
 require $_tests_dir . '/includes/bootstrap.php';
+
+require_once __DIR__ . '/TestCase.php';


### PR DESCRIPTION
### Motivation
- Ensure `KerbCycle\Tests\PhpUnit\TestCase` is available to smoke tests only after WordPress' test bootstrap defines `WP_UnitTestCase`, without changing plugin runtime code.

### Description
- Modified `tests/phpunit/bootstrap.php` to `require_once dirname(__DIR__, 2) . '/vendor/autoload.php';` before loading the WordPress test includes and to `require_once __DIR__ . '/TestCase.php';` after `$_tests_dir . '/includes/bootstrap.php'`, keeping all other behaviour unchanged.

### Testing
- Ran `php -l tests/phpunit/bootstrap.php` which reported no syntax errors, and attempted `composer install`/`vendor/bin/phpunit` but Composer dependency download failed in this environment (network/Packagist error) so full PHPUnit run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf586c9d8832dbcb4a74f06645d43)