### PR TITLE
PHPCS cleanup: scoped formatting in AdminAjax dedupe helpers

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -832,6 +832,7 @@ class AdminAjax
             strtolower(trim((string) $issue)),
             strtolower(trim((string) $notes)),
         ];
+
         return 'kerbcycle_pickup_dedupe_' . md5(implode('|', $parts));
     }
 
@@ -862,7 +863,12 @@ class AdminAjax
     private function store_pickup_dedupe_record($key, $record_id)
     {
         $expires = time() + self::PICKUP_DEDUPE_TTL;
-        update_option($key, (int) $record_id . ':' . (int) $expires, false);
+
+        update_option(
+            $key,
+            (int) $record_id . ':' . (int) $expires,
+            false
+        );
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Apply a PHPCS-friendly, mechanical formatting pass limited to the dedupe/log helper methods to satisfy style rules without changing behavior.

### Description
- Changed file: `includes/Admin/Ajax/AdminAjax.php`; applied mechanical formatting-only edits inside `pickup_dedupe_option_key` (added blank line before the `return`) and `store_pickup_dedupe_record` (reformatted the `update_option()` call to multi-line); no logic or behavior changes were made, `log_action` and all other methods remain unmodified, and dedupe key composition, TTL/expiry calculation, `update_option` arguments, `ErrorLogRepository::log()` usage, payloads, and return values are unchanged.

### Testing
- Verified with `git diff --name-only` and `git diff -- includes/Admin/Ajax/AdminAjax.php` that only `includes/Admin/Ajax/AdminAjax.php` changed and the diff is limited to the intended methods, and attempted to run `vendor/bin/phpunit` but `phpunit` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4172d5220832dabd2c7236e7bfd05)