### PR TITLE
Fix Activator text-domain mismatch in operator role label

### DIFF
--- a/includes/Install/Activator.php
+++ b/includes/Install/Activator.php
@@ -172,7 +172,7 @@ class Activator {
 			\Kerbcycle\QrCode\Helpers\Capabilities::manage_operations() => true,
 		);
 
-		add_role( 'kerbcycle_operator', __( 'KerbCycle Operator', 'kerbcycle' ), $operator_caps );
+		add_role( 'kerbcycle_operator', __( 'KerbCycle Operator', 'kerbcycle-qr-code-manager' ), $operator_caps );
 
 		$operator = get_role( 'kerbcycle_operator' );
 		if ( $operator ) {


### PR DESCRIPTION
### Motivation
- Address a PHPCS `WordPress.WP.I18n.TextDomainMismatch` reported on line 175 by correcting the text domain used in the operator role translation call.

### Description
- Changed `includes/Install/Activator.php` line 175 from `add_role( 'kerbcycle_operator', __( 'KerbCycle Operator', 'kerbcycle' ), $operator_caps );` to `add_role( 'kerbcycle_operator', __( 'KerbCycle Operator', 'kerbcycle-qr-code-manager' ), $operator_caps );` and made no other file or behavior changes.

### Testing
- Ran `php -l includes/Install/Activator.php` which returned: `No syntax errors detected in includes/Install/Activator.php`; attempted `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Install/Activator.php -s` which could not be executed in this environment and returned: `/bin/bash: line 1: vendor/bin/phpcs: No such file or directory`; a `git diff` confirmed only `includes/Install/Activator.php` changed and the diff shows a single text-domain string replacement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9906b1f10832db385421344a6dda1)