### PR TITLE
style: PHPCS formatting for includes/Helpers/Nonces.php

### DIFF
--- a/includes/Helpers/Nonces.php
+++ b/includes/Helpers/Nonces.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Helpers;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 /**
@@ -13,42 +13,40 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Helpers
  */
-class Nonces
-{
-    /**
-     * Verify a nonce value.
-     *
-     * @param string               $action  Action name.
-     * @param string               $field   Field name containing the nonce.
-     * @param \WP_REST_Request|null $request Optional REST request.
-     *
-     * @return bool|\WP_Error True if valid, WP_Error otherwise (REST).
-     */
-    public static function verify($action, $field = '_wpnonce', $request = null)
-    {
-        $nonce = '';
-        if ($request instanceof \WP_REST_Request) {
-            $nonce = $request->get_param($field);
-        } elseif (isset($_REQUEST[$field])) {
-            $nonce = $_REQUEST[$field];
-        }
+class Nonces {
+	/**
+	 * Verify a nonce value.
+	 *
+	 * @param string                $action  Action name.
+	 * @param string                $field   Field name containing the nonce.
+	 * @param \WP_REST_Request|null $request Optional REST request.
+	 *
+	 * @return bool|\WP_Error True if valid, WP_Error otherwise (REST).
+	 */
+	public static function verify( $action, $field = '_wpnonce', $request = null ) {
+		$nonce = '';
+		if ( $request instanceof \WP_REST_Request ) {
+			$nonce = $request->get_param( $field );
+		} elseif ( isset( $_REQUEST[ $field ] ) ) {
+			$nonce = $_REQUEST[ $field ];
+		}
 
-        $nonce = sanitize_text_field($nonce);
+		$nonce = sanitize_text_field( $nonce );
 
-        if (!wp_verify_nonce($nonce, $action)) {
-            $message = __('Security check failed', 'kerbcycle');
+		if ( ! wp_verify_nonce( $nonce, $action ) ) {
+			$message = __( 'Security check failed', 'kerbcycle' );
 
-            if ($request instanceof \WP_REST_Request) {
-                return new \WP_Error('rest_nonce_invalid', $message, ['status' => 403]);
-            }
+			if ( $request instanceof \WP_REST_Request ) {
+				return new \WP_Error( 'rest_nonce_invalid', $message, array( 'status' => 403 ) );
+			}
 
-            if (wp_doing_ajax()) {
-                wp_send_json_error(['message' => $message], 403);
-            }
+			if ( wp_doing_ajax() ) {
+				wp_send_json_error( array( 'message' => $message ), 403 );
+			}
 
-            wp_die($message, __('Error', 'kerbcycle'), 403);
-        }
+			wp_die( $message, __( 'Error', 'kerbcycle' ), 403 );
+		}
 
-        return true;
-    }
+		return true;
+	}
 }


### PR DESCRIPTION
### Motivation

- Bring `includes/Helpers/Nonces.php` into PHPCS/WordPress formatting convention compliance with a minimal, mechanical-only change. 
- Make only spacing, indentation, brace, array, and docblock structure adjustments while preserving all runtime behavior.

### Description

- Modified exactly one file: `includes/Helpers/Nonces.php`, and applied mechanical formatting fixes (ABSPATH guard spacing, class and method brace placement, indentation, spacing around function calls and arrays, and docblock alignment). 
- Normalized method signature spacing and converted short array literals to spaced `array()`/consistent spacing where appropriate to match repository style guidelines. 
- Preserved all identifiers, function names, nonces, capability checks, control flow branches (REST/AJAX/wp_die), and return values so there are no behavior or security changes. 
- No other files were touched and no logic or API changes were introduced. 

### Testing

- Ran `php -l includes/Helpers/Nonces.php` and it reported no syntax errors. 
- Attempted `phpcs includes/Helpers/Nonces.php` and `./vendor/bin/phpcs includes/Helpers/Nonces.php` but PHPCS was not available in the environment. 
- No PHPUnit tests were executed as this is a formatting-only change and no behavioral modifications were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30bc27ff0832da1c498659b7ea04d)