### PR TITLE
Fix QrController SQL scanner regression — inline prepared query + narrow PHPCS ignore

### DIFF
--- a/includes/Api/Controllers/QrController.php
+++ b/includes/Api/Controllers/QrController.php
@@ -107,7 +107,7 @@ class QrController {
 		$qr_code = sanitize_text_field( $request['qr_code'] );
 		$table   = $wpdb->prefix . 'kerbcycle_qr_codes';
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; qr_code value is prepared.
-		$result  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE qr_code = %s", $qr_code ) );
+		$result = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE qr_code = %s", $qr_code ) );
 		return $result ? rest_ensure_response( $result ) : new \WP_Error( 'not_found', 'QR Code not found', array( 'status' => 404 ) );
 	}
 }

--- a/includes/Api/Controllers/QrController.php
+++ b/includes/Api/Controllers/QrController.php
@@ -106,8 +106,8 @@ class QrController {
 		global $wpdb;
 		$qr_code = sanitize_text_field( $request['qr_code'] );
 		$table   = $wpdb->prefix . 'kerbcycle_qr_codes';
-		$query   = $wpdb->prepare( 'SELECT * FROM ' . esc_sql( $table ) . ' WHERE qr_code = %s', $qr_code );
-		$result  = $wpdb->get_row( $query );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; qr_code value is prepared.
+		$result  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE qr_code = %s", $qr_code ) );
 		return $result ? rest_ensure_response( $result ) : new \WP_Error( 'not_found', 'QR Code not found', array( 'status' => 404 ) );
 	}
 }


### PR DESCRIPTION
### Motivation
- Address a PHPCS/DeepSource SQL scanner regression by removing `esc_sql()` and restoring an inline prepared query while keeping the user-controlled `qr_code` value prepared with `%s` in a single-file, minimal change. 

### Description
- Files changed: `includes/Api/Controllers/QrController.php` was updated. 
- Exact SQL cleanup: removed `esc_sql()`, removed the intermediate `$query` variable, restored the inline `$wpdb->prepare()` inside `$wpdb->get_row()`, and added one narrow PHPCS suppression for `WordPress.DB.PreparedSQL.InterpolatedNotPrepared` immediately above the query. 
- No-drift confirmation: no REST route changes, no permission/capability changes, no input parameter changes, no response payload/status changes, and no repository/service files were modified. 

### Testing
- `git diff --name-only` output: `includes/Api/Controllers/QrController.php`. 
- `php -l includes/Api/Controllers/QrController.php` output: `No syntax errors detected in includes/Api/Controllers/QrController.php`. 
- `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Api/Controllers/QrController.php -s` output: `/bin/bash: line 1: vendor/bin/phpcs: No such file or directory` (PHPCS not available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c05f20e8832d8a7dcf91007624d2)