### PR TITLE
Add explicit TestCase require in smoke tests to fix PHPUnit discovery

### DIFF
--- a/tests/phpunit/Smoke/ActivationSmokeTest.php
+++ b/tests/phpunit/Smoke/ActivationSmokeTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace KerbCycle\Tests\PhpUnit\Smoke;
 
+require_once __DIR__ . '/../TestCase.php';
+
 use KerbCycle\Tests\PhpUnit\TestCase;
 use Kerbcycle\QrCode\Install\Activator;
 

--- a/tests/phpunit/Smoke/QrLifecycleSmokeTest.php
+++ b/tests/phpunit/Smoke/QrLifecycleSmokeTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace KerbCycle\Tests\PhpUnit\Smoke;
 
+require_once __DIR__ . '/../TestCase.php';
+
 use KerbCycle\Tests\PhpUnit\TestCase;
 use Kerbcycle\QrCode\Admin\Ajax\AdminAjax;
 

--- a/tests/phpunit/Smoke/SecurityBoundarySmokeTest.php
+++ b/tests/phpunit/Smoke/SecurityBoundarySmokeTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace KerbCycle\Tests\PhpUnit\Smoke;
 
+require_once __DIR__ . '/../TestCase.php';
+
 use KerbCycle\Tests\PhpUnit\TestCase;
 use Kerbcycle\QrCode\Admin\Ajax\AdminAjax;
 use WP_REST_Request;


### PR DESCRIPTION
### Motivation
- Ensure `KerbCycle\Tests\PhpUnit\TestCase` is available during PHPUnit test discovery to prevent "Class ... TestCase not found" errors without changing runtime/plugin code.

### Description
- Inserted `require_once __DIR__ . '/../TestCase.php';` immediately after the `namespace` declaration in `tests/phpunit/Smoke/ActivationSmokeTest.php`, `tests/phpunit/Smoke/QrLifecycleSmokeTest.php`, and `tests/phpunit/Smoke/SecurityBoundarySmokeTest.php` so the base TestCase is loaded before each smoke test class is evaluated.

### Testing
- Executed `php -l` on the three modified files (`tests/phpunit/Smoke/ActivationSmokeTest.php`, `tests/phpunit/Smoke/QrLifecycleSmokeTest.php`, `tests/phpunit/Smoke/SecurityBoundarySmokeTest.php`) and all syntax checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec189f249c832db5a2f10d5cdf62a6)