### PR TITLE
PHPCS: minimal formatting cleanup in AdminAjax scoped methods

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -172,7 +172,7 @@ class AdminAjax
         }
 
         $user_id = isset($_POST['customer_id']) ? intval(wp_unslash($_POST['customer_id'])) : 0;
-        if (!$user_id) {
+        if ( ! $user_id ) {
             wp_send_json_error(['message' => __('Invalid user ID', 'kerbcycle')]);
         }
 
@@ -423,8 +423,10 @@ class AdminAjax
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
 
-        $ids = isset($_POST['log_ids']) && is_array($_POST['log_ids']) ? array_map('absint', wp_unslash($_POST['log_ids'])) : [];
-        if (!$ids) {
+        $ids = isset($_POST['log_ids']) && is_array($_POST['log_ids'])
+            ? array_map('absint', wp_unslash($_POST['log_ids']))
+            : [];
+        if ( ! $ids ) {
             wp_send_json_error(['message' => __('No logs selected', 'kerbcycle')]);
         }
 


### PR DESCRIPTION
### Motivation
- Apply a focused PHPCS formatting pass to address spacing/indentation issues inside the allowed Admin AJAX methods without changing any behavior or logic.

### Description
- Updated `includes/Admin/Ajax/AdminAjax.php` with only mechanical formatting changes inside `get_assigned_qr_codes` (normalized conditional spacing) and `delete_logs` (multi-line ternary assignment and normalized conditional spacing), with no logic, security, API, or payload changes.

### Testing
- Verified PHP syntax with `php -l includes/Admin/Ajax/AdminAjax.php` and confirmed only `includes/Admin/Ajax/AdminAjax.php` changed using `git diff --name-only` and `git diff -- includes/Admin/Ajax/AdminAjax.php`, then committed the patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3fac2811c832dbc4649ab5a2365ee)