### PR TITLE
PHPCS cleanup for QrRepoRepository formatting and targeted SQL suppressions

### DIFF
--- a/includes/Data/Repositories/QrRepoRepository.php
+++ b/includes/Data/Repositories/QrRepoRepository.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode\Data\Repositories;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/includes/Data/Repositories/QrRepoRepository.php
+++ b/includes/Data/Repositories/QrRepoRepository.php
@@ -52,9 +52,9 @@ class QrRepoRepository {
      */
     public function list_between( string $from, string $to ): array {
         global $wpdb;
-        return $wpdb->get_results(
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; date values are prepared.
+        return $wpdb->get_results(			
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; date values are prepared.
 				"SELECT id, code, status, created_at FROM $this->table WHERE DATE(created_at) BETWEEN %s AND %s ORDER BY created_at ASC",
 				$from,
 				$to

--- a/includes/Data/Repositories/QrRepoRepository.php
+++ b/includes/Data/Repositories/QrRepoRepository.php
@@ -52,7 +52,7 @@ class QrRepoRepository {
      */
     public function list_between( string $from, string $to ): array {
         global $wpdb;
-        return $wpdb->get_results(			
+		return $wpdb->get_results(
 			$wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; date values are prepared.
 				"SELECT id, code, status, created_at FROM $this->table WHERE DATE(created_at) BETWEEN %s AND %s ORDER BY created_at ASC",

--- a/includes/Data/Repositories/QrRepoRepository.php
+++ b/includes/Data/Repositories/QrRepoRepository.php
@@ -9,13 +9,11 @@ if (!defined('ABSPATH')) {
 /**
  * Repository for QR code generator table.
  */
-class QrRepoRepository
-{
+class QrRepoRepository {
     /** @var string */
     private $table;
 
-    public function __construct()
-    {
+    public function __construct() {
         global $wpdb;
         $this->table = $wpdb->prefix . 'kerbcycle_qr_repo';
     }
@@ -23,17 +21,18 @@ class QrRepoRepository
     /**
      * Check if a code already exists in the repository.
      */
-    public function exists(string $code): bool
-    {
+    public function exists( string $code ): bool {
         global $wpdb;
-        return (bool) $wpdb->get_var($wpdb->prepare("SELECT id FROM $this->table WHERE code = %s", $code));
+        return (bool) $wpdb->get_var(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; code value is prepared.
+			$wpdb->prepare( "SELECT id FROM $this->table WHERE code = %s", $code )
+		);
     }
 
     /**
      * Insert a new code.
      */
-    public function insert(string $code, ?int $user_id = null)
-    {
+    public function insert( string $code, ?int $user_id = null ) {
         global $wpdb;
         return $wpdb->insert(
             $this->table,
@@ -42,7 +41,7 @@ class QrRepoRepository
                 'status'     => 'available',
                 'created_by' => $user_id,
             ],
-            ['%s', '%s', '%d']
+            [ '%s', '%s', '%d' ]
         );
     }
 
@@ -51,15 +50,15 @@ class QrRepoRepository
      *
      * @return array[]
      */
-    public function list_between(string $from, string $to): array
-    {
+    public function list_between( string $from, string $to ): array {
         global $wpdb;
         return $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT id, code, status, created_at FROM $this->table WHERE DATE(created_at) BETWEEN %s AND %s ORDER BY created_at ASC",
-                $from,
-                $to
-            ),
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; date values are prepared.
+			$wpdb->prepare(
+				"SELECT id, code, status, created_at FROM $this->table WHERE DATE(created_at) BETWEEN %s AND %s ORDER BY created_at ASC",
+				$from,
+				$to
+			),
             ARRAY_A
         );
     }


### PR DESCRIPTION
### Motivation
- Reduce PHPCS formatting/spacing issues in the QR repository class while preserving all runtime behavior and silencing two specific DB scanner warnings about an internally-derived table name.

### Description
- Applied formatting-equivalent fixes for brace placement and function declaration/call spacing in `includes/Data/Repositories/QrRepoRepository.php`.
- Normalized single-line array spacing in the `insert` format array and kept all SQL placeholders intact.
- Added two narrow `// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared` comments immediately above the two `$wpdb->prepare(...)` calls that interpolate `$this->table` (code lookup and date-range queries) without changing the SQL text or placeholders.
- No namespace, class, method, property, table-suffix, SQL columns/WHERE/ORDER, or repository behavior changes were made. 

### Testing
- Only `includes/Data/Repositories/QrRepoRepository.php` was modified and committed with message `Style cleanup for QrRepoRepository with targeted SQL PHPCS suppressions`.
- Syntax check `php -l includes/Data/Repositories/QrRepoRepository.php` passed with `No syntax errors detected`.
- `vendor/bin/phpcs` could not be executed in this environment (`vendor/bin/phpcs: No such file or directory`), so file-specific PHPCS verification is blocked and must be run in the Codespace or CI before merge.
- `git diff --name-only` confirms the single changed file: `includes/Data/Repositories/QrRepoRepository.php`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3a0dd208832da542390cf4a69ace)