### PR TITLE
QrController: update textdomain, adjust formatting, and fix DB prepare call

### DIFF
--- a/includes/Api/Controllers/QrController.php
+++ b/includes/Api/Controllers/QrController.php
@@ -19,8 +19,7 @@ use Kerbcycle\QrCode\Data\Repositories\QrCodeRepository;
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Api\Controllers
  */
-class QrController
-{
+class QrController {
 	/**
 	 * Handle the QR code scan.
 	 *
@@ -32,18 +31,18 @@ class QrController
 	 */
 	public function handle_qr_code_scan( WP_REST_Request $request ) {
 		if ( ! current_user_can( 'manage_options' ) ) {
-			return new \WP_Error( 'rest_forbidden', __( 'Unauthorized', 'kerbcycle' ), array( 'status' => 403 ) );
+			return new \WP_Error( 'rest_forbidden', __( 'Unauthorized', 'kerbcycle-qr-code-manager' ), array( 'status' => 403 ) );
 		}
 
 		$qr_code = sanitize_text_field( $request->get_param( 'qr_code' ) );
 		$user_id = intval( $request->get_param( 'user_id' ) );
 
 		if ( '' === $qr_code ) {
-			return new \WP_Error( 'invalid_qr_code', __( 'QR code is required.', 'kerbcycle' ), array( 'status' => 400 ) );
+			return new \WP_Error( 'invalid_qr_code', __( 'QR code is required.', 'kerbcycle-qr-code-manager' ), array( 'status' => 400 ) );
 		}
 
 		if ( $user_id < 1 || ! get_userdata( $user_id ) ) {
-			return new \WP_Error( 'invalid_user', __( 'Invalid customer selected.', 'kerbcycle' ), array( 'status' => 400 ) );
+			return new \WP_Error( 'invalid_user', __( 'Invalid customer selected.', 'kerbcycle-qr-code-manager' ), array( 'status' => 400 ) );
 		}
 
 		$nonce_check = Nonces::verify( 'kerbcycle_qr_nonce', 'nonce', $request );
@@ -57,7 +56,7 @@ class QrController
 			return new WP_REST_Response(
 				array(
 					'success' => false,
-					'message' => __( 'QR code already assigned.', 'kerbcycle' ),
+					'message' => __( 'QR code already assigned.', 'kerbcycle-qr-code-manager' ),
 				),
 				409
 			);
@@ -81,7 +80,7 @@ class QrController
 		return new WP_REST_Response(
 			array(
 				'success'      => true,
-				'message'      => __( 'QR code processed', 'kerbcycle' ),
+				'message'      => __( 'QR code processed', 'kerbcycle-qr-code-manager' ),
 				'qr_code'      => $qr_code,
 				'user_id'      => $user_id,
 				'display_name' => $name,
@@ -101,13 +100,14 @@ class QrController
 	 */
 	public function get_qr_status( WP_REST_Request $request ) {
 		if ( ! current_user_can( 'manage_options' ) ) {
-			return new \WP_Error( 'rest_forbidden', __( 'Unauthorized', 'kerbcycle' ), array( 'status' => 403 ) );
+			return new \WP_Error( 'rest_forbidden', __( 'Unauthorized', 'kerbcycle-qr-code-manager' ), array( 'status' => 403 ) );
 		}
 
 		global $wpdb;
 		$qr_code = sanitize_text_field( $request['qr_code'] );
 		$table   = $wpdb->prefix . 'kerbcycle_qr_codes';
-		$result  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE qr_code = %s", $qr_code ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; qr_code value is prepared.
+		$result  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE qr_code = %s", $qr_code ) );
 		return $result ? rest_ensure_response( $result ) : new \WP_Error( 'not_found', 'QR Code not found', array( 'status' => 404 ) );
 	}
 }


### PR DESCRIPTION
### Motivation
- Ensure translation strings use the correct plugin textdomain and address a DB prepare/PHPCS warning for the QR controller.

### Description
- Replace occurrences of the `kerbcycle` textdomain with `kerbcycle-qr-code-manager` in `handle_qr_code_scan` responses and messages.
- Normalize the class opening brace formatting for `QrController`.
- Update the `wpdb->prepare` call in `get_qr_status` to interpolate the table variable as `{$table}` and add a `// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared` comment because the table name is derived from the WordPress prefix and is not user input.

### Testing
- Ran the project's automated unit test suite and static analysis/linting, and they completed successfully.
- Exercised `get_qr_status` behavior via existing tests to confirm it returns a `404` `WP_Error` when the QR code is not found and returns the DB row when present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fabaa29164832dbe9c2af54e690542)