### PR TITLE
style: PHPCS formatting cleanup in AdminAjax::get_pickup_exceptions

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -691,8 +691,8 @@ class AdminAjax
         \Kerbcycle\QrCode\Install\Activator::activate();
 
         global $wpdb;
-        $table_name = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
-        $limit = 50;
+        $table_name    = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
+        $limit         = 50;
         $status_filter = isset($_POST['status_filter']) ? sanitize_key(wp_unslash($_POST['status_filter'])) : '';
         if ($status_filter === 'failed') {
             $sql = $wpdb->prepare(
@@ -714,16 +714,16 @@ class AdminAjax
             );
         }
         $records = $wpdb->get_results($sql);
-        $rows = [];
+        $rows    = [];
 
         foreach ($records as $record) {
-            $status = isset($record->status) ? (string) $record->status : (((int) $record->webhook_sent) === 1 ? 'sent' : 'failed');
+            $status    = isset($record->status) ? (string) $record->status : (((int) $record->webhook_sent) === 1 ? 'sent' : 'failed');
             $retry_url = '';
             if (((int) $record->webhook_sent) === 0) {
                 $retry_args = [
-                    'page' => 'kerbcycle-pickup-exceptions',
+                    'page'              => 'kerbcycle-pickup-exceptions',
                     'kerbcycle_action' => 'retry_pickup_exception',
-                    'exception_id' => (int) $record->id,
+                    'exception_id'      => (int) $record->id,
                 ];
                 if ($status_filter === 'failed') {
                     $retry_args['status_filter'] = 'failed';
@@ -738,25 +738,25 @@ class AdminAjax
             }
 
             $rows[] = [
-                'id' => (int) $record->id,
-                'submitted_at' => isset($record->submitted_at) ? (string) $record->submitted_at : '',
-                'updated_at' => isset($record->updated_at) ? (string) $record->updated_at : '',
-                'qr_code' => isset($record->qr_code) ? (string) $record->qr_code : '',
-                'customer_id' => isset($record->customer_id) ? (string) $record->customer_id : '',
-                'issue' => isset($record->issue) ? (string) $record->issue : '',
-                'notes' => isset($record->notes) ? (string) $record->notes : '',
-                'status' => $status,
-                'source' => isset($record->source) && $record->source !== '' ? (string) $record->source : '',
-                'ai_severity' => isset($record->ai_severity) ? (string) $record->ai_severity : '',
-                'ai_category' => isset($record->ai_category) ? (string) $record->ai_category : '',
+                'id'                    => (int) $record->id,
+                'submitted_at'          => isset($record->submitted_at) ? (string) $record->submitted_at : '',
+                'updated_at'            => isset($record->updated_at) ? (string) $record->updated_at : '',
+                'qr_code'               => isset($record->qr_code) ? (string) $record->qr_code : '',
+                'customer_id'           => isset($record->customer_id) ? (string) $record->customer_id : '',
+                'issue'                 => isset($record->issue) ? (string) $record->issue : '',
+                'notes'                 => isset($record->notes) ? (string) $record->notes : '',
+                'status'                => $status,
+                'source'                => isset($record->source) && $record->source !== '' ? (string) $record->source : '',
+                'ai_severity'           => isset($record->ai_severity) ? (string) $record->ai_severity : '',
+                'ai_category'           => isset($record->ai_category) ? (string) $record->ai_category : '',
                 'ai_recommended_action' => isset($record->ai_recommended_action) ? (string) $record->ai_recommended_action : '',
-                'ai_summary' => isset($record->ai_summary) ? (string) $record->ai_summary : '',
-                'webhook_status_code' => isset($record->webhook_status_code) ? (string) $record->webhook_status_code : '',
+                'ai_summary'            => isset($record->ai_summary) ? (string) $record->ai_summary : '',
+                'webhook_status_code'   => isset($record->webhook_status_code) ? (string) $record->webhook_status_code : '',
                 'webhook_response_body' => isset($record->webhook_response_body) ? (string) $record->webhook_response_body : '',
-                'retry_count' => isset($record->retry_count) ? (int) $record->retry_count : 0,
-                'last_retry_at' => isset($record->last_retry_at) ? (string) $record->last_retry_at : '',
-                'retry_url' => $retry_url,
-                'can_retry' => ((int) $record->webhook_sent) === 0,
+                'retry_count'           => isset($record->retry_count) ? (int) $record->retry_count : 0,
+                'last_retry_at'         => isset($record->last_retry_at) ? (string) $record->last_retry_at : '',
+                'retry_url'             => $retry_url,
+                'can_retry'             => ((int) $record->webhook_sent) === 0,
             ];
         }
 


### PR DESCRIPTION
### Motivation
- Fix PHPCS/formatting issues only inside `get_pickup_exceptions` to satisfy style conventions while preserving existing behavior and security checks.

### Description
- Applied mechanical formatting changes (spacing, alignment, array formatting, and line-wrapping where appropriate) inside the `get_pickup_exceptions` method in `includes/Admin/Ajax/AdminAjax.php` and did not alter any logic, SQL, nonces, capability checks, pagination, row mapping, retry URLs, or response structure.
- The only file modified is `includes/Admin/Ajax/AdminAjax.php` and the only method touched is `get_pickup_exceptions`.

### Testing
- Ran `git diff --name-only` which showed only `includes/Admin/Ajax/AdminAjax.php`, ran `git diff -- includes/Admin/Ajax/AdminAjax.php` to inspect the patch limited to `get_pickup_exceptions`, and committed the change; these validation commands completed successfully.
- No PHPUnit or other automated test suites were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f419ba4644832d96c8f19fa8c4641a)