### PR TITLE
PHPCBF: format kerbcycle-qr-code-manager.php

### DIFF
--- a/kerbcycle-qr-code-manager.php
+++ b/kerbcycle-qr-code-manager.php
@@ -9,24 +9,24 @@ Text Domain: kerbcycle
 */
 
 // Prevent direct access
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
 // Define plugin URL constant
-if (!defined('KERBCYCLE_QR_URL')) {
-    define('KERBCYCLE_QR_URL', plugin_dir_url(__FILE__));
+if ( ! defined( 'KERBCYCLE_QR_URL' ) ) {
+    define( 'KERBCYCLE_QR_URL', plugin_dir_url( __FILE__ ) );
 }
 
 // Define plugin PATH constant
-if (!defined('KERBCYCLE_QR_PATH')) {
-    define('KERBCYCLE_QR_PATH', plugin_dir_path(__FILE__));
+if ( ! defined( 'KERBCYCLE_QR_PATH' ) ) {
+    define( 'KERBCYCLE_QR_PATH', plugin_dir_path( __FILE__ ) );
 }
 
 // Define plugin version constant
-if (!defined('KERBCYCLE_QR_VERSION')) {
+if ( ! defined( 'KERBCYCLE_QR_VERSION' ) ) {
     // bump to bust cached CSS/JS after compact layout changes
-    define('KERBCYCLE_QR_VERSION', '2.0.3');
+    define( 'KERBCYCLE_QR_VERSION', '2.0.3' );
 }
 
 // Require the autoloader
@@ -40,8 +40,7 @@ require_once KERBCYCLE_QR_PATH . 'includes/Autoloader.php';
  *
  * @return \Kerbcycle\QrCode\Plugin
  */
-function kerbcycle_qr_code_manager()
-{
+function kerbcycle_qr_code_manager() {
     return \Kerbcycle\QrCode\Plugin::instance();
 }
 
@@ -49,5 +48,5 @@ function kerbcycle_qr_code_manager()
 kerbcycle_qr_code_manager();
 
 // Activation/Deactivation hooks
-register_activation_hook(__FILE__, ['\\Kerbcycle\\QrCode\\Install\\Activator', 'activate']);
-register_deactivation_hook(__FILE__, ['\\Kerbcycle\\QrCode\\Install\\Uninstaller', 'deactivate']);
+register_activation_hook( __FILE__, [ '\\Kerbcycle\\QrCode\\Install\\Activator', 'activate' ] );
+register_deactivation_hook( __FILE__, [ '\\Kerbcycle\\QrCode\\Install\\Uninstaller', 'deactivate' ] );


### PR DESCRIPTION
## Summary

Controlled one-file PHPCBF formatting cleanup for `kerbcycle-qr-code-manager.php`.

Fixed auto-fixable PHPCS formatting issues only, including:

- Constant/ABSPATH guard spacing
- Function call spacing
- Function opening brace placement
- Single-line array spacing

## Scope / No drift

No behavior changes intended or introduced.

Confirmed no changes to:

- Plugin constants or values
- Plugin version
- Plugin path/URL definitions
- Activation/deactivation hook behavior
- Autoloader include path
- Plugin boot sequence
- Function names
- Runtime logic

## Validation

- `git diff --name-only`
- `git --no-pager diff -- kerbcycle-qr-code-manager.php`
- `php -l kerbcycle-qr-code-manager.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist kerbcycle-qr-code-manager.php -s`

Expected PHPCS result:

- 0 errors
- 0 warnings