### PR TITLE
style: PHPCS formatting cleanup for pickup exception AJAX guards

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -443,7 +443,7 @@ class AdminAjax
     public function test_pickup_exception()
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
-        if (!current_user_can('manage_options')) {
+        if (!current_user_can( 'manage_options' )) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
         $this->handle_pickup_exception_submission('admin');
@@ -452,7 +452,7 @@ class AdminAjax
     public function submit_scanner_pickup_exception()
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
-        if (!Capabilities::can(Capabilities::manage_operations())) {
+        if (!Capabilities::can( Capabilities::manage_operations() )) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
         $this->handle_pickup_exception_submission('scanner');


### PR DESCRIPTION
### Motivation
- Address PHPCS formatting violations in two admin AJAX handlers so the code conforms to the plugin's style expectations while preserving all behavior.

### Description
- Updated spacing inside the capability/nonce guard calls in `test_pickup_exception` and `submit_scanner_pickup_exception` within `includes/Admin/Ajax/AdminAjax.php` (argument spacing only); no logic, call arguments, responses, hooks, or other files/methods were modified.

### Testing
- Confirmed changes are limited to `includes/Admin/Ajax/AdminAjax.php` with `git diff --name-only`, inspected the diff to ensure only the two scoped methods were touched, and ran `php -l includes/Admin/Ajax/AdminAjax.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f407e371b8832d9ec1c7998ff7c0de)