### PR TITLE
style: apply PHPCS formatting to RedirectsPage.php

### DIFF
--- a/includes/Admin/Pages/RedirectsPage.php
+++ b/includes/Admin/Pages/RedirectsPage.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Admin\Pages;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 /**
@@ -13,27 +13,24 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Admin\Pages
  */
-class RedirectsPage
-{
-    /**
-     * Redirect to the Bookly appointments page.
-     *
-     * @since    1.0.0
-     */
-    public function bookly_appointments()
-    {
-        wp_redirect(admin_url('admin.php?page=bookly-appointments'));
-        exit;
-    }
+class RedirectsPage {
+	/**
+	 * Redirect to the Bookly appointments page.
+	 *
+	 * @since    1.0.0
+	 */
+	public function bookly_appointments() {
+		wp_redirect( admin_url( 'admin.php?page=bookly-appointments' ) );
+		exit;
+	}
 
-    /**
-     * Redirect to the TeraWallet page.
-     *
-     * @since    1.0.0
-     */
-    public function terawallet()
-    {
-        wp_redirect(admin_url('admin.php?page=woo-wallet'));
-        exit;
-    }
+	/**
+	 * Redirect to the TeraWallet page.
+	 *
+	 * @since    1.0.0
+	 */
+	public function terawallet() {
+		wp_redirect( admin_url( 'admin.php?page=woo-wallet' ) );
+		exit;
+	}
 }


### PR DESCRIPTION
### Motivation
- Fix PHPCS formatting violations in `includes/Admin/Pages/RedirectsPage.php` as a formatting-only change with no behavior or API modifications.

### Description
- Applied mechanical PHPCS-style formatting to `includes/Admin/Pages/RedirectsPage.php` (normalized `defined( 'ABSPATH' )` guard spacing, class/method brace placement, indentation, and function-call spacing) and did not modify any logic, identifiers, or control flow.

### Testing
- Attempted to run `./vendor/bin/phpcs` and `phpcs` but both commands were unavailable in the environment, so no automated style tests executed locally; no functional/Unit tests were run and PHPUnit smoke tests are expected to be unaffected because no logic changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3082e0f2c832db381749246c5b550)