### PR TITLE
PHPCS cleanup: ReportService formatting + narrow SQL suppressions

### DIFF
--- a/includes/Services/ReportService.php
+++ b/includes/Services/ReportService.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Services;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 /**
@@ -13,42 +13,42 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Services
  */
-class ReportService
-{
-    public function get_report_data()
-    {
-        global $wpdb;
-        $table = $wpdb->prefix . 'kerbcycle_qr_codes';
+class ReportService {
+	public function get_report_data() {
+		global $wpdb;
+		$table = $wpdb->prefix . 'kerbcycle_qr_codes';
 
-        // Weekly assignment counts
-        $results = $wpdb->get_results("SELECT DATE(assigned_at) AS date, COUNT(*) AS count FROM $table WHERE assigned_at IS NOT NULL GROUP BY DATE(assigned_at) ORDER BY date DESC LIMIT 7");
-        $labels  = [];
-        $counts  = [];
-        if ($results) {
-            foreach (array_reverse($results) as $row) {
-                $labels[] = $row->date;
-                $counts[] = (int) $row->count;
-            }
-        }
+		// Weekly assignment counts
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; report query has no user-supplied SQL fragments.
+		$results = $wpdb->get_results( "SELECT DATE(assigned_at) AS date, COUNT(*) AS count FROM $table WHERE assigned_at IS NOT NULL GROUP BY DATE(assigned_at) ORDER BY date DESC LIMIT 7" );
+		$labels  = [];
+		$counts  = [];
+		if ( $results ) {
+			foreach ( array_reverse( $results ) as $row ) {
+				$labels[] = $row->date;
+				$counts[] = (int) $row->count;
+			}
+		}
 
-        // Today's assignment counts by hour
-        $hour_results = $wpdb->get_results("SELECT HOUR(assigned_at) AS hour, COUNT(*) AS count FROM $table WHERE assigned_at >= CURDATE() GROUP BY HOUR(assigned_at) ORDER BY hour");
-        $daily_labels = [];
-        $daily_counts = [];
-        if ($hour_results) {
-            foreach ($hour_results as $row) {
-                $daily_labels[] = sprintf('%02d:00', $row->hour);
-                $daily_counts[] = (int) $row->count;
-            }
-        }
+		// Today's assignment counts by hour
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; report query has no user-supplied SQL fragments.
+		$hour_results = $wpdb->get_results( "SELECT HOUR(assigned_at) AS hour, COUNT(*) AS count FROM $table WHERE assigned_at >= CURDATE() GROUP BY HOUR(assigned_at) ORDER BY hour" );
+		$daily_labels = [];
+		$daily_counts = [];
+		if ( $hour_results ) {
+			foreach ( $hour_results as $row ) {
+				$daily_labels[] = sprintf( '%02d:00', $row->hour );
+				$daily_counts[] = (int) $row->count;
+			}
+		}
 
-        return [
-            'labels'       => $labels,
-            'counts'       => $counts,
-            'daily_labels' => $daily_labels,
-            'daily_counts' => $daily_counts,
-            'ajax_url'     => admin_url('admin-ajax.php'),
-            'nonce'        => wp_create_nonce('kerbcycle_qr_report_nonce'),
-        ];
-    }
+		return [
+			'labels'       => $labels,
+			'counts'       => $counts,
+			'daily_labels' => $daily_labels,
+			'daily_counts' => $daily_counts,
+			'ajax_url'     => admin_url( 'admin-ajax.php' ),
+			'nonce'        => wp_create_nonce( 'kerbcycle_qr_report_nonce' ),
+		];
+	}
 }


### PR DESCRIPTION
### Motivation
- Resolve PHPCS formatting/spacing findings in `includes/Services/ReportService.php` without changing behavior or public APIs.
- Silence two specific SQL scanner findings about interpolated table names while leaving the two report queries unchanged.
- Keep the change surgical and limited to only the target service file per repository guardrails.

### Description
- Modified only `includes/Services/ReportService.php` to fix ABSPATH guard spacing, class/function brace placement, and function-call/parenthesis spacing to match PHPCS expectations.
- Added exactly two narrow PHPCS suppressions immediately above the flagged queries using the required comment: `// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; report query has no user-supplied SQL fragments.`
- Preserved all report query text and semantics (SELECT/WHERE/GROUP BY/ORDER BY/LIMIT), the table suffix, namespace, class and method names, and the returned data structure.

### Testing
- Ran `git diff --name-only` which reported only `includes/Services/ReportService.php` as changed.
- Ran `php -l includes/Services/ReportService.php` which returned `No syntax errors detected in includes/Services/ReportService.php`.
- Attempted to run `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Services/ReportService.php -s` but `vendor/bin/phpcs` is not available in this environment, so file-specific PHPCS verification is blocked and must be run where PHPCS is installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc42674300832d8ee5c0c8f1908be4)