### PR TITLE
Fix Nonces helper: unslash+sanitize request nonce, correct text domain, escape wp_die message

### DIFF
--- a/includes/Helpers/Nonces.php
+++ b/includes/Helpers/Nonces.php
@@ -28,13 +28,13 @@ class Nonces {
 		if ( $request instanceof \WP_REST_Request ) {
 			$nonce = $request->get_param( $field );
 		} elseif ( isset( $_REQUEST[ $field ] ) ) {
-			$nonce = $_REQUEST[ $field ];
+			$nonce = sanitize_text_field( wp_unslash( $_REQUEST[ $field ] ) );
 		}
 
 		$nonce = sanitize_text_field( $nonce );
 
 		if ( ! wp_verify_nonce( $nonce, $action ) ) {
-			$message = __( 'Security check failed', 'kerbcycle' );
+			$message = __( 'Security check failed', 'kerbcycle-qr-code-manager' );
 
 			if ( $request instanceof \WP_REST_Request ) {
 				return new \WP_Error( 'rest_nonce_invalid', $message, array( 'status' => 403 ) );
@@ -44,7 +44,7 @@ class Nonces {
 				wp_send_json_error( array( 'message' => $message ), 403 );
 			}
 
-			wp_die( $message, __( 'Error', 'kerbcycle' ), 403 );
+			wp_die( esc_html( $message ), esc_html__( 'Error', 'kerbcycle-qr-code-manager' ), 403 );
 		}
 
 		return true;

--- a/includes/Helpers/Nonces.php
+++ b/includes/Helpers/Nonces.php
@@ -44,7 +44,7 @@ class Nonces {
 				wp_send_json_error( array( 'message' => $message ), 403 );
 			}
 
-			wp_die( esc_html( $message ), esc_html__( 'Error', 'kerbcycle-qr-code-manager' ), 403 );
+			wp_die( esc_html( $message ), esc_html( __( 'Error', 'kerbcycle-qr-code-manager' ) ), 403 );
 		}
 
 		return true;


### PR DESCRIPTION
### Motivation
- Address PHPCS findings in the nonce verification helper by unslashing/sanitizing incoming request data, fixing i18n text domains, and escaping output at the sink while keeping behavior unchanged.

### Description
- Files changed: `includes/Helpers/Nonces.php` only.
- Request nonce read: the `$_REQUEST[$field]` branch now reads the value with `wp_unslash()` and `sanitize_text_field()` at the read site (`sanitize_text_field( wp_unslash( $_REQUEST[ $field ] ) )`).
- Text domains: changed `'kerbcycle'` to `'kerbcycle-qr-code-manager'` for the security message and the `wp_die()` title.
- `wp_die` escaping: `$message` is escaped at the output sink with `esc_html()` and the title uses `esc_html__()`, preserving the original `403` status and control flow; no other behavior, signatures, or branch logic was modified.
- No-drift confirmation: no nonce action/field names were changed, no REST/AJAX branching changed, no status code changed, no call sites changed, no PHPCBF run, and no suppressions added.

### Testing
- Ran `git diff --name-only` and confirmed only the target file changed; output:
```
includes/Helpers/Nonces.php
```
- Ran `php -l includes/Helpers/Nonces.php` and confirmed syntax is valid; output:
```
No syntax errors detected in includes/Helpers/Nonces.php
```
- Attempted to run PHPCS but `vendor/bin/phpcs` is not available in this environment; command and output were:
```
vendor/bin/phpcs --standard=phpcs.xml.dist includes/Helpers/Nonces.php -s
/bin/bash: line 1: vendor/bin/phpcs: No such file or directory
```
- Remaining finding: the contextual PHPCS warning about "Processing form data without nonce verification" may still appear and is a false positive because this helper implements nonce verification; it was not suppressed as per scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a976b038832d820d7d370229471e)