### PR TITLE
Wire SonarQube & Snyk tokens and set Sonar project key in CI workflows

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -34,7 +34,15 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
+      - name: Validate Snyk token
+        run: |
+          if [ -z "${SNYK_TOKEN}" ]; then
+            echo "SNYK_TOKEN is not configured in GitHub repository secrets."
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - name: Set up Snyk CLI to check for security issues
         # Snyk can be used to break the build when it detects security issues.
@@ -46,10 +54,6 @@ jobs:
         #- uses: actions/setup-node@v4
         #  with:
         #    node-version: 20
-
-        env:
-          # This is where you will need to introduce the Snyk API token created with your Snyk account
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
         # Runs Snyk Code (SAST) analysis and uploads result into GitHub.
         # Use || true to not fail the pipeline

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -41,6 +41,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Validate SonarQube secrets
+        run: |
+          if [ -z "${{ secrets.SONAR_TOKEN }}" ]; then
+            echo "SONAR_TOKEN is not configured in GitHub repository secrets."
+            exit 1
+          fi
+          if [ -z "${{ secrets.SONAR_HOST_URL }}" ]; then
+            echo "SONAR_HOST_URL is not configured in GitHub repository secrets."
+            exit 1
+          fi
       - name: Analyze with SonarQube
 
         # You can pin the exact commit or the version.
@@ -55,7 +65,7 @@ jobs:
           args:
             # Unique key of your project. You can find it in SonarQube > [my project] > Project Information (top-right menu)
             # mandatory
-            -Dsonar.projectKey=
+            -Dsonar.projectKey=${{ github.event.repository.name }}
             # Comma-separated paths to directories containing main source files.
             #-Dsonar.sources= # optional, default is project base directory
             # When you need the analysis to take place in a directory other than the one from which it was launched


### PR DESCRIPTION
### Motivation
- CI SonarQube runs were failing due to missing `SONAR_TOKEN` and an empty `sonar.projectKey`, and Snyk runs were failing with 401 because the `SNYK_TOKEN` was not correctly available to job steps. 
- Make failures explicit when secrets are not configured and ensure Sonar has a non-empty project key so analyses can run when secrets exist.

### Description
- Updated `.github/workflows/sonarqube.yml` to add a validation step that checks for `SONAR_TOKEN` and `SONAR_HOST_URL` and to set `-Dsonar.projectKey=${{ github.event.repository.name }}` so the project key is not empty. 
- Updated `.github/workflows/snyk-security.yml` to move `SNYK_TOKEN` to the job-level `env` and add a validation step that exits with an explicit error if `SNYK_TOKEN` is missing so all Snyk CLI commands authenticate. 
- Only the two workflow files were changed and no plugin/PHP code, action versions, workflow triggers, or unrelated files were modified.

### Testing
- Ran `git diff --check` which passed with no whitespace errors. 
- Inspected the workflow diffs with `git diff -- .github/workflows/sonarqube.yml .github/workflows/snyk-security.yml` to confirm only the intended auth/config wiring changes were made. 
- Verified repository state with `git status --short` and committed the changes via `git commit`, and those commands completed successfully; runtime validation depends on repository secrets being present and will now fail clearly if they are not.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b1b935cc832da29048f2c7c3ab94)