### PR TITLE
style: PHPCS formatting fixes in Capabilities helper

### DIFF
--- a/includes/Helpers/Capabilities.php
+++ b/includes/Helpers/Capabilities.php
@@ -3,7 +3,7 @@
 namespace Kerbcycle\QrCode\Helpers;
 
 if (!defined('ABSPATH')) {
-    exit;
+	exit;
 }
 
 /**
@@ -11,34 +11,34 @@ if (!defined('ABSPATH')) {
  */
 class Capabilities
 {
-    public const MANAGE_OPERATIONS = 'kerbcycle_manage_operations';
-    public const MANAGE_SETTINGS = 'kerbcycle_manage_settings';
-    public const VIEW_LOGS = 'kerbcycle_view_logs';
+	public const MANAGE_OPERATIONS = 'kerbcycle_manage_operations';
+	public const MANAGE_SETTINGS = 'kerbcycle_manage_settings';
+	public const VIEW_LOGS = 'kerbcycle_view_logs';
 
-    public static function manage_operations()
-    {
-        return self::MANAGE_OPERATIONS;
-    }
+	public static function manage_operations()
+	{
+		return self::MANAGE_OPERATIONS;
+	}
 
-    public static function manage_settings()
-    {
-        return self::MANAGE_SETTINGS;
-    }
+	public static function manage_settings()
+	{
+		return self::MANAGE_SETTINGS;
+	}
 
-    public static function view_logs()
-    {
-        return self::VIEW_LOGS;
-    }
+	public static function view_logs()
+	{
+		return self::VIEW_LOGS;
+	}
 
-    /**
-     * Backward-compatible capability check.
-     *
-     * @param string $capability Capability to check.
-     *
-     * @return bool
-     */
-    public static function can($capability)
-    {
-        return current_user_can($capability) || current_user_can('manage_options');
-    }
+	/**
+	 * Backward-compatible capability check.
+	 *
+	 * @param string $capability Capability to check.
+	 *
+	 * @return bool
+	 */
+	public static function can($capability)
+	{
+		return current_user_can($capability) || current_user_can('manage_options');
+	}
 }


### PR DESCRIPTION
### Motivation
- Normalize PHPCS/WordPress formatting in the centralized capabilities helper to match repository style without changing behavior.

### Description
- Applied mechanical formatting fixes in `includes/Helpers/Capabilities.php`, converting indentation/brace placement to tab-based WordPress style and adjusting docblock/spacing only.
- Modified exactly one file: `includes/Helpers/Capabilities.php`, with no renames, logic changes, or API surface changes.

### Testing
- Ran a PHP syntax check `php -l includes/Helpers/Capabilities.php`, which passed.
- Verified repository change count with `git status --short` to confirm only the target file was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30922536c832da3360eac766d9843)