### PR TITLE
PHPCS cleanup: IntegrationsPage formatting and text domain

### DIFF
--- a/includes/Admin/Pages/IntegrationsPage.php
+++ b/includes/Admin/Pages/IntegrationsPage.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode\Admin\Pages;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -15,33 +15,31 @@ use Kerbcycle\QrCode\Services\IntegrationsService;
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Admin\Pages
  */
-class IntegrationsPage
-{
+class IntegrationsPage {
     /**
      * Render the integrations page.
      *
      * @since    1.0.0
      */
-    public function render()
-    {
+    public function render() {
         $summaries = IntegrationsService::get_summaries();
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e('Plugin Integrations', 'kerbcycle'); ?></h1>
+            <h1><?php esc_html_e( 'Plugin Integrations', 'kerbcycle-qr-code-manager' ); ?></h1>
             <table class="wp-list-table widefat fixed striped">
                 <thead>
                     <tr>
-                        <th><?php esc_html_e('Plugin', 'kerbcycle'); ?></th>
-                        <th><?php esc_html_e('Status', 'kerbcycle'); ?></th>
-                        <th><?php esc_html_e('Summary', 'kerbcycle'); ?></th>
+                        <th><?php esc_html_e( 'Plugin', 'kerbcycle-qr-code-manager' ); ?></th>
+                        <th><?php esc_html_e( 'Status', 'kerbcycle-qr-code-manager' ); ?></th>
+                        <th><?php esc_html_e( 'Summary', 'kerbcycle-qr-code-manager' ); ?></th>
                     </tr>
                 </thead>
                 <tbody>
                     <?php foreach ($summaries as $summary) : ?>
                         <tr>
-                            <td><?php echo esc_html($summary['name']); ?></td>
-                            <td><?php echo $summary['active'] ? esc_html__('Active', 'kerbcycle') : esc_html__('Inactive', 'kerbcycle'); ?></td>
-                            <td><?php echo esc_html($summary['summary']); ?></td>
+                            <td><?php echo esc_html( $summary['name'] ); ?></td>
+                            <td><?php echo $summary['active'] ? esc_html__( 'Active', 'kerbcycle-qr-code-manager' ) : esc_html__( 'Inactive', 'kerbcycle-qr-code-manager' ); ?></td>
+                            <td><?php echo esc_html( $summary['summary'] ); ?></td>
                         </tr>
                     <?php endforeach; ?>
                 </tbody>

--- a/includes/Admin/Pages/IntegrationsPage.php
+++ b/includes/Admin/Pages/IntegrationsPage.php
@@ -35,7 +35,7 @@ class IntegrationsPage {
                     </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ($summaries as $summary) : ?>
+                    <?php foreach ( $summaries as $summary ) : ?>
                         <tr>
                             <td><?php echo esc_html( $summary['name'] ); ?></td>
                             <td><?php echo $summary['active'] ? esc_html__( 'Active', 'kerbcycle-qr-code-manager' ) : esc_html__( 'Inactive', 'kerbcycle-qr-code-manager' ); ?></td>


### PR DESCRIPTION
### Motivation
- Fix file-specific PHPCS issues and a text-domain mismatch in the Integrations admin page without changing any runtime behavior or visible strings.

### Description
- Edited only `includes/Admin/Pages/IntegrationsPage.php` to correct ABSPATH guard spacing, move the `IntegrationsPage` class and `render()` function opening braces to the same line, fix function-call parenthesis spacing on the reported lines, and replace text-domain arguments from `'kerbcycle'` to `'kerbcycle-qr-code-manager'` while preserving all visible string text and HTML structure.
- No namespace, class name, method name, hook, capability, nonce, or integration behavior changes were made and no other files were modified.

### Testing
- Ran `git diff --name-only` which returned `includes/Admin/Pages/IntegrationsPage.php` confirming only the target file changed.
- Ran `php -l includes/Admin/Pages/IntegrationsPage.php` which returned `No syntax errors detected in includes/Admin/Pages/IntegrationsPage.php`.
- Attempted `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Admin/Pages/IntegrationsPage.php -s` but `vendor/bin/phpcs` was not present in the environment, so file-specific PHPCS validation is blocked and must be run in CI/Codespace before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc552dfbbc832d9eac06c7a416d6bb)