### PR TITLE
style: fix PHPCS formatting in RestService

### DIFF
--- a/includes/Api/RestService.php
+++ b/includes/Api/RestService.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Api;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 /**
@@ -13,47 +13,56 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Api
  */
-class RestService
-{
-    /**
-     * Initialize the class and set its properties.
-     *
-     * @since    1.0.0
-     */
-    public function __construct()
-    {
-        add_action('rest_api_init', [$this, 'register_routes']);
-    }
+class RestService {
+	/**
+	 * Initialize the class and set its properties.
+	 *
+	 * @since    1.0.0
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
 
-    /**
-     * Register the routes for the objects of the controller.
-     *
-     * @since    1.0.0
-     */
-    public function register_routes()
-    {
-        $ai_controller = new Controllers\AiController();
+	/**
+	 * Register the routes for the objects of the controller.
+	 *
+	 * @since    1.0.0
+	 */
+	public function register_routes() {
+		$ai_controller = new Controllers\AiController();
 
-        register_rest_route('kerbcycle/v1', '/qr-code/scanned', [
-            'methods'  => 'POST',
-            'callback' => [new Controllers\QrController(), 'handle_qr_code_scan'],
-            'permission_callback' => function () {
-                return current_user_can('manage_options');
-            },
-        ]);
+		register_rest_route(
+			'kerbcycle/v1',
+			'/qr-code/scanned',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( new Controllers\QrController(), 'handle_qr_code_scan' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
 
-        register_rest_route('kerbcycle/v1', '/qr-status/(?P<qr_code>[a-zA-Z0-9-]+)', [
-            'methods'  => 'GET',
-            'callback' => [new Controllers\QrController(), 'get_qr_status'],
-            'permission_callback' => function () {
-                return current_user_can('manage_options');
-            },
-        ]);
+		register_rest_route(
+			'kerbcycle/v1',
+			'/qr-status/(?P<qr_code>[a-zA-Z0-9-]+)',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( new Controllers\QrController(), 'get_qr_status' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
 
-        register_rest_route('kerbcycle/v1', '/ai', [
-            'methods'  => 'POST',
-            'callback' => [$ai_controller, 'dispatch_action'],
-            'permission_callback' => [$ai_controller, 'permissions'],
-        ]);
-    }
+		register_rest_route(
+			'kerbcycle/v1',
+			'/ai',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $ai_controller, 'dispatch_action' ),
+				'permission_callback' => array( $ai_controller, 'permissions' ),
+			)
+		);
+	}
 }


### PR DESCRIPTION
### Motivation
- Bring `includes/Api/RestService.php` into WordPress PHPCS-compliant formatting without changing behavior.
- Make a minimal, surgical formatting pass limited to mechanical fixes (spacing, indentation, brace and array formatting, and docblock structure) per repository guardrails.

### Description
- Modified file: `includes/Api/RestService.php` only, with no other files changed.
- Normalized the `ABSPATH` guard spacing and brace placement, converted short array syntax to long `array()` where appropriate, and adjusted indentation and alignment to WordPress conventions.
- Reformatted route registration calls to use multiline `register_rest_route()` arguments with consistent spacing and array alignment, and standardized anonymous function spacing, while preserving the exact callbacks and permission checks.
- No logic, names, hooks, routes, capability checks, nonces, SQL, or execution flow were changed.

### Testing
- Ran a PHP syntax check with `php -l includes/Api/RestService.php`, which reported no syntax errors.
- Attempted to run `phpcs --standard=WordPress includes/Api/RestService.php`, but the `phpcs` binary is not available in this environment so the linter could not be executed.
- No automated unit tests were run as part of this change in this environment; behavior-preservation was validated by ensuring only formatting-level edits were made to the single target file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30ea7d9bc832d9a3b071bd05999d7)