### PR TITLE
PHPCBF: format Capabilities helper

### DIFF
--- a/includes/Helpers/Capabilities.php
+++ b/includes/Helpers/Capabilities.php
@@ -2,31 +2,28 @@
 
 namespace Kerbcycle\QrCode\Helpers;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
  * Centralized capability names and compatibility checks.
  */
-class Capabilities
-{
-	public const MANAGE_OPERATIONS = 'kerbcycle_manage_operations';
-	public const MANAGE_SETTINGS = 'kerbcycle_manage_settings';
-	public const VIEW_LOGS = 'kerbcycle_view_logs';
+class Capabilities {
 
-	public static function manage_operations()
-	{
+	public const MANAGE_OPERATIONS = 'kerbcycle_manage_operations';
+	public const MANAGE_SETTINGS   = 'kerbcycle_manage_settings';
+	public const VIEW_LOGS         = 'kerbcycle_view_logs';
+
+	public static function manage_operations() {
 		return self::MANAGE_OPERATIONS;
 	}
 
-	public static function manage_settings()
-	{
+	public static function manage_settings() {
 		return self::MANAGE_SETTINGS;
 	}
 
-	public static function view_logs()
-	{
+	public static function view_logs() {
 		return self::VIEW_LOGS;
 	}
 
@@ -37,8 +34,7 @@ class Capabilities
 	 *
 	 * @return bool
 	 */
-	public static function can($capability)
-	{
-		return current_user_can($capability) || current_user_can('manage_options');
+	public static function can( $capability ) {
+		return current_user_can( $capability ) || current_user_can( 'manage_options' );
 	}
 }


### PR DESCRIPTION
Summary:
- Ran PHPCBF only on includes/Helpers/Capabilities.php.
- Fixed auto-fixable formatting/spacing findings only.
- Preserved capability names, role names, method names, class/namespace, and logic.

Validation:
- php -l includes/Helpers/Capabilities.php
- vendor/bin/phpcs --standard=phpcs.xml.dist includes/Helpers/Capabilities.php -s

Scope:
- Only includes/Helpers/Capabilities.php changed.