### PR TITLE
Style: normalize conditional spacing in pickup exception AJAX methods

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -443,7 +443,7 @@ class AdminAjax
     public function test_pickup_exception()
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
-        if (!current_user_can( 'manage_options' )) {
+        if ( ! current_user_can( 'manage_options' ) ) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
         $this->handle_pickup_exception_submission('admin');
@@ -452,7 +452,7 @@ class AdminAjax
     public function submit_scanner_pickup_exception()
     {
         Nonces::verify('kerbcycle_qr_nonce', 'security');
-        if (!Capabilities::can( Capabilities::manage_operations() )) {
+        if ( ! Capabilities::can( Capabilities::manage_operations() ) ) {
             wp_send_json_error(['message' => __('Unauthorized', 'kerbcycle')], 403);
         }
         $this->handle_pickup_exception_submission('scanner');


### PR DESCRIPTION
### Motivation
- Align conditional spacing in two AJAX handlers with WordPress PHPCS conditional style as a targeted, minimal formatting pass.

### Description
- Modified only `includes/Admin/Ajax/AdminAjax.php` to normalize the `if` condition spacing inside the `test_pickup_exception` and `submit_scanner_pickup_exception` methods to the `if ( ! ... )` form, with no other files, methods, logic, nonces, capability checks, hooks, imports, or responses changed.

### Testing
- Ran `git diff --name-only` and `git diff -- includes/Admin/Ajax/AdminAjax.php` which confirmed only `includes/Admin/Ajax/AdminAjax.php` was modified and that the changes were limited to conditional spacing in the two target methods, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40df19494832daa12c1e443d4f333)