### PR TITLE
Style: PHPCS formatting cleanup for OsrmService

### DIFF
--- a/includes/Services/OsrmService.php
+++ b/includes/Services/OsrmService.php
@@ -2,61 +2,57 @@
 
 namespace Kerbcycle\QrCode\Services;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 /**
  * Centralized service for managing OSRM settings.
  */
-class OsrmService
-{
-    private const OPTION_KEY = 'kerbcycle_osrm_options';
+class OsrmService {
+	private const OPTION_KEY = 'kerbcycle_osrm_options';
 
-    /**
-     * Retrieve stored options merged with defaults.
-     */
-    public static function get_options()
-    {
-        return wp_parse_args(get_option(self::OPTION_KEY, []), self::defaults());
-    }
+	/**
+	 * Retrieve stored options merged with defaults.
+	 */
+	public static function get_options() {
+		return wp_parse_args( get_option( self::OPTION_KEY, array() ), self::defaults() );
+	}
 
-    /**
-     * Provide default option values.
-     */
-    public static function defaults()
-    {
-        return [
-            'env'              => 'dev',
-            'endpoint_dev'     => 'https://router.project-osrm.org',
-            'endpoint_stage'   => '',
-            'endpoint_prod'    => '',
-            'profile'          => 'driving',
-            'tile_url'         => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-            'tile_attrib'      => '© OpenStreetMap',
-            'deny_demo_in_prod' => 1,
-            'timeout'          => 10,
-            'default_start'    => '',
-        ];
-    }
+	/**
+	 * Provide default option values.
+	 */
+	public static function defaults() {
+		return array(
+			'env'               => 'dev',
+			'endpoint_dev'      => 'https://router.project-osrm.org',
+			'endpoint_stage'    => '',
+			'endpoint_prod'     => '',
+			'profile'           => 'driving',
+			'tile_url'          => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			'tile_attrib'       => '© OpenStreetMap',
+			'deny_demo_in_prod' => 1,
+			'timeout'           => 10,
+			'default_start'     => '',
+		);
+	}
 
-    /**
-     * Determine the current endpoint based on selected environment.
-     */
-    public static function current_endpoint($options = null)
-    {
-        $options = $options ?: self::get_options();
-        $environment = $options['env'];
-        $map = [
-            'dev'   => $options['endpoint_dev'],
-            'stage' => $options['endpoint_stage'],
-            'prod'  => $options['endpoint_prod'],
-        ];
-        $url = isset($map[$environment]) ? rtrim((string) $map[$environment], '/') : '';
+	/**
+	 * Determine the current endpoint based on selected environment.
+	 */
+	public static function current_endpoint( $options = null ) {
+		$options     = $options ?: self::get_options();
+		$environment = $options['env'];
+		$map         = array(
+			'dev'   => $options['endpoint_dev'],
+			'stage' => $options['endpoint_stage'],
+			'prod'  => $options['endpoint_prod'],
+		);
+		$url = isset( $map[ $environment ] ) ? rtrim( (string) $map[ $environment ], '/' ) : '';
 
-        /**
-         * Filter the resolved endpoint URL.
-         */
-        return apply_filters('kerbcycle/osrm/endpoint', $url, $options);
-    }
+		/**
+		 * Filter the resolved endpoint URL.
+		 */
+		return apply_filters( 'kerbcycle/osrm/endpoint', $url, $options );
+	}
 }


### PR DESCRIPTION
### Motivation
- Bring `includes/Services/OsrmService.php` into PHPCS/WordPress formatting compliance without altering runtime behavior.
- Apply only mechanical formatting fixes (spacing, indentation, brace placement, array formatting, and docblock structure) to satisfy style rules.
- Restrict the work to a single-file change to minimize risk and preserve existing behavior.

### Description
- Modified exactly one file: `includes/Services/OsrmService.php`.
- Normalized the `ABSPATH` guard spacing and adjusted class/function brace placement and indentation to WordPress conventions.
- Standardized spacing around function calls and operators, aligned docblocks, and reformatted arrays for PHPCS consistency while preserving all literal values.
- Made no changes to logic, method/class names, option keys, endpoints, hooks, nonces, or security checks.

### Testing
- Reviewed the formatting-only diff with `git diff -- includes/Services/OsrmService.php` and confirmed only style changes were introduced.
- Attempted to run `phpcs includes/Services/OsrmService.php` but `phpcs` is not installed in this environment, so automated linting could not be executed.
- Committed the change with `git commit` which completed successfully and only the target file was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f329ba29b4832d85fa88fdcdccb6f4)