### PR TITLE
Fix IntegrationsService PHPCS formatting and i18n domain mismatches

### DIFF
--- a/includes/Services/IntegrationsService.php
+++ b/includes/Services/IntegrationsService.php
@@ -3,20 +3,18 @@
 namespace Kerbcycle\QrCode\Services;
 
 // Handle third-party plugin integrations and summaries
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-class IntegrationsService
-{
-    public static function get_summaries()
-    {
+class IntegrationsService {
+    public static function get_summaries() {
         $user_id   = get_current_user_id();
         $summaries = array();
 
         // Bookly - scheduling pickups
-        $bookly_active  = class_exists('Bookly\\Lib\\Plugin') || defined('BOOKLY_VERSION');
-        $bookly_summary = $bookly_active ? __('Bookly active. Schedule pickups through Bookly.', 'kerbcycle') : __('Bookly inactive.', 'kerbcycle');
+        $bookly_active  = class_exists( 'Bookly\\Lib\\Plugin' ) || defined( 'BOOKLY_VERSION' );
+        $bookly_summary = $bookly_active ? __( 'Bookly active. Schedule pickups through Bookly.', 'kerbcycle-qr-code-manager' ) : __( 'Bookly inactive.', 'kerbcycle-qr-code-manager' );
         $summaries[]    = array(
             'name'    => 'Bookly',
             'active'  => $bookly_active,
@@ -24,8 +22,8 @@ class IntegrationsService
         );
 
         // Ultimate Member - customer portal
-        $um_active  = function_exists('um_user') || class_exists('UM');
-        $um_summary = $um_active ? __('Ultimate Member active. Customer portal available.', 'kerbcycle') : __('Ultimate Member inactive.', 'kerbcycle');
+        $um_active   = function_exists( 'um_user' ) || class_exists( 'UM' );
+        $um_summary  = $um_active ? __( 'Ultimate Member active. Customer portal available.', 'kerbcycle-qr-code-manager' ) : __( 'Ultimate Member inactive.', 'kerbcycle-qr-code-manager' );
         $summaries[] = array(
             'name'    => 'Ultimate Member',
             'active'  => $um_active,
@@ -33,8 +31,8 @@ class IntegrationsService
         );
 
         // WooCommerce - payments
-        $wc_active  = class_exists('WooCommerce');
-        $wc_summary = $wc_active ? __('WooCommerce active. Payments enabled.', 'kerbcycle') : __('WooCommerce inactive.', 'kerbcycle');
+        $wc_active   = class_exists( 'WooCommerce' );
+        $wc_summary  = $wc_active ? __( 'WooCommerce active. Payments enabled.', 'kerbcycle-qr-code-manager' ) : __( 'WooCommerce inactive.', 'kerbcycle-qr-code-manager' );
         $summaries[] = array(
             'name'    => 'WooCommerce',
             'active'  => $wc_active,
@@ -42,20 +40,21 @@ class IntegrationsService
         );
 
         // TeraWallet - customer balance
-        $wallet_active = function_exists('woo_wallet') || class_exists('Woo_Wallet');
+        $wallet_active = function_exists( 'woo_wallet' ) || class_exists( 'Woo_Wallet' );
         $balance       = '';
-        if ($wallet_active && $wc_active && function_exists('woo_wallet')) {
+        if ( $wallet_active && $wc_active && function_exists( 'woo_wallet' ) ) {
             $wallet = woo_wallet();
-            if (isset($wallet->wallet) && method_exists($wallet->wallet, 'get_wallet_balance')) {
-                $balance_raw = $wallet->wallet->get_wallet_balance($user_id, 'edit');
-                if (function_exists('wc_price')) {
-                    $balance = wc_price($balance_raw);
+            if ( isset( $wallet->wallet ) && method_exists( $wallet->wallet, 'get_wallet_balance' ) ) {
+                $balance_raw = $wallet->wallet->get_wallet_balance( $user_id, 'edit' );
+                if ( function_exists( 'wc_price' ) ) {
+                    $balance = wc_price( $balance_raw );
                 } else {
                     $balance = $balance_raw;
                 }
             }
         }
-        $wallet_summary = $wallet_active ? sprintf(__('Wallet balance: %s', 'kerbcycle'), $balance !== '' ? $balance : __('N/A', 'kerbcycle')) : __('TeraWallet inactive.', 'kerbcycle');
+        /* translators: %s: wallet balance amount or N/A fallback text. */
+        $wallet_summary = $wallet_active ? sprintf( __( 'Wallet balance: %s', 'kerbcycle-qr-code-manager' ), $balance !== '' ? $balance : __( 'N/A', 'kerbcycle-qr-code-manager' ) ) : __( 'TeraWallet inactive.', 'kerbcycle-qr-code-manager' );
         $summaries[]    = array(
             'name'    => 'TeraWallet',
             'active'  => $wallet_active,
@@ -63,8 +62,8 @@ class IntegrationsService
         );
 
         // WP SMS - messaging
-        $sms_active  = class_exists('WP_SMS') || defined('WP_SMS_VERSION');
-        $sms_summary = $sms_active ? __('WP SMS active. SMS notifications available.', 'kerbcycle') : __('WP SMS inactive.', 'kerbcycle');
+        $sms_active   = class_exists( 'WP_SMS' ) || defined( 'WP_SMS_VERSION' );
+        $sms_summary  = $sms_active ? __( 'WP SMS active. SMS notifications available.', 'kerbcycle-qr-code-manager' ) : __( 'WP SMS inactive.', 'kerbcycle-qr-code-manager' );
         $summaries[] = array(
             'name'    => 'WP SMS',
             'active'  => $sms_active,

--- a/includes/Services/IntegrationsService.php
+++ b/includes/Services/IntegrationsService.php
@@ -62,8 +62,8 @@ class IntegrationsService {
         );
 
         // WP SMS - messaging
-        $sms_active   = class_exists( 'WP_SMS' ) || defined( 'WP_SMS_VERSION' );
-        $sms_summary  = $sms_active ? __( 'WP SMS active. SMS notifications available.', 'kerbcycle-qr-code-manager' ) : __( 'WP SMS inactive.', 'kerbcycle-qr-code-manager' );
+        $sms_active  = class_exists( 'WP_SMS' ) || defined( 'WP_SMS_VERSION' );
+        $sms_summary = $sms_active ? __( 'WP SMS active. SMS notifications available.', 'kerbcycle-qr-code-manager' ) : __( 'WP SMS inactive.', 'kerbcycle-qr-code-manager' );
         $summaries[] = array(
             'name'    => 'WP SMS',
             'active'  => $sms_active,


### PR DESCRIPTION
### Motivation
- Resolve PHPCS formatting and i18n text-domain issues flagged in `includes/Services/IntegrationsService.php` while preserving existing integration behavior and visible strings.
- Make minimal, file-scoped edits so the service continues to behave identically but meets the repository's style and translation expectations.

### Description
- Fixed ABSPATH guard spacing and moved class/function opening braces to K&R style for `IntegrationsService::get_summaries()` in `includes/Services/IntegrationsService.php`.
- Normalized function-call spacing, control-structure spacing, and assignment alignment across the file where PHPCS flagged issues.
- Replaced text-domain arguments in this file from `'kerbcycle'` to `'kerbcycle-qr-code-manager'` without changing any translated string text.
- Added a `/* translators: ... */` comment immediately above the `sprintf()` wallet balance translation to explain the `%s` placeholder.

### Testing
- Ran `git diff --name-only` which shows only `includes/Services/IntegrationsService.php` was modified.
- Ran `php -l includes/Services/IntegrationsService.php` which returned `No syntax errors detected in includes/Services/IntegrationsService.php`.
- Attempted to run `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Services/IntegrationsService.php -s` but `vendor/bin/phpcs` is not present in this environment so file-specific PHPCS validation is blocked and must be verified in CI/Codespace before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd591c83c8832daddfa99a7d966521)