### PR TITLE
Fix QrController prepared SQL scanner warning

### DIFF
--- a/includes/Api/Controllers/QrController.php
+++ b/includes/Api/Controllers/QrController.php
@@ -108,7 +108,7 @@ class QrController
 		$qr_code = sanitize_text_field( $request['qr_code'] );
 		$table   = $wpdb->prefix . 'kerbcycle_qr_codes';
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; qr_code value is prepared.
-		$result  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE qr_code = %s", $qr_code ) );
+		$result = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE qr_code = %s", $qr_code ) );
 		return $result ? rest_ensure_response( $result ) : new \WP_Error( 'not_found', 'QR Code not found', array( 'status' => 404 ) );
 	}
 }

--- a/includes/Api/Controllers/QrController.php
+++ b/includes/Api/Controllers/QrController.php
@@ -107,7 +107,8 @@ class QrController
 		global $wpdb;
 		$qr_code = sanitize_text_field( $request['qr_code'] );
 		$table   = $wpdb->prefix . 'kerbcycle_qr_codes';
-		$result  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE qr_code = %s", $qr_code ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; qr_code value is prepared.
+		$result  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE qr_code = %s", $qr_code ) );
 		return $result ? rest_ensure_response( $result ) : new \WP_Error( 'not_found', 'QR Code not found', array( 'status' => 404 ) );
 	}
 }


### PR DESCRIPTION
### Motivation
- Resolve a PHPCS/DeepSource SQL-scanner regression by removing `esc_sql()` and an intermediate query variable while keeping the `$qr_code` value properly prepared, making only a minimal change to address the lint finding without altering REST, permission, or behavior.

### Description
- Modified `includes/Api/Controllers/QrController.php` to remove the intermediate `$query` and `esc_sql()` usage, restore the inline prepared query using `{$table}` inside `$wpdb->prepare()` and `$wpdb->get_row()`, and add one narrow `// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared` comment immediately above the query to document the fixed internal table-name interpolation.

### Testing
- Ran `git diff --name-only` which returned `includes/Api/Controllers/QrController.php`, ran `php -l includes/Api/Controllers/QrController.php` which reported `No syntax errors detected`, and attempted `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Api/Controllers/QrController.php -s` but the `phpcs` tool was not available in the environment (`vendor/bin/phpcs: No such file or directory`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fabaa29164832dbe9c2af54e690542)