### PR TITLE
Stage PHPCS CI: keep repo-wide summary visible but non-blocking

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -38,25 +38,27 @@ jobs:
         #run: |
           #vendor/bin/phpcs --standard=phpcs.xml.dist --report=checkstyle > phpcs-report.xml
 
-      - name: Run PHPCS summary and capture exit code
+      - name: Run PHPCS repo-wide summary
         id: phpcs
         run: |
           set +e
           vendor/bin/phpcs --standard=phpcs.xml.dist --report=summary
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          PHPCS_EXIT_CODE=$?
           set -e
 
-      - name: Explain PHPCS result
-        run: |
-          if [ "${{ steps.phpcs.outputs.exit_code }}" != "0" ]; then
-            echo "❌ PHPCS violations found. This means the scan completed but found WordPress coding-standard issues."
+          echo "exit_code=${PHPCS_EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+          if [ "$PHPCS_EXIT_CODE" != "0" ]; then
+            echo "⚠️ Repo-wide PHPCS violations found."
+            echo "⚠️ Repo-wide PHPCS is report-only during staged cleanup."
+            echo "⚠️ Future passes should add changed-files or selected-clean-files gating."
           else
-            echo "✅ PHPCS passed with no violations."
+            echo "✅ Repo-wide PHPCS passed with no violations."
           fi
 
-      - name: Fail if PHPCS found violations
-        if: steps.phpcs.outputs.exit_code != '0'
-        run: exit 1
+      - name: Placeholder for future staged blocking gate
+        run: |
+          echo "ℹ️ Placeholder: future pass should add changed-files or selected-clean-files PHPCS blocking gate."
 
       #- name: Annotate PHPCS results
         #if: always()
@@ -64,6 +66,3 @@ jobs:
         #with:
           #path: phpcs-report.xml
 
-      - name: Fail if PHPCS found violations
-        if: steps.phpcs.outcome == 'failure'
-        run: exit 1


### PR DESCRIPTION
### Motivation
- Reduce CI merge-blocking from large legacy PHPCS debt by making the repo-wide PHPCS scan report-only during a staged cleanup while keeping full visibility in CI logs.
- Preserve existing PHPCS standards and CI triggers so future passes can safely introduce changed-files or allowlist gating without hiding current findings.

### Description
- Updated `.github/workflows/phpcs.yml` to run `vendor/bin/phpcs --standard=phpcs.xml.dist --report=summary`, capture the exit code in `GITHUB_OUTPUT`, and print a staged-cleanup message when violations are found instead of hard-failing the job.
- Removed the prior `exit 1` hard-fail steps that made the repo-wide PHPCS summary block merges and removed the outcome-based failure step.
- Added a placeholder step that documents the intended future path for a changed-files or selected-clean-files blocking gate.
- Preserved workflow triggers, permissions, pinned action SHAs, PHP setup, `composer install` behavior, and the PHPCS standard (`phpcs.xml.dist`).

### Testing
- Parsed the edited workflow with Ruby using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/phpcs.yml'); puts 'YAML OK'"`, which returned `YAML OK` (success).
- Verified only the workflow file was modified with `git diff --name-only`, which reported only `.github/workflows/phpcs.yml` (success).
- Inspected the workflow for PHPCS/PHPCBF/annotation/exit gates using `grep -n "phpcs\|phpcbf\|checkstyle\|reviewdog\|exit 1\|continue-on-error" .github/workflows/phpcs.yml` and confirmed the repo-wide summary remains, annotation tooling is still commented out, and there is no active `exit 1` hard-fail (success).
- Confirmed the `git diff` of the workflow shows only staged-policy edits and no source, ruleset, or dependency changes (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f976516940832db955e51aeabc5b47)