### PR TITLE
tests: rely on Composer autoload for PHPUnit TestCase

### DIFF
--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -23,4 +23,3 @@ tests_add_filter('muplugins_loaded', static function (): void {
 
 require $_tests_dir . '/includes/bootstrap.php';
 
-require_once __DIR__ . '/TestCase.php';

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -22,4 +22,3 @@ tests_add_filter('muplugins_loaded', static function (): void {
 });
 
 require $_tests_dir . '/includes/bootstrap.php';
-


### PR DESCRIPTION
### Motivation
- Remove a redundant manual include and allow `KerbCycle\Tests\PhpUnit\TestCase` to be resolved by Composer `autoload-dev` so smoke tests use standard unbracketed namespaces.

### Description
- Removed the single-line manual include `require_once __DIR__ . '/TestCase.php';` from `tests/phpunit/bootstrap.php` and retained the early `require_once dirname(__DIR__, 2) . '/vendor/autoload.php';`, leaving `composer.json`, `phpunit.xml.dist`, `tests/phpunit/TestCase.php`, and the smoke tests unchanged.

### Testing
- Ran `composer dump-autoload` which generated autoload files, ran `php -l` on `tests/phpunit/bootstrap.php` and the three smoke tests which all reported "No syntax errors detected", and attempted `vendor/bin/phpunit -c phpunit.xml.dist --filter ActivationSmokeTest` but `vendor/bin/phpunit` was not present in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec13b02e8c832da90e000b4f0128b1)