### PR TITLE
PHPCS formatting pass (AdminAjax scoped methods)

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -192,8 +192,8 @@ class AdminAjax
         }
 
         $raw_codes = explode(',', wp_unslash($_POST['qr_codes']));
-        $codes = array_map('trim', array_map('sanitize_text_field', $raw_codes));
-        $codes = array_filter($codes);
+        $codes     = array_map('trim', array_map('sanitize_text_field', $raw_codes));
+        $codes     = array_filter($codes);
 
         if (empty($codes)) {
             wp_send_json_error(['message' => 'No valid QR codes provided.']);
@@ -210,7 +210,9 @@ class AdminAjax
                 )
             ]);
         } else {
-            wp_send_json_error(['message' => 'Could not find or release any of the selected QR codes. They may have already been released or do not exist.']);
+            wp_send_json_error(
+                ['message' => 'Could not find or release any of the selected QR codes. They may have already been released or do not exist.']
+            );
         }
     }
 
@@ -226,8 +228,8 @@ class AdminAjax
         }
 
         $raw_codes = explode(',', wp_unslash($_POST['qr_codes']));
-        $codes = array_map('trim', array_map('sanitize_text_field', $raw_codes));
-        $codes = array_filter($codes);
+        $codes     = array_map('trim', array_map('sanitize_text_field', $raw_codes));
+        $codes     = array_filter($codes);
 
         if (empty($codes)) {
             wp_send_json_error(['message' => 'No valid QR codes provided.']);
@@ -244,7 +246,9 @@ class AdminAjax
                 )
             ]);
         } else {
-            wp_send_json_error(['message' => 'Could not delete any of the selected QR codes. Ensure they are available.']);
+            wp_send_json_error(
+                ['message' => 'Could not delete any of the selected QR codes. Ensure they are available.']
+            );
         }
     }
 
@@ -329,7 +333,7 @@ class AdminAjax
             wp_send_json_error(['message' => __('Could not read uploaded file.', 'kerbcycle')]);
         }
 
-        $header = fgetcsv($handle);
+        $header     = fgetcsv($handle);
         if ($header === false) {
             fclose($handle);
             wp_send_json_error(['message' => __('Invalid CSV file.', 'kerbcycle')]);


### PR DESCRIPTION
### Motivation
- Apply a minimal, PHPCS-driven formatting pass inside the targeted admin AJAX methods to satisfy style checks while preserving runtime behaviour.

### Description
- Made only mechanical formatting edits in `includes/Admin/Ajax/AdminAjax.php` limited to the methods `import_qr_codes`, `bulk_release_qr_codes`, and `bulk_delete_qr_codes`, with no logic changes.
- Aligned assignment spacing for `$codes` and `$header` and wrapped long `wp_send_json_error()` array calls for PHPCS-friendly line lengths.
- Did not change any nonces, capability checks, SQL, service calls, response payloads, method names, or any out-of-scope code.

### Testing
- Verified changed files with `git diff --name-only` and confirmed only `includes/Admin/Ajax/AdminAjax.php` was modified.
- Inspected `git diff -- includes/Admin/Ajax/AdminAjax.php` to ensure diffs are scoped to the allowed methods and approved formatting-only edits.
- Ran `php -l includes/Admin/Ajax/AdminAjax.php` for a PHP syntax check which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3fed58dac832d80bc368a10f0b3f3)