### PR TITLE
Use wp_safe_redirect for RedirectsPage admin redirects

### DIFF
--- a/includes/Admin/Pages/RedirectsPage.php
+++ b/includes/Admin/Pages/RedirectsPage.php
@@ -20,7 +20,7 @@ class RedirectsPage {
 	 * @since    1.0.0
 	 */
 	public function bookly_appointments() {
-		wp_redirect( admin_url( 'admin.php?page=bookly-appointments' ) );
+		wp_safe_redirect( admin_url( 'admin.php?page=bookly-appointments' ) );
 		exit;
 	}
 
@@ -30,7 +30,7 @@ class RedirectsPage {
 	 * @since    1.0.0
 	 */
 	public function terawallet() {
-		wp_redirect( admin_url( 'admin.php?page=woo-wallet' ) );
+		wp_safe_redirect( admin_url( 'admin.php?page=woo-wallet' ) );
 		exit;
 	}
 }


### PR DESCRIPTION
### Motivation
- Fix PHPCS Safe Redirect warnings by switching to `wp_safe_redirect()` while preserving existing redirect targets and behavior.

### Description
- Replaced the two `wp_redirect()` calls with `wp_safe_redirect()` in `includes/Admin/Pages/RedirectsPage.php` and kept the `exit;` calls and all redirect targets/conditions unchanged.

### Testing
- Ran `git diff --name-only` (shows `includes/Admin/Pages/RedirectsPage.php`), `php -l includes/Admin/Pages/RedirectsPage.php` (No syntax errors detected), and attempted `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Admin/Pages/RedirectsPage.php -s` which could not run because `vendor/bin/phpcs` is not present in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae408b614832d923eedc76514f631)