### PR TITLE
style: PHPCS formatting cleanup in AdminAjax webhook section

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -549,13 +549,15 @@ class AdminAjax
             'issue'        => $issue,
         ], 'pickup_exception');
 
-        $result = $this->qr_service->send_pickup_exception_to_n8n([
-            'qr_code'     => $qr_code,
-            'customer_id' => $customer_id,
-            'issue'       => $issue,
-            'notes'       => $notes,
-            'timestamp'   => $timestamp,
-        ]);
+        $result = $this->qr_service->send_pickup_exception_to_n8n(
+            [
+                'qr_code'     => $qr_code,
+                'customer_id' => $customer_id,
+                'issue'       => $issue,
+                'notes'       => $notes,
+                'timestamp'   => $timestamp,
+            ]
+        );
 
         if (is_wp_error($result)) {
             $this->log_action('pickup_exception_submit', 'failed', __('Webhook delivery failed after local save.', 'kerbcycle'), [
@@ -579,19 +581,19 @@ class AdminAjax
 
             // Webhook failures return partial success because local persistence already succeeded.
             wp_send_json_success([
-                'status'      => 'partial_success',
-                'message'     => __('Pickup exception saved locally, but webhook delivery failed.', 'kerbcycle'),
+                'status'                => 'partial_success',
+                'message'               => __('Pickup exception saved locally, but webhook delivery failed.', 'kerbcycle'),
                 'exception_id' => $exception_id,
-                'local_save'  => ['success' => true, 'id' => $exception_id],
-                'webhook'     => [
+                'local_save'            => ['success' => true, 'id' => $exception_id],
+                'webhook'               => [
                     'success' => false,
                     'message' => $result->get_error_message(),
                     'code'    => $result->get_error_code(),
                 ],
                 'ai_recommended_action' => '',
-                'ai_summary'  => '',
-                'ai_category' => '',
-                'ai_severity' => '',
+                'ai_summary'            => '',
+                'ai_category'           => '',
+                'ai_severity'           => '',
             ]);
         }
 


### PR DESCRIPTION
### Motivation
- Apply a minimal, PHPCS-friendly formatting pass to the webhook dispatch and pre-AI failure handling inside `handle_pickup_exception_submission()` while preserving all behavior and payloads.

### Description
- Reformatted the `send_pickup_exception_to_n8n()` call to use multiline argument wrapping and normalized spacing/alignment for the pre-AI webhook failure JSON response array in `includes/Admin/Ajax/AdminAjax.php` without changing any logic, keys, values, or control flow.

### Testing
- Ran `php -l includes/Admin/Ajax/AdminAjax.php` which reported no syntax errors, and validated that only `includes/Admin/Ajax/AdminAjax.php` was changed and the diff is confined to the webhook section of `handle_pickup_exception_submission()`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f427312e28832db58ce86a933c89de)