### PR TITLE
PHPCBF: format Autoloader.php

### DIFF
--- a/includes/Autoloader.php
+++ b/includes/Autoloader.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -11,8 +11,8 @@ if (!defined('ABSPATH')) {
  *
  * @since 1.0.0
  */
-class Autoloader
-{
+class Autoloader {
+
     /**
      * Run autoloader.
      *
@@ -22,9 +22,8 @@ class Autoloader
      * @access public
      * @static
      */
-    public static function run()
-    {
-        spl_autoload_register([__CLASS__, 'autoload']);
+    public static function run() {
+        spl_autoload_register( [ __CLASS__, 'autoload' ] );
     }
 
     /**
@@ -34,8 +33,7 @@ class Autoloader
      *
      * @param string $class The class name.
      */
-    public static function autoload($class)
-    {
+    public static function autoload( $class ) {
         // Project-specific namespace prefix
         $prefix = 'Kerbcycle\\QrCode\\';
 
@@ -43,22 +41,22 @@ class Autoloader
         $base_dir = __DIR__ . '/';
 
         // Does the class use the namespace prefix?
-        $len = strlen($prefix);
-        if (strncmp($prefix, $class, $len) !== 0) {
+        $len = strlen( $prefix );
+        if ( strncmp( $prefix, $class, $len ) !== 0 ) {
             // No, move to the next registered autoloader
             return;
         }
 
         // Get the relative class name
-        $relative_class = substr($class, $len);
+        $relative_class = substr( $class, $len );
 
         // Replace the namespace prefix with the base directory, replace namespace
         // separators with directory separators in the relative class name, append
         // with .php
-        $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+        $file = $base_dir . str_replace( '\\', '/', $relative_class ) . '.php';
 
         // If the file exists, require it
-        if (file_exists($file)) {
+        if ( file_exists( $file ) ) {
             require $file;
         }
     }


### PR DESCRIPTION
## Summary

Controlled one-file PHPCBF formatting cleanup for `includes/Autoloader.php`.

Fixed auto-fixable PHPCS formatting issues only, including:

- ABSPATH guard spacing
- Class/method opening brace placement
- Function signature spacing
- Function call spacing
- Array shorthand spacing
- String/concatenation spacing

## Scope / No drift

No behavior changes intended or introduced.

Confirmed no changes to:

- Autoload mapping
- Namespace checks
- File path construction
- `require_once` behavior
- Method names
- Class name
- Public API identifiers
- Code paths or conditions

## Deferred finding

The remaining `$class` parameter-name warning is intentionally deferred. `$class` is standard/readable in autoloader callbacks, and renaming it is not part of this formatting-only pass.

## Validation

- `php -l includes/Autoloader.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Autoloader.php -s`

Expected PHPCS result:

- 0 errors
- 1 intentionally deferred warning for `Universal.NamingConventions.NoReservedKeywordParameterNames.classFound`