### PR TITLE
Fix PHPCS formatting in Utils helper

### DIFF
--- a/includes/Helpers/Utils.php
+++ b/includes/Helpers/Utils.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode\Helpers;
 
-if (! defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -13,7 +13,7 @@ if (! defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Helpers
  */
-class Utils
-{
+class Utils {
+
     // Utility functions will be added here.
 }


### PR DESCRIPTION
## Summary

- Runs a narrow PHPCS formatting cleanup for `includes/Helpers/Utils.php`.
- Fixes the ABSPATH guard spacing.
- Fixes the class opening brace placement.

## Scope

- One file changed: `includes/Helpers/Utils.php`.
- Formatting-only cleanup.
- No behavior changes.

## Validation

- `php -l includes/Helpers/Utils.php` passed.
- `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Helpers/Utils.php -s` passed.
- `git diff --name-only` showed only `includes/Helpers/Utils.php`.