### PR TITLE
PHPCS cleanup: ErrorLogRepository formatting and SQL scanner suppressions

### DIFF
--- a/includes/Data/Repositories/ErrorLogRepository.php
+++ b/includes/Data/Repositories/ErrorLogRepository.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode\Data\Repositories;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -12,8 +12,7 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Data\Repositories
  */
-class ErrorLogRepository
-{
+class ErrorLogRepository {
 	private $table;
 
 	public function __construct() {

--- a/includes/Data/Repositories/ErrorLogRepository.php
+++ b/includes/Data/Repositories/ErrorLogRepository.php
@@ -14,13 +14,12 @@ if (!defined('ABSPATH')) {
  */
 class ErrorLogRepository
 {
-    private $table;
+	private $table;
 
-    public function __construct()
-    {
-        global $wpdb;
-        $this->table = $wpdb->prefix . 'kerbcycle_error_logs';
-    }
+	public function __construct() {
+		global $wpdb;
+		$this->table = $wpdb->prefix . 'kerbcycle_error_logs';
+	}
 
     /**
      * Record a log entry for any message, alert or notification.
@@ -28,29 +27,28 @@ class ErrorLogRepository
      * @param array $args
      * @return void
      */
-    public static function log($args)
-    {
-        global $wpdb;
+	public static function log( $args ) {
+		global $wpdb;
 
-        $defaults = [
-            'type'    => '',
-            'message' => '',
-            'page'    => '',
-            'status'  => '',
-        ];
-        $data = wp_parse_args($args, $defaults);
+		$defaults = [
+			'type'    => '',
+			'message' => '',
+			'page'    => '',
+			'status'  => '',
+		];
+		$data     = wp_parse_args( $args, $defaults );
 
-        $row = [
-            'type'       => sanitize_text_field($data['type']),
-            'message'    => wp_kses_post($data['message']),
-            'page'       => sanitize_text_field($data['page']),
-            'status'     => sanitize_text_field($data['status']),
-            'created_at' => current_time('mysql', true), // UTC
-        ];
+		$row = [
+			'type'       => sanitize_text_field( $data['type'] ),
+			'message'    => wp_kses_post( $data['message'] ),
+			'page'       => sanitize_text_field( $data['page'] ),
+			'status'     => sanitize_text_field( $data['status'] ),
+			'created_at' => current_time( 'mysql', true ), // UTC
+		];
 
-        $table = $wpdb->prefix . 'kerbcycle_error_logs';
-        $wpdb->insert($table, $row, ['%s', '%s', '%s', '%s', '%s']);
-    }
+		$table = $wpdb->prefix . 'kerbcycle_error_logs';
+		$wpdb->insert( $table, $row, [ '%s', '%s', '%s', '%s', '%s' ] );
+	}
 
     /**
      * Backwards compatibility for previous log_error calls.
@@ -58,112 +56,112 @@ class ErrorLogRepository
      * @param array $args
      * @return void
      */
-    public static function log_error($args)
-    {
-        self::log($args);
-    }
+	public static function log_error( $args ) {
+		self::log( $args );
+	}
 
     /**
      * Retrieve logs from database.
      */
-    public function get_logs($search, $status, $page, $paged, $per_page)
-    {
-        global $wpdb;
+	public function get_logs( $search, $status, $page, $paged, $per_page ) {
+		global $wpdb;
 
-        $where  = '1=1';
-        $params = [];
+		$where  = '1=1';
+		$params = [];
 
-        if ($search !== '') {
-            $like = '%' . $wpdb->esc_like($search) . '%';
-            $where .= ' AND (type LIKE %s OR message LIKE %s OR page LIKE %s OR status LIKE %s)';
-            array_push($params, $like, $like, $like, $like);
-        }
-        if ($status !== '') {
-            $where .= ' AND status = %s';
-            $params[] = $status;
-        }
-        if ($page !== '') {
-            $where .= ' AND page = %s';
-            $params[] = $page;
-        }
+		if ( '' !== $search ) {
+			$like   = '%' . $wpdb->esc_like( $search ) . '%';
+			$where .= ' AND (type LIKE %s OR message LIKE %s OR page LIKE %s OR status LIKE %s)';
+			array_push( $params, $like, $like, $like, $like );
+		}
+		if ( '' !== $status ) {
+			$where    .= ' AND status = %s';
+			$params[] = $status;
+		}
+		if ( '' !== $page ) {
+			$where    .= ' AND page = %s';
+			$params[] = $page;
+		}
 
-        $offset = ($paged - 1) * $per_page;
-        $sql    = "SELECT * FROM {$this->table} WHERE $where ORDER BY id DESC LIMIT %d OFFSET %d";
-        $params[] = $per_page;
-        $params[] = $offset;
+		$offset   = ( $paged - 1 ) * $per_page;
+		$sql      = "SELECT * FROM {$this->table} WHERE $where ORDER BY id DESC LIMIT %d OFFSET %d";
+		$params[] = $per_page;
+		$params[] = $offset;
 
-        return $wpdb->get_results($wpdb->prepare($sql, $params));
-    }
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments and internally derived table name; dynamic values are prepared before execution.
+		return $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
+	}
 
     /**
      * Count logs in database.
      */
-    public function count_logs($search, $status, $page)
-    {
-        global $wpdb;
+	public function count_logs( $search, $status, $page ) {
+		global $wpdb;
 
-        $where  = '1=1';
-        $params = [];
+		$where  = '1=1';
+		$params = [];
 
-        if ($search !== '') {
-            $like = '%' . $wpdb->esc_like($search) . '%';
-            $where .= ' AND (type LIKE %s OR message LIKE %s OR page LIKE %s OR status LIKE %s)';
-            array_push($params, $like, $like, $like, $like);
-        }
-        if ($status !== '') {
-            $where .= ' AND status = %s';
-            $params[] = $status;
-        }
-        if ($page !== '') {
-            $where .= ' AND page = %s';
-            $params[] = $page;
-        }
+		if ( '' !== $search ) {
+			$like   = '%' . $wpdb->esc_like( $search ) . '%';
+			$where .= ' AND (type LIKE %s OR message LIKE %s OR page LIKE %s OR status LIKE %s)';
+			array_push( $params, $like, $like, $like, $like );
+		}
+		if ( '' !== $status ) {
+			$where    .= ' AND status = %s';
+			$params[] = $status;
+		}
+		if ( '' !== $page ) {
+			$where    .= ' AND page = %s';
+			$params[] = $page;
+		}
 
-        $sql = "SELECT COUNT(*) FROM {$this->table} WHERE $where";
-        return (int) $wpdb->get_var($wpdb->prepare($sql, $params));
-    }
+		$sql = "SELECT COUNT(*) FROM {$this->table} WHERE $where";
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments and internally derived table name; dynamic values are prepared before execution.
+		return (int) $wpdb->get_var( $wpdb->prepare( $sql, $params ) );
+	}
 
-    public function delete_by_ids(array $ids)
-    {
-        if (empty($ids)) {
-            return 0;
-        }
+	public function delete_by_ids( array $ids ) {
+		if ( empty( $ids ) ) {
+			return 0;
+		}
 
-        global $wpdb;
-        $placeholders = implode(',', array_fill(0, count($ids), '%d'));
-        return $wpdb->query($wpdb->prepare("DELETE FROM {$this->table} WHERE id IN ($placeholders)", $ids));
-    }
+		global $wpdb;
+		$ids          = array_map( 'absint', $ids );
+		$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; IDs are absint-normalized and passed via prepare placeholders.
+		return $wpdb->query( $wpdb->prepare( "DELETE FROM {$this->table} WHERE id IN ($placeholders)", $ids ) );
+	}
 
-    public function table_is_valid()
-    {
-        global $wpdb;
-        $expected = ['id', 'type', 'message', 'page', 'status', 'created_at'];
-        $cols = $wpdb->get_col("SHOW COLUMNS FROM {$this->table}", 0);
-        if (empty($cols) || !is_array($cols)) {
-            return false;
-        }
-        foreach ($expected as $c) {
-            if (!in_array($c, $cols, true)) {
-                return false;
-            }
-        }
-        return true;
-    }
+	public function table_is_valid() {
+		global $wpdb;
+		$expected = [ 'id', 'type', 'message', 'page', 'status', 'created_at' ];
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
+		$cols = $wpdb->get_col( "SHOW COLUMNS FROM {$this->table}", 0 );
+		if ( empty( $cols ) || ! is_array( $cols ) ) {
+			return false;
+		}
+		foreach ( $expected as $c ) {
+			if ( ! in_array( $c, $cols, true ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-    public function clear_all()
-    {
-        global $wpdb;
-        return $wpdb->query("TRUNCATE TABLE {$this->table}");
-    }
+	public function clear_all() {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
+		return $wpdb->query( "TRUNCATE TABLE {$this->table}" );
+	}
 
     /**
      * Get list of distinct pages recorded in the log.
      *
      * @return array
      */
-    public function get_pages()
-    {
-        global $wpdb;
-        return $wpdb->get_col("SELECT DISTINCT page FROM {$this->table} WHERE page <> '' ORDER BY page ASC");
-    }
+	public function get_pages() {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
+		return $wpdb->get_col( "SELECT DISTINCT page FROM {$this->table} WHERE page <> '' ORDER BY page ASC" );
+	}
 }

--- a/includes/Data/Repositories/ErrorLogRepository.php
+++ b/includes/Data/Repositories/ErrorLogRepository.php
@@ -74,11 +74,11 @@ class ErrorLogRepository {
 			array_push( $params, $like, $like, $like, $like );
 		}
 		if ( '' !== $status ) {
-			$where    .= ' AND status = %s';
+			$where   .= ' AND status = %s';
 			$params[] = $status;
 		}
 		if ( '' !== $page ) {
-			$where    .= ' AND page = %s';
+			$where   .= ' AND page = %s';
 			$params[] = $page;
 		}
 
@@ -106,11 +106,11 @@ class ErrorLogRepository {
 			array_push( $params, $like, $like, $like, $like );
 		}
 		if ( '' !== $status ) {
-			$where    .= ' AND status = %s';
+			$where   .= ' AND status = %s';
 			$params[] = $status;
 		}
 		if ( '' !== $page ) {
-			$where    .= ' AND page = %s';
+			$where   .= ' AND page = %s';
 			$params[] = $page;
 		}
 


### PR DESCRIPTION
### Motivation
- Fix PHPCS formatting issues and address WordPress DB prepared-statement scanner findings in `includes/Data/Repositories/ErrorLogRepository.php` while preserving behavior and public API.
- Make a minimal, narrow change set consistent with repository guardrails so table names, method signatures, SQL semantics, and return formats remain unchanged.

### Description
- Applied formatting-only cleanup to spacing, brace placement, function declaration/call spacing, and array alignment inside `ErrorLogRepository` to match WordPress style.
- Added narrow inline `phpcs:ignore` comments with explanations on SQL sites that use an internally derived table name for `get_logs()`, `count_logs()`, `delete_by_ids()`, `table_is_valid()`, `clear_all()`, and `get_pages()`.
- For the `DELETE ... IN (...)` site, preserved placeholder-based prepare usage and added `absint` normalization via `array_map('absint', $ids)` so IDs are sanitized before being passed to `$wpdb->prepare()`.
- Preserved the table suffix (`kerbcycle_error_logs`), all method names, signatures, query filters, ordering, delete/truncate behavior, and return formats.

### Testing
- Ran `git diff --name-only` which reported only `includes/Data/Repositories/ErrorLogRepository.php` was modified.
- Ran `php -l includes/Data/Repositories/ErrorLogRepository.php` which returned `No syntax errors detected in includes/Data/Repositories/ErrorLogRepository.php`.
- Attempted to run `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Data/Repositories/ErrorLogRepository.php -s` but `vendor/bin/phpcs` is not available in this environment, so file-level PHPCS must be verified in CI/Codespace before merge.
- Inspected the file diff to confirm only formatting-equivalent changes, narrow SQL suppressions, and the minimal `absint` normalization for deletion were introduced and that no other files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6d2ebad4832dbae73cddc1c31b30)