### PR TITLE
style: PHPCS formatting cleanup in AdminAjax dedupe/local-save section

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -497,15 +497,15 @@ class AdminAjax
                 'issue'        => $issue,
             ], 'pickup_exception');
             wp_send_json_success([
-                'status'      => 'duplicate_suppressed',
-                'message'     => __('Duplicate pickup exception suppressed. Existing record retained.', 'kerbcycle'),
-                'exception_id' => $duplicate_id,
-                'local_save'  => ['success' => true, 'id' => $duplicate_id],
-                'webhook'     => ['success' => true, 'duplicate' => true],
+                'status'                => 'duplicate_suppressed',
+                'message'               => __('Duplicate pickup exception suppressed. Existing record retained.', 'kerbcycle'),
+                'exception_id'          => $duplicate_id,
+                'local_save'            => ['success' => true, 'id' => $duplicate_id],
+                'webhook'               => ['success' => true, 'duplicate' => true],
                 'ai_recommended_action' => '',
-                'ai_summary'  => '',
-                'ai_category' => '',
-                'ai_severity' => '',
+                'ai_summary'            => '',
+                'ai_category'           => '',
+                'ai_severity'           => '',
             ]);
         }
 


### PR DESCRIPTION
### Motivation
- Fix PHPCS formatting issues in the dedupe + local-save section of `handle_pickup_exception_submission` to satisfy style constraints while keeping behavior identical.

### Description
- Normalize array key alignment and spacing in the duplicate-suppression JSON response inside `handle_pickup_exception_submission`.
- Normalize spacing for the `'last_retry_at' => null` entry in the local DB create payload.
- All edits are strictly limited to the section between the first validation check and the call to `store_pickup_dedupe_record(...)` and do not change any logic or values.

### Testing
- Ran PHP syntax check with `php -l includes/Admin/Ajax/AdminAjax.php` and it passed.
- Confirmed that only `includes/Admin/Ajax/AdminAjax.php` was modified and that changes are confined to the specified section of `handle_pickup_exception_submission`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f422a62694832db6becd0baf15c239)