### PR TITLE
style: format pickup exception webhook response section

### DIFF
--- a/includes/Admin/Ajax/AdminAjax.php
+++ b/includes/Admin/Ajax/AdminAjax.php
@@ -603,7 +603,7 @@ class AdminAjax
         );
 
         if ($is_webhook_success) {
-            $body = isset($result['body']) ? $result['body'] : '';
+            $body         = isset($result['body']) ? $result['body'] : '';
             $decoded_body = is_array($body) ? $body : json_decode((string) $body, true);
             $ai_payload = [];
 
@@ -617,34 +617,34 @@ class AdminAjax
                 }
             }
 
-            $ai_summary = isset($ai_payload['summary']) ? (string) $ai_payload['summary'] : '';
-            $ai_category = isset($ai_payload['category']) ? (string) $ai_payload['category'] : '';
-            $ai_severity = isset($ai_payload['severity']) ? (string) $ai_payload['severity'] : '';
+            $ai_summary            = isset($ai_payload['summary']) ? (string) $ai_payload['summary'] : '';
+            $ai_category           = isset($ai_payload['category']) ? (string) $ai_payload['category'] : '';
+            $ai_severity           = isset($ai_payload['severity']) ? (string) $ai_payload['severity'] : '';
             $ai_recommended_action = isset($ai_payload['recommended_action']) ? (string) $ai_payload['recommended_action'] : '';
 
             PickupExceptionRepository::update_result($exception_id, [
-                'webhook_sent'             => 1,
-                'webhook_status_code'      => $result_status_code,
-                'status'                   => 'sent',
-                'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
-                'ai_severity'              => $ai_severity,
-                'ai_category'              => $ai_category,
-                'ai_summary'               => $ai_summary,
-                'ai_recommended_action'    => $ai_recommended_action,
-                'updated_at'               => current_time('mysql', true),
+                'webhook_sent'          => 1,
+                'webhook_status_code'   => $result_status_code,
+                'status'                => 'sent',
+                'webhook_response_body' => is_scalar($body) ? (string) $body : wp_json_encode($body),
+                'ai_severity'           => $ai_severity,
+                'ai_category'           => $ai_category,
+                'ai_summary'            => $ai_summary,
+                'ai_recommended_action' => $ai_recommended_action,
+                'updated_at'            => current_time('mysql', true),
             ]);
 
             wp_send_json_success([
-                'status'      => 'success',
-                'message'     => __('Pickup exception saved locally and sent to webhook.', 'kerbcycle'),
-                'exception_id' => $exception_id,
-                'local_save'  => ['success' => true, 'id' => $exception_id],
-                'webhook'     => $result,
-                'webhook_body' => $body,
+                'status'                => 'success',
+                'message'               => __('Pickup exception saved locally and sent to webhook.', 'kerbcycle'),
+                'exception_id'          => $exception_id,
+                'local_save'            => ['success' => true, 'id' => $exception_id],
+                'webhook'               => $result,
+                'webhook_body'          => $body,
                 'ai_recommended_action' => $ai_recommended_action,
-                'ai_summary'  => $ai_summary,
-                'ai_category' => $ai_category,
-                'ai_severity' => $ai_severity,
+                'ai_summary'            => $ai_summary,
+                'ai_category'           => $ai_category,
+                'ai_severity'           => $ai_severity,
             ]);
         }
 
@@ -657,28 +657,28 @@ class AdminAjax
             'status_code'  => isset($result['status_code']) ? (int) $result['status_code'] : 0,
         ], 'pickup_exception');
         PickupExceptionRepository::update_result($exception_id, [
-            'webhook_sent'             => 0,
-            'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
-            'status'                   => 'failed',
-            'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
-            'ai_severity'              => '',
-            'ai_category'              => '',
-            'ai_summary'               => '',
-            'ai_recommended_action'    => '',
-            'updated_at'               => current_time('mysql', true),
+            'webhook_sent'          => 0,
+            'webhook_status_code'   => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+            'status'                => 'failed',
+            'webhook_response_body' => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
+            'ai_severity'           => '',
+            'ai_category'           => '',
+            'ai_summary'            => '',
+            'ai_recommended_action' => '',
+            'updated_at'            => current_time('mysql', true),
         ]);
 
         wp_send_json_success([
-            'status'      => 'partial_success',
-            'message'     => __('Pickup exception saved locally, but webhook delivery failed.', 'kerbcycle'),
-            'exception_id' => $exception_id,
-            'local_save'  => ['success' => true, 'id' => $exception_id],
-            'webhook'     => is_array($result) ? $result : ['success' => false],
-            'webhook_body' => isset($result['body']) ? $result['body'] : '',
+            'status'                => 'partial_success',
+            'message'               => __('Pickup exception saved locally, but webhook delivery failed.', 'kerbcycle'),
+            'exception_id'          => $exception_id,
+            'local_save'            => ['success' => true, 'id' => $exception_id],
+            'webhook'               => is_array($result) ? $result : ['success' => false],
+            'webhook_body'          => isset($result['body']) ? $result['body'] : '',
             'ai_recommended_action' => '',
-            'ai_summary'  => '',
-            'ai_category' => '',
-            'ai_severity' => '',
+            'ai_summary'            => '',
+            'ai_category'           => '',
+            'ai_severity'           => '',
         ]);
     }
 


### PR DESCRIPTION
### Motivation
- Fix PHPCS/formatting issues inside the final webhook + AI extraction response block of `handle_pickup_exception_submission()` to satisfy style requirements. 
- Keep the change surgical and strictly limited to whitespace/alignment so runtime behavior remains identical.

### Description
- Adjusted spacing and alignment for local variable assignments and array key/value lines inside the `if ($is_webhook_success) {` block through the final non-success webhook response. 
- Re-aligned AI payload variable assignments and normalized array formatting for the `PickupExceptionRepository::update_result(...)` calls and both `wp_send_json_success(...)` responses. 
- Only `includes/Admin/Ajax/AdminAjax.php` was modified and changes are confined to the allowed section of `handle_pickup_exception_submission()`.

### Testing
- Confirmed only one file changed with `git diff --name-only` and the diff was limited to the targeted section with `git diff -- includes/Admin/Ajax/AdminAjax.php`, both as expected (success). 
- Verified PHP syntax for the modified file with `php -l includes/Admin/Ajax/AdminAjax.php` (no syntax errors). 
- No unit tests were added or modified; existing automated checks listed above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42a5fc41c832dbb00bef56976751d)