### PR TITLE
style: fix PHPCS spacing in ReportsPage.php guard

### DIFF
--- a/includes/Admin/Pages/ReportsPage.php
+++ b/includes/Admin/Pages/ReportsPage.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode\Admin\Pages;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 


### PR DESCRIPTION
### Motivation
- Apply a mechanical PHPCS/WordPress formatting fix to bring the `ABSPATH` guard in `includes/Admin/Pages/ReportsPage.php` in line with coding standards without changing behavior.

### Description
- Updated only `includes/Admin/Pages/ReportsPage.php` to change the guard from `if (!defined('ABSPATH')) {` to `if ( ! defined( 'ABSPATH' ) ) {`; no logic, security checks, nonces, names, or execution flow were modified, and there are no behavioral changes or renames; risk is minimal and limited to formatting only.

### Testing
- Ran `php -l includes/Admin/Pages/ReportsPage.php` which completed successfully (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f306a17124832d8ac6f0c691e57a81)