### PR TITLE
style: PHPCS formatting cleanup for assign/release ajax methods

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -61,10 +61,10 @@ class AdminAjax
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
 
-        $qr_code      = sanitize_text_field(wp_unslash($_POST['qr_code']));
-        $user_id      = intval(wp_unslash($_POST['customer_id']));
-        $send_email   = !empty($_POST['send_email']) && get_option('kerbcycle_qr_enable_email', 1);
-        $send_sms     = !empty($_POST['send_sms']) && get_option('kerbcycle_qr_enable_sms', 0);
+        $qr_code       = sanitize_text_field(wp_unslash($_POST['qr_code']));
+        $user_id       = intval(wp_unslash($_POST['customer_id']));
+        $send_email    = !empty($_POST['send_email']) && get_option('kerbcycle_qr_enable_email', 1);
+        $send_sms      = !empty($_POST['send_sms']) && get_option('kerbcycle_qr_enable_sms', 0);
         $send_reminder = !empty($_POST['send_reminder']) && get_option('kerbcycle_qr_enable_reminders', 0);
 
         $result = $this->qr_service->assign($qr_code, $user_id, $send_email, $send_sms, $send_reminder);
@@ -131,7 +131,7 @@ class AdminAjax
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
 
-        $qr_code   = sanitize_text_field(wp_unslash($_POST['qr_code']));
+        $qr_code    = sanitize_text_field(wp_unslash($_POST['qr_code']));
         $send_email = !empty($_POST['send_email']) && get_option('kerbcycle_qr_enable_email', 1);
         $send_sms   = !empty($_POST['send_sms']) && get_option('kerbcycle_qr_enable_sms', 0);
 


### PR DESCRIPTION
### Motivation
- Fix PHPCS formatting in two admin AJAX handlers to satisfy style checks while preserving all behavior and security invariants.

### Description
- Aligned variable-assignment spacing inside `assign_qr_code` and `release_qr_code` in `includes/Admin/Ajax/AdminAjax.php`; only those two method bodies were edited and no logic, nonces, capability checks, service-call arguments, response payloads, or other files/methods were changed.

### Testing
- Ran `php -l includes/Admin/Ajax/AdminAjax.php` with no syntax errors and verified the repository diff shows only `includes/Admin/Ajax/AdminAjax.php` was modified and the diff is limited to `assign_qr_code` and `release_qr_code`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f404ecd508832db027169758801b20)