### PR TITLE
PHPCS cleanup: format QrCodeHistoryRepository and suppress table interpolation warning

### DIFF
--- a/includes/Data/Repositories/QrCodeHistoryRepository.php
+++ b/includes/Data/Repositories/QrCodeHistoryRepository.php
@@ -38,9 +38,9 @@ class QrCodeHistoryRepository {
     public function recent( $limit ) {
         global $wpdb;
         $limit = absint( $limit );
-
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; limit value is prepared.
+        
         return $wpdb->get_results(
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; limit value is prepared.
             $wpdb->prepare( "SELECT * FROM $this->table ORDER BY changed_at DESC LIMIT %d", $limit )
         );
     }

--- a/includes/Data/Repositories/QrCodeHistoryRepository.php
+++ b/includes/Data/Repositories/QrCodeHistoryRepository.php
@@ -38,7 +38,7 @@ class QrCodeHistoryRepository {
     public function recent( $limit ) {
         global $wpdb;
         $limit = absint( $limit );
-        
+     
         return $wpdb->get_results(
             // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; limit value is prepared.
             $wpdb->prepare( "SELECT * FROM $this->table ORDER BY changed_at DESC LIMIT %d", $limit )

--- a/includes/Data/Repositories/QrCodeHistoryRepository.php
+++ b/includes/Data/Repositories/QrCodeHistoryRepository.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode\Data\Repositories;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -13,37 +13,35 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Data\Repositories
  */
-class QrCodeHistoryRepository
-{
+class QrCodeHistoryRepository {
     private $table;
 
-    public function __construct()
-    {
+    public function __construct() {
         global $wpdb;
         $this->table = $wpdb->prefix . 'kerbcycle_qr_code_history';
     }
 
-    public function log($qr_code, $user_id, $status)
-    {
+    public function log( $qr_code, $user_id, $status ) {
         global $wpdb;
         return $wpdb->insert(
             $this->table,
             [
-                'qr_code'   => $qr_code,
-                'user_id'   => $user_id,
-                'status'    => $status,
-                'changed_at' => current_time('mysql'),
+                'qr_code'    => $qr_code,
+                'user_id'    => $user_id,
+                'status'     => $status,
+                'changed_at' => current_time( 'mysql' ),
             ],
-            ['%s', '%d', '%s', '%s']
+            [ '%s', '%d', '%s', '%s' ]
         );
     }
 
-    public function recent($limit)
-    {
+    public function recent( $limit ) {
         global $wpdb;
-        $limit = absint($limit);
+        $limit = absint( $limit );
+
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; limit value is prepared.
         return $wpdb->get_results(
-            $wpdb->prepare("SELECT * FROM $this->table ORDER BY changed_at DESC LIMIT %d", $limit)
+            $wpdb->prepare( "SELECT * FROM $this->table ORDER BY changed_at DESC LIMIT %d", $limit )
         );
     }
 }

--- a/includes/Data/Repositories/QrCodeHistoryRepository.php
+++ b/includes/Data/Repositories/QrCodeHistoryRepository.php
@@ -38,7 +38,7 @@ class QrCodeHistoryRepository {
     public function recent( $limit ) {
         global $wpdb;
         $limit = absint( $limit );
-     
+
         return $wpdb->get_results(
             // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; limit value is prepared.
             $wpdb->prepare( "SELECT * FROM $this->table ORDER BY changed_at DESC LIMIT %d", $limit )


### PR DESCRIPTION
### Motivation
- Apply a narrow, file-scoped PHPCBF-style formatting pass to `QrCodeHistoryRepository` to satisfy style rules without changing behavior.
- Suppress a single PHPCS SQL scanner false-positive for an internally-derived table name while keeping the query prepared for the `LIMIT` placeholder.

### Description
- Files changed: `includes/Data/Repositories/QrCodeHistoryRepository.php`.
- Applied formatting-equivalent changes: fixed `ABSPATH` guard spacing, moved class/function opening braces to same-line style, normalized function declaration and call spacing, and adjusted array alignment/spacing as in the supplied PHPCBF diff.
- Added exactly one narrow PHPCS suppression comment immediately above the `recent()` query: `// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; limit value is prepared.`
- Preserved all behavior: the table suffix and `$this->table` assignment are unchanged, `$limit` remains `absint( $limit )` and is prepared via `%d` in `$wpdb->prepare()`, and insert/get calls are unchanged.

### Testing
- `git diff --name-only` output: `includes/Data/Repositories/QrCodeHistoryRepository.php`.
- `php -l includes/Data/Repositories/QrCodeHistoryRepository.php` output: `No syntax errors detected in includes/Data/Repositories/QrCodeHistoryRepository.php`.
- `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Data/Repositories/QrCodeHistoryRepository.php -s` could not be run in this environment because the binary is missing, output: `/bin/bash: line 1: vendor/bin/phpcs: No such file or directory`.
- No other files were modified and there were no namespace/class/method/table-suffix/SQL-behavior changes in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc20b486e0832d816480a4906cccff)