### PR TITLE
Intercept both wp_die handlers in PHPUnit AJAX helper

### DIFF
--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -74,6 +74,7 @@ abstract class TestCase extends \WP_UnitTestCase
         $_REQUEST = $_POST;
 
         add_filter('wp_die_ajax_handler', [$this, 'ajax_die_handler']);
+        add_filter('wp_die_handler', [$this, 'ajax_die_handler']);
 
         $json = '';
         $bufferLevel = ob_get_level();
@@ -89,6 +90,7 @@ abstract class TestCase extends \WP_UnitTestCase
             }
 
             remove_filter('wp_die_ajax_handler', [$this, 'ajax_die_handler']);
+            remove_filter('wp_die_handler', [$this, 'ajax_die_handler']);
         }
 
         $decoded = json_decode($json, true);


### PR DESCRIPTION
### Motivation
- Prevent raw JSON from wp_send_json_* leaking into PHPUnit output by ensuring both `wp_die_ajax_handler` and `wp_die_handler` paths are intercepted during AJAX-style handler calls.

### Description
- In `tests/phpunit/TestCase.php::call_admin_ajax()` register both `wp_die_ajax_handler` and `wp_die_handler` with `[$this, 'ajax_die_handler']` before invoking the AJAX method.
- In the `finally` cleanup remove both filters to restore state; buffering, JSON decoding, and assertions remain unchanged.

### Testing
- Ran `php -l tests/phpunit/TestCase.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3c676f70832dbd0ba3c4efc19788)