### PR TITLE
style: PHPCS formatting cleanup for EmailService.php

### DIFF
--- a/includes/Services/EmailService.php
+++ b/includes/Services/EmailService.php
@@ -3,7 +3,7 @@
 namespace Kerbcycle\QrCode\Services;
 
 if (!defined('ABSPATH')) {
-    exit;
+	exit;
 }
 
 use Kerbcycle\QrCode\Services\MessagesService;
@@ -18,48 +18,53 @@ use Kerbcycle\QrCode\Data\Repositories\MessageLogRepository;
  */
 class EmailService
 {
-    /**
-     * Send a notification email.
-     *
-     * @param int    $user_id The user ID.
-     * @param string $qr_code The QR code.
-     * @param string $type    The type of notification (e.g., 'assigned', 'released').
-     * @param array  $vars    Additional placeholder variables.
-     *
-     * @return bool|\WP_Error True on success, WP_Error on failure.
-     */
-    public function send_notification($user_id, $qr_code, $type = 'assigned', array $vars = [])
-    {
-        $user = get_userdata($user_id);
-        if (!$user || empty($user->user_email)) {
-            return new \WP_Error('email_config', __('Missing user email', 'kerbcycle'));
-        }
+	/**
+	 * Send a notification email.
+	 *
+	 * @param int    $user_id The user ID.
+	 * @param string $qr_code The QR code.
+	 * @param string $type    The type of notification (e.g., 'assigned', 'released').
+	 * @param array  $vars    Additional placeholder variables.
+	 *
+	 * @return bool|\WP_Error True on success, WP_Error on failure.
+	 */
+	public function send_notification($user_id, $qr_code, $type = 'assigned', array $vars = [])
+	{
+		$user = get_userdata($user_id);
+		if (!$user || empty($user->user_email)) {
+			return new \WP_Error('email_config', __('Missing user email', 'kerbcycle'));
+		}
 
-        $vars = array_merge([
-            'user' => $user->display_name ?: $user->user_login,
-            'code' => $qr_code,
-        ], $vars);
+		$vars = array_merge(
+			[
+				'user' => $user->display_name ?: $user->user_login,
+				'code' => $qr_code,
+			],
+			$vars
+		);
 
-        $rendered = MessagesService::render($type, $vars);
+		$rendered = MessagesService::render($type, $vars);
 
-        $subject = 'KerbCycle: ' . ucfirst($type);
-        $sent    = wp_mail($user->user_email, $subject, $rendered['email']);
+		$subject = 'KerbCycle: ' . ucfirst($type);
+		$sent    = wp_mail($user->user_email, $subject, $rendered['email']);
 
-        if (!$sent) {
-            return new \WP_Error('email_send', __('Failed to send email', 'kerbcycle'));
-        }
+		if (!$sent) {
+			return new \WP_Error('email_send', __('Failed to send email', 'kerbcycle'));
+		}
 
-        // Log the email
-        MessageLogRepository::log_message([
-            'type'     => 'email',
-            'to'       => $user->user_email,
-            'subject'  => $subject,
-            'body'     => $rendered['email'],
-            'status'   => $sent ? 'sent' : 'failed',
-            'provider' => 'wp_mail',
-            'response' => $sent ? 'OK' : 'wp_mail returned false',
-        ]);
+		// Log the email.
+		MessageLogRepository::log_message(
+			[
+				'type'     => 'email',
+				'to'       => $user->user_email,
+				'subject'  => $subject,
+				'body'     => $rendered['email'],
+				'status'   => $sent ? 'sent' : 'failed',
+				'provider' => 'wp_mail',
+				'response' => $sent ? 'OK' : 'wp_mail returned false',
+			]
+		);
 
-        return true;
-    }
+		return true;
+	}
 }


### PR DESCRIPTION
### Motivation
- Bring `includes/Services/EmailService.php` into PHPCS-compatible formatting without changing any behavior, names, or execution flow.

### Description
- Apply a formatting-only pass to normalize tab-based indentation, reflow the docblock, multiline array and function-call layouts, and minor comment punctuation; only `includes/Services/EmailService.php` was modified and no logic or identifiers were changed.

### Testing
- Ran `php -l includes/Services/EmailService.php` which returned no syntax errors, and verified only the target file changed with `git status --short`; `phpcs` could not be executed in this environment because the binary is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32f745f60832db3d3fa9ff1fa9037)