### PR TITLE
Fix PHPUnit TestCase autoloading for CI discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,11 @@
   "name": "kerbcycle/qr-code-manager",
   "description": "KerbCycle QR Code Manager test dependencies",
   "type": "project",
+  "autoload-dev": {
+    "psr-4": {
+      "KerbCycle\\Tests\\PhpUnit\\": "tests/phpunit/"
+    }
+  },
   "require-dev": {
     "phpunit/phpunit": "^9.6",
     "yoast/phpunit-polyfills": "^2.0"


### PR DESCRIPTION
### Motivation
- Ensure `KerbCycle\Tests\PhpUnit\TestCase` is autoloadable during PHPUnit discovery because PHPUnit loads test classes before `tests/phpunit/bootstrap.php` executes.

### Description
- Add an `autoload-dev` PSR-4 mapping in `composer.json`: `"KerbCycle\\Tests\\PhpUnit\\": "tests/phpunit/"` and regenerate Composer autoload files with `composer dump-autoload`, while leaving plugin runtime files and `TestCase` inheritance (`extends \WP_UnitTestCase`) unchanged.

### Testing
- Ran `composer dump-autoload` (succeeded), attempted `composer install` (failed due to Packagist network/403), and could not run `vendor/bin/phpunit --list-tests` because dependencies were not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0aa95478832dbabd74efe84a3925)