### PR TITLE
style: PHPCS formatting cleanup for QrController

### DIFF
--- a/includes/Api/Controllers/QrController.php
+++ b/includes/Api/Controllers/QrController.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Api\Controllers;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 use WP_REST_Request;
@@ -21,87 +21,93 @@ use Kerbcycle\QrCode\Data\Repositories\QrCodeRepository;
  */
 class QrController
 {
-    /**
-     * Handle the QR code scan.
-     *
-     * @param WP_REST_Request $request The request object.
-     *
-     * @return WP_REST_Response The response object.
-     * @since    1.0.0
-     *
-     */
-    public function handle_qr_code_scan(WP_REST_Request $request)
-    {
-        if (!current_user_can('manage_options')) {
-            return new \WP_Error('rest_forbidden', __('Unauthorized', 'kerbcycle'), ['status' => 403]);
-        }
+	/**
+	 * Handle the QR code scan.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response The response object.
+	 */
+	public function handle_qr_code_scan( WP_REST_Request $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error( 'rest_forbidden', __( 'Unauthorized', 'kerbcycle' ), array( 'status' => 403 ) );
+		}
 
-        $qr_code = sanitize_text_field($request->get_param('qr_code'));
-        $user_id = intval($request->get_param('user_id'));
+		$qr_code = sanitize_text_field( $request->get_param( 'qr_code' ) );
+		$user_id = intval( $request->get_param( 'user_id' ) );
 
-        if ($qr_code === '') {
-            return new \WP_Error('invalid_qr_code', __('QR code is required.', 'kerbcycle'), ['status' => 400]);
-        }
+		if ( '' === $qr_code ) {
+			return new \WP_Error( 'invalid_qr_code', __( 'QR code is required.', 'kerbcycle' ), array( 'status' => 400 ) );
+		}
 
-        if ($user_id < 1 || !get_userdata($user_id)) {
-            return new \WP_Error('invalid_user', __('Invalid customer selected.', 'kerbcycle'), ['status' => 400]);
-        }
+		if ( $user_id < 1 || ! get_userdata( $user_id ) ) {
+			return new \WP_Error( 'invalid_user', __( 'Invalid customer selected.', 'kerbcycle' ), array( 'status' => 400 ) );
+		}
 
-        $nonce_check = Nonces::verify('kerbcycle_qr_nonce', 'nonce', $request);
-        if (is_wp_error($nonce_check)) {
-            return $nonce_check;
-        }
+		$nonce_check = Nonces::verify( 'kerbcycle_qr_nonce', 'nonce', $request );
+		if ( is_wp_error( $nonce_check ) ) {
+			return $nonce_check;
+		}
 
-        $repo = new QrCodeRepository();
-        $existing = $repo->find_by_qr_code($qr_code);
-        if ($existing && $existing->status === 'assigned') {
-            return new WP_REST_Response([
-                'success' => false,
-                'message' => __('QR code already assigned.', 'kerbcycle'),
-            ], 409);
-        }
+		$repo     = new QrCodeRepository();
+		$existing = $repo->find_by_qr_code( $qr_code );
+		if ( $existing && 'assigned' === $existing->status ) {
+			return new WP_REST_Response(
+				array(
+					'success' => false,
+					'message' => __( 'QR code already assigned.', 'kerbcycle' ),
+				),
+				409
+			);
+		}
 
-        $service = new QrService();
-        $assign = $service->assign($qr_code, $user_id, false, false, false);
-        if (is_wp_error($assign)) {
-            return new WP_REST_Response([
-                'success' => false,
-                'message' => $assign->get_error_message(),
-            ], 500);
-        }
+		$service = new QrService();
+		$assign  = $service->assign( $qr_code, $user_id, false, false, false );
+		if ( is_wp_error( $assign ) ) {
+			return new WP_REST_Response(
+				array(
+					'success' => false,
+					'message' => $assign->get_error_message(),
+				),
+				500
+			);
+		}
 
-        $user  = get_userdata($user_id);
-        $name  = $user ? $user->display_name : '';
+		$user = get_userdata( $user_id );
+		$name = $user ? $user->display_name : '';
 
-        return new WP_REST_Response([
-            'success'      => true,
-            'message'      => __('QR code processed', 'kerbcycle'),
-            'qr_code'      => $qr_code,
-            'user_id'      => $user_id,
-            'display_name' => $name,
-        ], 200);
-    }
+		return new WP_REST_Response(
+			array(
+				'success'      => true,
+				'message'      => __( 'QR code processed', 'kerbcycle' ),
+				'qr_code'      => $qr_code,
+				'user_id'      => $user_id,
+				'display_name' => $name,
+			),
+			200
+		);
+	}
 
-    /**
-     * Get the status of a QR code.
-     *
-     * @param WP_REST_Request $request The request object.
-     *
-     * @return WP_REST_Response The response object.
-     * @since    1.0.0
-     *
-     */
-    public function get_qr_status(WP_REST_Request $request)
-    {
-        if (!current_user_can('manage_options')) {
-            return new \WP_Error('rest_forbidden', __('Unauthorized', 'kerbcycle'), ['status' => 403]);
-        }
+	/**
+	 * Get the status of a QR code.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response The response object.
+	 */
+	public function get_qr_status( WP_REST_Request $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error( 'rest_forbidden', __( 'Unauthorized', 'kerbcycle' ), array( 'status' => 403 ) );
+		}
 
-        global $wpdb;
-        $qr_code = sanitize_text_field($request['qr_code']);
-        $table   = $wpdb->prefix . 'kerbcycle_qr_codes';
-        $result  = $wpdb->get_row($wpdb->prepare("SELECT * FROM $table WHERE qr_code = %s", $qr_code));
-        return $result ? rest_ensure_response($result)
-                       : new \WP_Error('not_found', 'QR Code not found', ['status' => 404]);
-    }
+		global $wpdb;
+		$qr_code = sanitize_text_field( $request['qr_code'] );
+		$table   = $wpdb->prefix . 'kerbcycle_qr_codes';
+		$result  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE qr_code = %s", $qr_code ) );
+		return $result ? rest_ensure_response( $result ) : new \WP_Error( 'not_found', 'QR Code not found', array( 'status' => 404 ) );
+	}
 }


### PR DESCRIPTION
### Motivation
- Bring `includes/Api/Controllers/QrController.php` into PHPCS-compatible formatting without changing behavior. 
- The change is scoped to a single file to satisfy the repository's minimal-change requirement. 
- This is a mechanical style pass only and must preserve all security- and flow-sensitive code paths.

### Description
- Files changed: `includes/Api/Controllers/QrController.php` and nothing else. 
- Exact behavior changed: none; only whitespace, indentation, docblock formatting, ABSPATH guard style, spacing around operators/function calls, and array formatting were adjusted. 
- Risks / edge cases: none introduced by logic since no code paths, names, nonces, capability checks, SQL, or sanitization were altered. 
- Intentionally NOT changed: class/method/variable names, capability checks, nonce usage, SQL queries, escaping/sanitization, and execution flow.

### Testing
- Ran `php -l includes/Api/Controllers/QrController.php` which reported no syntax errors. 
- Verified repository status with `git status --short` and committed the single-file change. 
- Attempted PHPCS checks with `phpcs --standard=phpcs.xml.dist includes/Api/Controllers/QrController.php` and `./vendor/bin/phpcs --standard=phpcs.xml.dist includes/Api/Controllers/QrController.php` but the PHPCS binary was not available in the environment, so automated PHPCS verification could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3235e285c832d93047a3457501e1e)