### PR TITLE
Fix PHPUnit AJAX helper output capture for wp_send_json responses

### DIFF
--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -76,17 +76,20 @@ abstract class TestCase extends \WP_UnitTestCase
         add_filter('wp_die_ajax_handler', [$this, 'ajax_die_handler']);
 
         $json = '';
+        $bufferLevel = ob_get_level();
         ob_start();
 
         try {
             $ajax->{$method}();
         } catch (AjaxDieException $e) {
             // expected for wp_send_json_* in ajax handlers
+        } finally {
+            if (ob_get_level() > $bufferLevel) {
+                $json = (string) ob_get_clean();
+            }
+
+            remove_filter('wp_die_ajax_handler', [$this, 'ajax_die_handler']);
         }
-
-        $json = (string) ob_get_clean();
-
-        remove_filter('wp_die_ajax_handler', [$this, 'ajax_die_handler']);
 
         $decoded = json_decode($json, true);
 
@@ -98,7 +101,7 @@ abstract class TestCase extends \WP_UnitTestCase
 
     public function ajax_die_handler(): callable
     {
-        return static function (): void {
+        return static function ($message = '', $title = '', $args = []): void {
             throw new AjaxDieException('AJAX die captured');
         };
     }


### PR DESCRIPTION
### Motivation
- Prevent raw JSON emitted by `wp_send_json_success`/`wp_send_json_error` from leaking into PHPUnit output by making the AJAX test helper reliably capture and decode the response and intercept `wp_die()` termination.

### Description
- Modified `tests/phpunit/TestCase.php::call_admin_ajax()` to track the output buffer level with `ob_get_level()`, start buffering with `ob_start()`, and always perform buffer cleanup and `wp_die_ajax_handler` removal in a `finally` block so only helper-owned output is captured.
- Updated `ajax_die_handler()` closure signature to accept `($message = '', $title = '', $args = [])` to match WordPress `wp_die()` invocations while still throwing `AjaxDieException` to stop execution for `wp_send_json_*` paths.
- Preserved existing response-shape assertions and return the decoded JSON array to callers.

### Testing
- Ran PHP syntax check: `php -l tests/phpunit/TestCase.php` (no syntax errors).
- Attempted to run smoke tests with `./vendor/bin/phpunit --filter QrLifecycleSmokeTest --testsuite smoke` but the PHPUnit binary is not available in this environment, so full test execution could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3975af74832da523168f319e6733)