### PR TITLE
PHPCS cleanup: AiSettingsService formatting and explicit ternaries

### DIFF
--- a/includes/Services/AiSettingsService.php
+++ b/includes/Services/AiSettingsService.php
@@ -24,11 +24,11 @@ class AiSettingsService {
      */
 	public static function defaults() {
 		return array(
-			'env'              => 'dev',
-			'webhook_url_dev'  => '',
+			'env'               => 'dev',
+			'webhook_url_dev'   => '',
 			'webhook_url_stage' => '',
-			'webhook_url_prod' => '',
-			'timeout'          => 20,
+			'webhook_url_prod'  => '',
+			'timeout'           => 20,
 		);
 	}
 

--- a/includes/Services/AiSettingsService.php
+++ b/includes/Services/AiSettingsService.php
@@ -2,68 +2,63 @@
 
 namespace Kerbcycle\QrCode\Services;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 /**
  * Centralized service for managing AI webhook settings.
  */
-class AiSettingsService
-{
-    private const OPTION_KEY = 'kerbcycle_ai_webhook_options';
+class AiSettingsService {
+	private const OPTION_KEY = 'kerbcycle_ai_webhook_options';
 
     /**
      * Retrieve stored options merged with defaults.
      */
-    public static function get_options()
-    {
-        return wp_parse_args(get_option(self::OPTION_KEY, []), self::defaults());
-    }
+	public static function get_options() {
+		return wp_parse_args( get_option( self::OPTION_KEY, array() ), self::defaults() );
+	}
 
     /**
      * Provide default option values.
      */
-    public static function defaults()
-    {
-        return [
-            'env'                  => 'dev',
-            'webhook_url_dev'      => '',
-            'webhook_url_stage'    => '',
-            'webhook_url_prod'     => '',
-            'timeout'              => 20,
-        ];
-    }
+	public static function defaults() {
+		return array(
+			'env'              => 'dev',
+			'webhook_url_dev'  => '',
+			'webhook_url_stage' => '',
+			'webhook_url_prod' => '',
+			'timeout'          => 20,
+		);
+	}
 
     /**
      * Determine the active webhook URL based on selected environment.
      */
-    public static function current_webhook_url($options = null)
-    {
-        $options = $options ?: self::get_options();
-        $environment = $options['env'];
-        $map = [
-            'dev'   => $options['webhook_url_dev'],
-            'stage' => $options['webhook_url_stage'],
-            'prod'  => $options['webhook_url_prod'],
-        ];
+	public static function current_webhook_url( $options = null ) {
+		$options     = $options ? $options : self::get_options();
+		$environment = $options['env'];
+		$map         = array(
+			'dev'   => $options['webhook_url_dev'],
+			'stage' => $options['webhook_url_stage'],
+			'prod'  => $options['webhook_url_prod'],
+		);
 
-        $url = isset($map[$environment]) ? trim((string) $map[$environment]) : '';
+		$url = isset( $map[ $environment ] ) ? trim( (string) $map[ $environment ] ) : '';
 
         /**
          * Filter the resolved pickup exception webhook URL.
          */
-        return apply_filters('kerbcycle/ai/pickup_exception_webhook_url', $url, $options);
-    }
+		return apply_filters( 'kerbcycle/ai/pickup_exception_webhook_url', $url, $options );
+	}
 
     /**
      * Determine the configured timeout.
      */
-    public static function current_timeout($options = null)
-    {
-        $options = $options ?: self::get_options();
-        $timeout = isset($options['timeout']) ? (int) $options['timeout'] : 20;
+	public static function current_timeout( $options = null ) {
+		$options = $options ? $options : self::get_options();
+		$timeout = isset( $options['timeout'] ) ? (int) $options['timeout'] : 20;
 
-        return max(1, min(60, $timeout));
-    }
+		return max( 1, min( 60, $timeout ) );
+	}
 }


### PR DESCRIPTION
### Motivation
- Reduce file-specific PHPCS violations in `includes/Services/AiSettingsService.php` by fixing spacing, brace placement, alignment, and short-ternary usage while preserving runtime behavior and compatibility.
- Keep hook-name and public API unchanged to avoid breaking integrations and defer that naming warning to a separate compatibility pass.

### Description
- Fixed ABSPATH guard spacing and normalized class and function opening-brace placement without changing class/namespace/method names.
- Adjusted function declaration/call spacing, array key spacing, cast spacing, and alignment of array entries and assignments to satisfy PHPCS formatting rules.
- Replaced the two short ternaries (`$options = $options ?: self::get_options();`) with explicit equivalent expressions (`$options = $options ? $options : self::get_options();`) while preserving truthiness and fallback behavior.
- Only modified `includes/Services/AiSettingsService.php` and left the filter name `kerbcycle/ai/pickup_exception_webhook_url` and all option keys/defaults unchanged.

### Testing
- Ran `git diff --name-only` which reported only `includes/Services/AiSettingsService.php` as changed.
- Ran `php -l includes/Services/AiSettingsService.php` which returned `No syntax errors detected in includes/Services/AiSettingsService.php`.
- Attempted `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Services/AiSettingsService.php -s` but it could not be executed in this environment because `vendor/bin/phpcs` is not present, so final PHPCS verification is blocked and must be run in CI/Codespace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc64df1644832d9d46a45651e46c26)