### PR TITLE
PHPCS pass 3B.15A: cleanup EmailService formatting, text domain, and short ternary

### DIFF
--- a/includes/Services/EmailService.php
+++ b/includes/Services/EmailService.php
@@ -28,7 +28,7 @@ class EmailService {
 	 * @return bool|\WP_Error True on success, WP_Error on failure.
 	 */
 	public function send_notification( $user_id, $qr_code, $type = 'assigned', array $vars = [] ) {
-		$user = get_userdata($user_id);
+		$user = get_userdata( $user_id );
 		if ( ! $user || empty( $user->user_email ) ) {
 			return new \WP_Error( 'email_config', __( 'Missing user email', 'kerbcycle-qr-code-manager' ) );
 		}
@@ -41,10 +41,10 @@ class EmailService {
 			$vars
 		);
 
-		$rendered = MessagesService::render($type, $vars);
+		$rendered = MessagesService::render( $type, $vars );
 
-		$subject = 'KerbCycle: ' . ucfirst($type);
-		$sent    = wp_mail($user->user_email, $subject, $rendered['email']);
+		$subject = 'KerbCycle: ' . ucfirst( $type );
+		$sent    = wp_mail( $user->user_email, $subject, $rendered['email'] );
 
 		if ( ! $sent ) {
 			return new \WP_Error( 'email_send', __( 'Failed to send email', 'kerbcycle-qr-code-manager' ) );

--- a/includes/Services/EmailService.php
+++ b/includes/Services/EmailService.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode\Services;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
@@ -16,8 +16,7 @@ use Kerbcycle\QrCode\Data\Repositories\MessageLogRepository;
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Services
  */
-class EmailService
-{
+class EmailService {
 	/**
 	 * Send a notification email.
 	 *
@@ -28,16 +27,15 @@ class EmailService
 	 *
 	 * @return bool|\WP_Error True on success, WP_Error on failure.
 	 */
-	public function send_notification($user_id, $qr_code, $type = 'assigned', array $vars = [])
-	{
+	public function send_notification( $user_id, $qr_code, $type = 'assigned', array $vars = [] ) {
 		$user = get_userdata($user_id);
-		if (!$user || empty($user->user_email)) {
-			return new \WP_Error('email_config', __('Missing user email', 'kerbcycle'));
+		if ( ! $user || empty( $user->user_email ) ) {
+			return new \WP_Error( 'email_config', __( 'Missing user email', 'kerbcycle-qr-code-manager' ) );
 		}
 
 		$vars = array_merge(
 			[
-				'user' => $user->display_name ?: $user->user_login,
+				'user' => $user->display_name ? $user->display_name : $user->user_login,
 				'code' => $qr_code,
 			],
 			$vars
@@ -48,8 +46,8 @@ class EmailService
 		$subject = 'KerbCycle: ' . ucfirst($type);
 		$sent    = wp_mail($user->user_email, $subject, $rendered['email']);
 
-		if (!$sent) {
-			return new \WP_Error('email_send', __('Failed to send email', 'kerbcycle'));
+		if ( ! $sent ) {
+			return new \WP_Error( 'email_send', __( 'Failed to send email', 'kerbcycle-qr-code-manager' ) );
 		}
 
 		// Log the email.


### PR DESCRIPTION
### Motivation
- Fix file-specific PHPCS findings in `includes/Services/EmailService.php` (spacing/brace placement, text-domain mismatches, and a short ternary) without changing email behavior or visible strings.

### Description
- Adjusted ABSPATH guard spacing, moved class/function opening braces to the same line, normalized function declaration/call spacing, replaced text-domain arguments from `'kerbcycle'` to `'kerbcycle-qr-code-manager'`, and expanded the short ternary to an explicit equivalent; only `includes/Services/EmailService.php` was modified and all visible text and `wp_mail()` behaviour were preserved.

### Testing
- Ran `git diff --name-only` which returned `includes/Services/EmailService.php` confirming only the target file changed.
- Ran `php -l includes/Services/EmailService.php` which returned `No syntax errors detected in includes/Services/EmailService.php`.
- Attempted `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Services/EmailService.php -s` but it is blocked in this environment because `vendor/bin/phpcs` is not present; PHPCS must be run in the CI/Codespace environment to confirm file-level linting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5eab85e0832d90015f9af92c877e)