### PR TITLE
style: PHPCS formatting cleanup for Utils helper

### DIFF
--- a/includes/Helpers/Utils.php
+++ b/includes/Helpers/Utils.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Helpers;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+if (! defined('ABSPATH')) {
+    exit;
 }
 
 /**
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Helpers
  */
-class Utils {
-	// Utility functions will be added here.
+class Utils
+{
+    // Utility functions will be added here.
 }

--- a/includes/Helpers/Utils.php
+++ b/includes/Helpers/Utils.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Helpers;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 /**
@@ -13,7 +13,6 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Helpers
  */
-class Utils
-{
-    // Utility functions will be added here.
+class Utils {
+	// Utility functions will be added here.
 }


### PR DESCRIPTION
### Motivation
- Address PHPCS formatting violations in `includes/Helpers/Utils.php` with the smallest possible, behavior-preserving edits.

### Description
- Apply mechanical, formatting-only changes in `includes/Helpers/Utils.php` (adjust spacing around `defined( 'ABSPATH' )`, convert indentation to tabs, and normalize class brace placement) without changing any logic, names, or execution flow.

### Testing
- Ran `php -l includes/Helpers/Utils.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2eba047dc832d9eec12fd36ff2a0c)