### PR TITLE
Test: fully drain AJAX helper output buffers

### DIFF
--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -85,8 +85,8 @@ abstract class TestCase extends \WP_UnitTestCase
         } catch (AjaxDieException $e) {
             // expected for wp_send_json_* in ajax handlers
         } finally {
-            if (ob_get_level() > $bufferLevel) {
-                $json = (string) ob_get_clean();
+            while (ob_get_level() > $bufferLevel) {
+                $json .= (string) ob_get_clean();
             }
 
             remove_filter('wp_die_ajax_handler', [$this, 'ajax_die_handler']);


### PR DESCRIPTION
### Motivation
- Prevent raw AJAX JSON from leaking into PHPUnit logs by ensuring `call_admin_ajax()` removes every output buffer created during AJAX handler execution.

### Description
- In `tests/phpunit/TestCase.php` replace the single-buffer cleanup with a full drain loop: `while (ob_get_level() > $bufferLevel) { $json .= (string) ob_get_clean(); }`, preserving the existing `wp_die_ajax_handler`/`wp_die_handler` interception and JSON decode/assertions.

### Testing
- Ran `php -l tests/phpunit/TestCase.php` which reported no syntax errors and verified the only change is to `tests/phpunit/TestCase.php` via `git diff`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4065dae8832d83fbeda29515c3f7)