### PR TITLE
style: minimal PHPCS formatting cleanup in retry_pickup_exception

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -779,7 +779,10 @@ class AdminAjax
             wp_send_json_error(['message' => __('Invalid pickup exception ID.', 'kerbcycle')], 400);
         }
 
-        $retry_result = (new PickupExceptionRetryService())->retry($exception_id, $this->qr_service);
+        $retry_result = ( new PickupExceptionRetryService() )->retry(
+            $exception_id,
+            $this->qr_service
+        );
         if ($retry_result['state'] === 'not_found') {
             $this->log_action('pickup_exception_retry', 'failed', __('Pickup exception record not found.', 'kerbcycle'), [
                 'exception_id' => $exception_id,
@@ -791,14 +794,20 @@ class AdminAjax
             $this->log_action('pickup_exception_retry', 'invalid_state', __('Pickup exception is not eligible for retry.', 'kerbcycle'), [
                 'exception_id' => $exception_id,
             ], 'pickup_exception');
-            wp_send_json_error(['message' => __('This pickup exception is not eligible for retry.', 'kerbcycle')], 400);
+            wp_send_json_error(
+                ['message' => __('This pickup exception is not eligible for retry.', 'kerbcycle')],
+                400
+            );
         }
 
         if ($retry_result['state'] === 'lock_conflict') {
             $this->log_action('pickup_exception_retry', 'suppressed', __('Retry already in progress for this pickup exception.', 'kerbcycle'), [
                 'exception_id' => $exception_id,
             ], 'pickup_exception');
-            wp_send_json_error(['message' => __('Retry already in progress for this pickup exception.', 'kerbcycle')], 409);
+            wp_send_json_error(
+                ['message' => __('Retry already in progress for this pickup exception.', 'kerbcycle')],
+                409
+            );
         }
 
         if ($retry_result['state'] === 'webhook_error') {


### PR DESCRIPTION
### Motivation
- Apply a minimal, PHPCS-driven formatting pass inside the `retry_pickup_exception` method to satisfy coding-style rules without changing behavior.

### Description
- Reformatted code in `includes/Admin/Ajax/AdminAjax.php`, limiting edits to the `retry_pickup_exception` method only (multiline instantiation/call of `PickupExceptionRetryService()` and multiline `wp_send_json_error()` calls); no logic, branching, messages, status codes, or service-call arguments were changed.

### Testing
- Ran `git diff --name-only` to confirm only `includes/Admin/Ajax/AdminAjax.php` changed, ran `git diff -- includes/Admin/Ajax/AdminAjax.php` to confirm the diff is limited to `retry_pickup_exception`, and ran `php -l includes/Admin/Ajax/AdminAjax.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41c78de24832d9cd7d4e4a4d061ec)