### PR TITLE
Validate CI secrets and update Snyk/SonarQube workflow configs

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -34,7 +34,15 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
+      - name: Validate Snyk token
+        run: |
+          if [ -z "${SNYK_TOKEN}" ]; then
+            echo "SNYK_TOKEN is not configured in GitHub repository secrets."
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - name: Set up Snyk CLI to check for security issues
         # Snyk can be used to break the build when it detects security issues.
@@ -46,10 +54,6 @@ jobs:
         #- uses: actions/setup-node@v4
         #  with:
         #    node-version: 20
-
-        env:
-          # This is where you will need to introduce the Snyk API token created with your Snyk account
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
         # Runs Snyk Code (SAST) analysis and uploads result into GitHub.
         # Use || true to not fail the pipeline

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -41,11 +41,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Validate SonarQube secrets
+        run: |
+          if [ -z "${{ secrets.SONAR_TOKEN }}" ]; then
+            echo "SONAR_TOKEN is not configured in GitHub repository secrets."
+            exit 1
+          fi
+          if [ -z "${{ secrets.SONAR_HOST_URL }}" ]; then
+            echo "SONAR_HOST_URL is not configured in GitHub repository secrets."
+            exit 1
+          fi
       - name: Analyze with SonarQube
 
         # You can pin the exact commit or the version.
         # uses: SonarSource/sonarqube-scan-action@v1.1.0
-        uses: SonarSource/sonarqube-scan-action@7295e71c9583053f5bf40e9d4068a0c974603ec8
+        # TODO: Re-pin to a full commit SHA after validating v6 in this repository.
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}   # Generate a token on SonarQube, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)
@@ -55,7 +66,7 @@ jobs:
           args:
             # Unique key of your project. You can find it in SonarQube > [my project] > Project Information (top-right menu)
             # mandatory
-            -Dsonar.projectKey=
+            -Dsonar.projectKey=${{ github.event.repository.name }}
             # Comma-separated paths to directories containing main source files.
             #-Dsonar.sources= # optional, default is project base directory
             # When you need the analysis to take place in a directory other than the one from which it was launched


### PR DESCRIPTION
### Motivation

- Ensure required secrets are present before running Snyk and SonarQube jobs to fail early and provide clear error messages.
- Make the SonarQube action usage and project key more robust for typical repo setups.

### Description

- Add `SNYK_TOKEN` to the `snyk` job environment and insert a validation step that exits if `SNYK_TOKEN` is not set. 
- Remove the redundant `SNYK_TOKEN` env block under the Snyk setup step and keep Snyk CLI steps unchanged. 
- Add a validation step at the start of the SonarQube `Analysis` job that checks `SONAR_TOKEN` and `SONAR_HOST_URL` and exits with an error if either is missing. 
- Update the SonarQube action reference to `SonarSource/sonarqube-scan-action@v6` with a `TODO` to re-pin to a full SHA and set `-Dsonar.projectKey` to `${{ github.event.repository.name }}`.

### Testing

- No automated tests were executed as part of this change; these edits are workflow configuration updates and should be validated by running the workflows in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b1b935cc832da29048f2c7c3ab94)