### PR TITLE
PHPCS formatting cleanup and nonce audit for includes/Admin/Notices.php

### DIFF
--- a/includes/Admin/Notices.php
+++ b/includes/Admin/Notices.php
@@ -52,7 +52,7 @@ class Notices {
 		$sanitized_message = \wp_kses_post( $message );
 		$page              = $args['page'];
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only admin notice state used for logging context; no server-side state is changed here.
-		if ( '' === $page && isset( $_GET['page'] ) ) {			
+		if ( '' === $page && isset( $_GET['page'] ) ) {
 			$page = \sanitize_text_field( \wp_unslash( $_GET['page'] ) );
 		}
 

--- a/includes/Admin/Notices.php
+++ b/includes/Admin/Notices.php
@@ -51,8 +51,8 @@ class Notices {
 
 		$sanitized_message = \wp_kses_post( $message );
 		$page              = $args['page'];
-		if ( '' === $page && isset( $_GET['page'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only admin notice state used for logging context; no server-side state is changed here.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only admin notice state used for logging context; no server-side state is changed here.
+		if ( '' === $page && isset( $_GET['page'] ) ) {			
 			$page = \sanitize_text_field( \wp_unslash( $_GET['page'] ) );
 		}
 

--- a/includes/Admin/Notices.php
+++ b/includes/Admin/Notices.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Admin;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 use Kerbcycle\QrCode\Data\Repositories\ErrorLogRepository;
@@ -11,76 +11,77 @@ use Kerbcycle\QrCode\Data\Repositories\ErrorLogRepository;
 /**
  * Helper for rendering admin notices and logging them to the Kerbcycle log table.
  */
-class Notices
-{
-    /**
-     * Render an admin notice and persist it to the error log repository.
-     *
-     * @param string $notice_type WordPress notice type (success, error, warning, info).
-     * @param string $message     The HTML message to display inside the notice.
-     * @param array  $args        Optional arguments.
-     *
-     * @return string Rendered HTML for the notice.
-     */
-    public static function add($notice_type, $message, array $args = [])
-    {
-        $defaults = [
-            'dismissible'   => false,
-            'log_type'      => '',
-            'page'          => '',
-            'status'        => null,
-            'echo'          => true,
-            'extra_classes' => [],
-        ];
+class Notices {
+	/**
+	 * Render an admin notice and persist it to the error log repository.
+	 *
+	 * @param string $notice_type WordPress notice type (success, error, warning, info).
+	 * @param string $message     The HTML message to display inside the notice.
+	 * @param array  $args        Optional arguments.
+	 *
+	 * @return string Rendered HTML for the notice.
+	 */
+	public static function add( $notice_type, $message, array $args = array() ) {
+		$defaults = array(
+			'dismissible'   => false,
+			'log_type'      => '',
+			'page'          => '',
+			'status'        => null,
+			'echo'          => true,
+			'extra_classes' => array(),
+		);
 
-        $args = \wp_parse_args($args, $defaults);
+		$args = \wp_parse_args( $args, $defaults );
 
-        $notice_type = is_string($notice_type) ? strtolower($notice_type) : 'info';
-        $classes = ['notice', 'notice-' . $notice_type];
-        if (!empty($args['dismissible'])) {
-            $classes[] = 'is-dismissible';
-        }
+		$notice_type = is_string( $notice_type ) ? strtolower( $notice_type ) : 'info';
+		$classes     = array( 'notice', 'notice-' . $notice_type );
+		if ( ! empty( $args['dismissible'] ) ) {
+			$classes[] = 'is-dismissible';
+		}
 
-        $extra_classes = $args['extra_classes'];
-        if (!is_array($extra_classes)) {
-            $extra_classes = $extra_classes ? [$extra_classes] : [];
-        }
-        foreach ($extra_classes as $extra_class) {
-            if (is_string($extra_class) && $extra_class !== '') {
-                $classes[] = \sanitize_html_class($extra_class);
-            }
-        }
+		$extra_classes = $args['extra_classes'];
+		if ( ! is_array( $extra_classes ) ) {
+			$extra_classes = $extra_classes ? array( $extra_classes ) : array();
+		}
+		foreach ( $extra_classes as $extra_class ) {
+			if ( is_string( $extra_class ) && '' !== $extra_class ) {
+				$classes[] = \sanitize_html_class( $extra_class );
+			}
+		}
 
-        $sanitized_message = \wp_kses_post($message);
-        $page = $args['page'];
-        if ($page === '' && isset($_GET['page'])) {
-            $page = \sanitize_text_field(\wp_unslash($_GET['page']));
-        }
+		$sanitized_message = \wp_kses_post( $message );
+		$page              = $args['page'];
+		if ( '' === $page && isset( $_GET['page'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only admin notice state used for logging context; no server-side state is changed here.
+			$page = \sanitize_text_field( \wp_unslash( $_GET['page'] ) );
+		}
 
-        $status = $args['status'];
-        if ($status === null) {
-            $status = ($notice_type === 'success') ? 'success' : 'failure';
-        }
+		$status = $args['status'];
+		if ( null === $status ) {
+			$status = ( 'success' === $notice_type ) ? 'success' : 'failure';
+		}
 
-        $log_type = $args['log_type'] !== '' ? $args['log_type'] : $notice_type;
+		$log_type = '' !== $args['log_type'] ? $args['log_type'] : $notice_type;
 
-        ErrorLogRepository::log([
-            'type'    => $log_type,
-            'message' => $sanitized_message,
-            'page'    => $page,
-            'status'  => $status,
-        ]);
+		ErrorLogRepository::log(
+			array(
+				'type'    => $log_type,
+				'message' => $sanitized_message,
+				'page'    => $page,
+				'status'  => $status,
+			)
+		);
 
-        $html = \sprintf(
-            '<div class="%1$s"><p>%2$s</p></div>',
-            \esc_attr(\implode(' ', \array_filter($classes))),
-            $sanitized_message
-        );
+		$html = \sprintf(
+			'<div class="%1$s"><p>%2$s</p></div>',
+			\esc_attr( \implode( ' ', \array_filter( $classes ) ) ),
+			$sanitized_message
+		);
 
-        if (!empty($args['echo'])) {
-            echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        }
+		if ( ! empty( $args['echo'] ) ) {
+			echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
 
-        return $html;
-    }
+		return $html;
+	}
 }


### PR DESCRIPTION
### Motivation
- Address file-scoped PHPCS formatting and spacing issues in `includes/Admin/Notices.php` while preserving existing notice behavior and strings.
- Audit the two nonce/form-data warnings flagged around the `$_GET['page']` read and resolve them appropriately without introducing state-change logic.

### Description
- Applied stylistic PHPCS-equivalent fixes only inside `includes/Admin/Notices.php` (ABSPATH guard spacing, class/method brace placement, function call/parenthesis spacing, array formatting, assignment alignment, and multi-line call formatting). 
- Retained and kept `sanitize_text_field( wp_unslash( $_GET['page'] ) )` for the `page` context value and added a narrow inline PHPCS suppression with an explicit justification because the `$_GET['page']` read is used only as read-only notice/logging context and does not change server state. 
- Kept existing sanitization, logging call to `ErrorLogRepository::log`, echo behavior, notice text, dismiss semantics, hooks, capability logic, and request parameter names unchanged. 
- Only `includes/Admin/Notices.php` was modified.

### Testing
- Verified changed file list with `git diff --name-only`, which returned `includes/Admin/Notices.php` only. (Success.)
- Verified PHP syntax with `php -l includes/Admin/Notices.php`, which returned `No syntax errors detected in includes/Admin/Notices.php`. (Success.)
- Attempted PHPCS check with `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Admin/Notices.php -s`, but `vendor/bin/phpcs` is not present in this environment, so PHPCS validation is blocked here and must be run in the CI/Codespace environment before merge. (Blocked.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd465fd878832d90a5f3ead8f4ade7)