### PR TITLE
PHPCS: Admin.php formatting cleanup and nonce/form-data audit

### DIFF
--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Admin;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 use Kerbcycle\QrCode\Data\Repositories\ErrorLogRepository;
@@ -15,200 +15,197 @@ use Kerbcycle\QrCode\Data\Repositories\ErrorLogRepository;
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Admin
  */
-class Admin
-{
+class Admin {
     /**
      * Initialize the class and set its properties.
      *
      * @since    1.0.0
      */
-    public function __construct()
-    {
-        add_action('admin_menu', [$this, 'register_admin_menu']);
-        add_action('admin_notices', [$this, 'capture_admin_notices'], 0);
-    }
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_admin_menu' ) );
+		add_action( 'admin_notices', array( $this, 'capture_admin_notices' ), 0 );
+	}
 
     /**
      * Register the administration menu for this plugin into the WordPress Dashboard menu.
      *
      * @since    1.0.0
      */
-    public function register_admin_menu()
-    {
-        add_menu_page(
-            'QR Code Manager',
-            'QR Codes',
-            'manage_options',
-            'kerbcycle-qr-manager',
-            [new Pages\DashboardPage(), 'render'],
-            'dashicons-admin-generic',
-            20
-        );
+	public function register_admin_menu() {
+		add_menu_page(
+			'QR Code Manager',
+			'QR Codes',
+			'manage_options',
+			'kerbcycle-qr-manager',
+			array( new Pages\DashboardPage(), 'render' ),
+			'dashicons-admin-generic',
+			20
+		);
 
-        add_submenu_page(
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'QR Code History',
             'QR Code History',
             'manage_options',
             'kerbcycle-qr-history',
-            [new Pages\HistoryPage(), 'render']
-        );
+			array( new Pages\HistoryPage(), 'render' )
+		);
 
-        add_submenu_page(
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'Messages History',
             'Messages History',
             'manage_options',
             'kerbcycle-messages-history',
-            [new Pages\MessagesHistoryPage(), 'render']
-        );
+			array( new Pages\MessagesHistoryPage(), 'render' )
+		);
 
-        add_submenu_page(
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'QR Code Reports',
             'QR Code Reports',
             'manage_options',
             'kerbcycle-qr-reports',
-            [new Pages\ReportsPage(), 'render']
-        );
+			array( new Pages\ReportsPage(), 'render' )
+		);
 
-        $generator = Pages\GeneratorPage::instance();
-        add_submenu_page(
+		$generator = Pages\GeneratorPage::instance();
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'QR Code Generator',
             'QR Code Generate',
             'manage_options',
             'kerbcycle-qr-generator',
-            [$generator, 'render']
-        );
+			array( $generator, 'render' )
+		);
 
         // Shortcut to Bookly appointments if Bookly is active
-        $bookly_active = class_exists('Bookly\\Lib\\Plugin') || defined('BOOKLY_VERSION');
-        if ($bookly_active) {
-            add_submenu_page(
+		$bookly_active = class_exists( 'Bookly\\Lib\\Plugin' ) || defined( 'BOOKLY_VERSION' );
+		if ( $bookly_active ) {
+			add_submenu_page(
                 'kerbcycle-qr-manager',
                 'Pickup Schedule',
                 'Pickup Schedule',
                 'manage_options',
                 'kerbcycle-bookly-appointments',
-                [new Pages\RedirectsPage(), 'bookly_appointments']
-            );
-        }
+				array( new Pages\RedirectsPage(), 'bookly_appointments' )
+			);
+		}
 
         // Shortcut to TeraWallet user wallets if TeraWallet is active
-        $wallet_active = function_exists('woo_wallet') || class_exists('Woo_Wallet');
-        if ($wallet_active) {
-            add_submenu_page(
+		$wallet_active = function_exists( 'woo_wallet' ) || class_exists( 'Woo_Wallet' );
+		if ( $wallet_active ) {
+			add_submenu_page(
                 'kerbcycle-qr-manager',
                 'Customer Wallet',
                 'Customer Wallet',
                 'manage_options',
                 'kerbcycle-terawallet',
-                [new Pages\RedirectsPage(), 'terawallet']
-            );
-        }
+				array( new Pages\RedirectsPage(), 'terawallet' )
+			);
+		}
 
-        add_submenu_page(
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'Errors',
             'Errors',
             'manage_options',
             'kerbcycle-errors',
-            [new Pages\ErrorsPage(), 'render']
-        );
-
-
-        add_submenu_page(
+			array( new Pages\ErrorsPage(), 'render' )
+		);
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'Pickup Exceptions',
             'Pickup Exceptions',
             'manage_options',
             'kerbcycle-pickup-exceptions',
-            [new Pages\PickupExceptionsPage(), 'render']
-        );
+			array( new Pages\PickupExceptionsPage(), 'render' )
+		);
 
-        add_submenu_page(
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'Settings',
             'Settings',
             'manage_options',
             'kerbcycle-qr-settings',
-            [new Pages\SettingsPage(), 'render']
-        );
+			array( new Pages\SettingsPage(), 'render' )
+		);
 
-        add_submenu_page(
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'Message Settings',
             'Message Settings',
             'manage_options',
             'kerbcycle-messages',
-            [new \Kerbcycle\QrCode\Services\MessagesService(), 'render_page']
-        );
+			array( new \Kerbcycle\QrCode\Services\MessagesService(), 'render_page' )
+		);
 
-        add_submenu_page(
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'SMS Settings',
             'SMS Settings',
             'manage_options',
             'kerbcycle-sms',
-            ['\Kerbcycle\QrCode\Services\SmsService', 'render_settings_page']
-        );
-        $routing = Pages\RoutingPage::instance();
-        add_submenu_page(
+			array( '\Kerbcycle\QrCode\Services\SmsService', 'render_settings_page' )
+		);
+		$routing = Pages\RoutingPage::instance();
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'OSRM Settings',
             'Routing',
             'manage_options',
             'kerbcycle-routing',
-            [$routing, 'render']
-        );
+			array( $routing, 'render' )
+		);
 
-        $ai_settings = Pages\AiSettingsPage::instance();
-        add_submenu_page(
+		$ai_settings = Pages\AiSettingsPage::instance();
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'AI Settings',
             'AI Settings',
             'manage_options',
             'kerbcycle-ai-settings',
-            [$ai_settings, 'render']
-        );
+			array( $ai_settings, 'render' )
+		);
 
-        add_submenu_page(
+		add_submenu_page(
             'kerbcycle-qr-manager',
             'Plugin Integrations',
             'Integrations',
             'manage_options',
             'kerbcycle-plugin-integrations',
-            [new Pages\IntegrationsPage(), 'render']
-        );
-    }
+			array( new Pages\IntegrationsPage(), 'render' )
+		);
+	}
 
     /**
      * Capture and log admin notices for plugin pages.
      */
-    public function capture_admin_notices()
-    {
-        $page = isset($_GET['page']) ? sanitize_text_field(wp_unslash($_GET['page'])) : '';
-        if (strpos($page, 'kerbcycle') !== 0) {
-            return;
-        }
+	public function capture_admin_notices() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only admin routing/display context; no server-side state is changed here.
+		$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+		if ( strpos( $page, 'kerbcycle' ) !== 0 ) {
+			return;
+		}
 
-        $errors = get_settings_errors();
-        if (empty($errors)) {
-            return;
-        }
+		$errors = get_settings_errors();
+		if ( empty( $errors ) ) {
+			return;
+		}
 
-        foreach ($errors as $err) {
-            $notice_type = $err['type'] ?? '';
+		foreach ( $errors as $err ) {
+			$notice_type = $err['type'] ?? '';
 
-            ErrorLogRepository::log([
-                'type'   => $err['code'] ?? '',
-                'message' => $err['message'] ?? '',
-                'page'   => $page,
-                'status' => $this->determine_status_from_notice_type($notice_type),
-            ]);
-        }
-    }
+			ErrorLogRepository::log(
+				array(
+					'type'    => $err['code'] ?? '',
+					'message' => $err['message'] ?? '',
+					'page'    => $page,
+					'status'  => $this->determine_status_from_notice_type( $notice_type ),
+				)
+			);
+		}
+	}
 
     /**
      * Map a WordPress notice type to a Kerbcycle log status value.
@@ -221,21 +218,20 @@ class Admin
      * @param string $notice_type WordPress notice type (e.g. success, updated, error).
      * @return string
      */
-    private function determine_status_from_notice_type($notice_type)
-    {
-        if (!is_string($notice_type)) {
-            return 'failure';
-        }
+	private function determine_status_from_notice_type( $notice_type ) {
+		if ( ! is_string( $notice_type ) ) {
+			return 'failure';
+		}
 
-        $normalized = strtolower(trim($notice_type));
-        $success_keywords = ['success', 'updated'];
+		$normalized       = strtolower( trim( $notice_type ) );
+		$success_keywords = array( 'success', 'updated' );
 
-        foreach ($success_keywords as $keyword) {
-            if ($normalized === $keyword || strpos($normalized, $keyword) !== false) {
-                return 'success';
-            }
-        }
+		foreach ( $success_keywords as $keyword ) {
+			if ( $normalized === $keyword || strpos( $normalized, $keyword ) !== false ) {
+				return 'success';
+			}
+		}
 
-        return 'failure';
-    }
+		return 'failure';
+	}
 }


### PR DESCRIPTION
### Motivation
- Fix file-scoped PHPCS findings in `includes/Admin/Admin.php` (spacing, brace placement, call/array formatting, alignment and an extra blank line) without changing runtime behavior.
- Audit and resolve the `WordPress.Security.NonceVerification.Recommended` warning for the `$_GET['page']` access by determining whether it is state-changing or read-only and applying the minimal safe remediation.

### Description
- Applied formatting-only fixes: normalized the `ABSPATH` guard spacing, moved class/function opening braces to project style, normalized function-call spacing, converted short array usage in calls to canonical `array()` where PHPCS flagged spacing, fixed assignment/array alignment, and removed the flagged extra blank line. Only `includes/Admin/Admin.php` was modified. 
- Preserved sanitization for request-derived values by keeping `wp_unslash()` + `sanitize_text_field()` when reading `$_GET['page']`. 
- Determined the `$_GET['page']` usage is read-only routing/display context (used only to scope logging of settings errors) and therefore added a narrow inline PHPCS suppression immediately above the read with an explicit justification rather than adding nonce verification. 
- Did not change namespace, class name, method names, hooks, capability checks, admin menu slugs, page registration order, admin URLs, or any other file.

### Testing
- Ran `git diff --name-only` and confirmed only `includes/Admin/Admin.php` changed (output: `includes/Admin/Admin.php`).
- Ran `php -l includes/Admin/Admin.php` and received `No syntax errors detected in includes/Admin/Admin.php`.
- Attempted to run `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Admin/Admin.php -s` but `phpcs` is unavailable in this environment (`/bin/bash: line 1: vendor/bin/phpcs: No such file or directory`), so file-specific PHPCS must be verified in CI/Codespace where `vendor/bin/phpcs` is present.
- Committed the change (`style(admin): clean up Admin.php PHPCS formatting and nonce audit`) and created the PR with this description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd682c4c60832da9a2a8bd7a88c137)