### PR TITLE
PHPCS cleanup: ReportsPage brace formatting and text domain

### DIFF
--- a/includes/Admin/Pages/ReportsPage.php
+++ b/includes/Admin/Pages/ReportsPage.php
@@ -13,21 +13,19 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Admin\Pages
  */
-class ReportsPage
-{
+class ReportsPage {
     /**
      * Render the reports page.
      *
      * @since    1.0.0
      */
-    public function render()
-    {
+    public function render() {
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e('QR Code Reports', 'kerbcycle'); ?></h1>
-            <h2><?php esc_html_e('Today\'s Assignments', 'kerbcycle'); ?></h2>
+            <h1><?php esc_html_e( 'QR Code Reports', 'kerbcycle-qr-code-manager' ); ?></h1>
+            <h2><?php esc_html_e( 'Today\'s Assignments', 'kerbcycle-qr-code-manager' ); ?></h2>
             <canvas id="qr-daily-chart" style="max-width:600px;width:100%;"></canvas>
-            <h2><?php esc_html_e('Weekly Assignments', 'kerbcycle'); ?></h2>
+            <h2><?php esc_html_e( 'Weekly Assignments', 'kerbcycle-qr-code-manager' ); ?></h2>
             <canvas id="qr-report-chart" style="max-width:600px;width:100%;"></canvas>
         </div>
         <?php


### PR DESCRIPTION
### Motivation
- Fix reported PHPCS issues in `includes/Admin/Pages/ReportsPage.php` (brace placement, function-call spacing, and text-domain mismatch) while making the smallest possible change and without altering runtime behavior or output.

### Description
- Modified only `includes/Admin/Pages/ReportsPage.php` to move the `ReportsPage` class opening brace onto the declaration line and the `render()` method opening brace onto its declaration line.
- Adjusted spacing inside the reported `esc_html_e()` calls to satisfy the function-call spacing rules while preserving string text exactly.
- Replaced the file-local text-domain arguments from `'kerbcycle'` to `'kerbcycle-qr-code-manager'` and did not change any visible string text, logic, hooks, or HTML structure.

### Testing
- `git diff --name-only` output: `includes/Admin/Pages/ReportsPage.php`.
- `php -l includes/Admin/Pages/ReportsPage.php` output: `No syntax errors detected in includes/Admin/Pages/ReportsPage.php`.
- `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Admin/Pages/ReportsPage.php -s` output: `/bin/bash: line 1: vendor/bin/phpcs: No such file or directory` (PHPCS is not available in this environment so file-specific PHPCS could not be re-run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae92a9fc4832daca07fde4f8dc343)