### PR TITLE
style: PHPCS formatting cleanup for Uninstaller

### DIFF
--- a/includes/Install/Uninstaller.php
+++ b/includes/Install/Uninstaller.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Install;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 /**
@@ -15,20 +15,18 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Install
  */
-class Uninstaller
-{
-    /**
-     * Short Description. (use period)
-     *
-     * Long Description.
-     *
-     * @since    1.0.0
-     */
-    public static function deactivate()
-    {
-        $timestamp = wp_next_scheduled('kerbcycle_qr_reminder');
-        if ($timestamp) {
-            wp_unschedule_event($timestamp, 'kerbcycle_qr_reminder');
-        }
-    }
+class Uninstaller {
+	/**
+	 * Short Description. (use period)
+	 *
+	 * Long Description.
+	 *
+	 * @since    1.0.0
+	 */
+	public static function deactivate() {
+		$timestamp = wp_next_scheduled( 'kerbcycle_qr_reminder' );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, 'kerbcycle_qr_reminder' );
+		}
+	}
 }


### PR DESCRIPTION
### Motivation
- Bring `includes/Install/Uninstaller.php` into PHPCS / WordPress style by applying mechanical formatting fixes without changing behavior.

### Description
- Updated spacing, indentation, brace placement, and function-call spacing in `includes/Install/Uninstaller.php` only, with no renames or logic changes. 
- The ABSPATH guard and the `deactivate` flow that unschedules `kerbcycle_qr_reminder` remain unchanged.
- Files changed: exactly `includes/Install/Uninstaller.php`.

### Testing
- Ran `php -l includes/Install/Uninstaller.php` and it reported no syntax errors (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f302d0fb6c832da43af222e84fd351)