### PR TITLE
PHPCS cleanup for AiSettingsPage formatting and text domains

### DIFF
--- a/includes/Admin/Pages/AiSettingsPage.php
+++ b/includes/Admin/Pages/AiSettingsPage.php
@@ -43,7 +43,7 @@ class AiSettingsPage {
      * Render the admin page.
      */
     public function render() {
-        $options = AiSettingsService::get_options();
+        $options     = AiSettingsService::get_options();
         $webhook_url = AiSettingsService::current_webhook_url( $options );
         ?>
         <div class="wrap">
@@ -154,7 +154,7 @@ class AiSettingsPage {
     public function render_environment_field() {
         $options = AiSettingsService::get_options();
         ?>
-        <select name="<?php echo esc_attr(self::OPTION_KEY); ?>[env]">
+        <select name="<?php echo esc_attr( self::OPTION_KEY ); ?>[env]">
             <option value="dev" <?php selected( $options['env'], 'dev' ); ?>><?php esc_html_e( 'Development', 'kerbcycle-qr-code-manager' ); ?></option>
             <option value="stage" <?php selected( $options['env'], 'stage' ); ?>><?php esc_html_e( 'Staging', 'kerbcycle-qr-code-manager' ); ?></option>
             <option value="prod" <?php selected( $options['env'], 'prod' ); ?>><?php esc_html_e( 'Production', 'kerbcycle-qr-code-manager' ); ?></option>

--- a/includes/Admin/Pages/AiSettingsPage.php
+++ b/includes/Admin/Pages/AiSettingsPage.php
@@ -4,15 +4,14 @@ namespace Kerbcycle\QrCode\Admin\Pages;
 
 use Kerbcycle\QrCode\Services\AiSettingsService;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
 /**
  * Admin page and helpers for configuring AI webhook integration.
  */
-class AiSettingsPage
-{
+class AiSettingsPage {
     private const OPTION_KEY = 'kerbcycle_ai_webhook_options';
 
     /**
@@ -25,9 +24,8 @@ class AiSettingsPage
     /**
      * Get the singleton instance.
      */
-    public static function instance()
-    {
-        if (null === self::$instance) {
+    public static function instance() {
+        if ( null === self::$instance ) {
             self::$instance = new self();
         }
 
@@ -37,33 +35,31 @@ class AiSettingsPage
     /**
      * Constructor hooks.
      */
-    private function __construct()
-    {
-        add_action('admin_init', [$this, 'register_settings']);
+    private function __construct() {
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
     }
 
     /**
      * Render the admin page.
      */
-    public function render()
-    {
+    public function render() {
         $options = AiSettingsService::get_options();
-        $webhook_url = AiSettingsService::current_webhook_url($options);
+        $webhook_url = AiSettingsService::current_webhook_url( $options );
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e('AI Settings', 'kerbcycle'); ?></h1>
-            <p class="description"><?php esc_html_e('The selected environment determines which pickup-exception webhook URL is active.', 'kerbcycle'); ?></p>
+            <h1><?php esc_html_e( 'AI Settings', 'kerbcycle-qr-code-manager' ); ?></h1>
+            <p class="description"><?php esc_html_e( 'The selected environment determines which pickup-exception webhook URL is active.', 'kerbcycle-qr-code-manager' ); ?></p>
             <form method="post" action="options.php">
                 <?php
-                settings_fields(self::OPTION_KEY);
-        do_settings_sections(self::OPTION_KEY);
-        submit_button(__('Save AI Settings', 'kerbcycle'));
-        ?>
+                settings_fields( self::OPTION_KEY );
+                do_settings_sections( self::OPTION_KEY );
+                submit_button( __( 'Save AI Settings', 'kerbcycle-qr-code-manager' ) );
+                ?>
             </form>
 
-            <h2><?php esc_html_e('Active webhook', 'kerbcycle'); ?></h2>
+            <h2><?php esc_html_e( 'Active webhook', 'kerbcycle-qr-code-manager' ); ?></h2>
             <p>
-                <code><?php echo esc_html($webhook_url !== '' ? $webhook_url : __('Not configured', 'kerbcycle')); ?></code>
+                <code><?php echo esc_html( '' !== $webhook_url ? $webhook_url : __( 'Not configured', 'kerbcycle-qr-code-manager' ) ); ?></code>
             </p>
         </div>
         <?php
@@ -72,30 +68,29 @@ class AiSettingsPage
     /**
      * Register AI webhook settings and fields.
      */
-    public function register_settings()
-    {
-        register_setting(self::OPTION_KEY, self::OPTION_KEY, [$this, 'sanitize_options']);
+    public function register_settings() {
+        register_setting( self::OPTION_KEY, self::OPTION_KEY, array( $this, 'sanitize_options' ) );
 
         add_settings_section(
             'kc_ai_main',
-            __('Pickup Exception Webhook', 'kerbcycle'),
+            __( 'Pickup Exception Webhook', 'kerbcycle-qr-code-manager' ),
             '__return_false',
             self::OPTION_KEY
         );
 
         add_settings_field(
             'env',
-            __('Environment', 'kerbcycle'),
-            [$this, 'render_environment_field'],
+            __( 'Environment', 'kerbcycle-qr-code-manager' ),
+            array( $this, 'render_environment_field' ),
             self::OPTION_KEY,
             'kc_ai_main'
         );
 
         add_settings_field(
             'webhook_url_dev',
-            __('Development webhook URL', 'kerbcycle'),
+            __( 'Development webhook URL', 'kerbcycle-qr-code-manager' ),
             function () {
-                $this->render_webhook_url_field('webhook_url_dev');
+                $this->render_webhook_url_field( 'webhook_url_dev' );
             },
             self::OPTION_KEY,
             'kc_ai_main'
@@ -103,9 +98,9 @@ class AiSettingsPage
 
         add_settings_field(
             'webhook_url_stage',
-            __('Staging webhook URL', 'kerbcycle'),
+            __( 'Staging webhook URL', 'kerbcycle-qr-code-manager' ),
             function () {
-                $this->render_webhook_url_field('webhook_url_stage');
+                $this->render_webhook_url_field( 'webhook_url_stage' );
             },
             self::OPTION_KEY,
             'kc_ai_main'
@@ -113,9 +108,9 @@ class AiSettingsPage
 
         add_settings_field(
             'webhook_url_prod',
-            __('Production webhook URL', 'kerbcycle'),
+            __( 'Production webhook URL', 'kerbcycle-qr-code-manager' ),
             function () {
-                $this->render_webhook_url_field('webhook_url_prod');
+                $this->render_webhook_url_field( 'webhook_url_prod' );
             },
             self::OPTION_KEY,
             'kc_ai_main'
@@ -123,8 +118,8 @@ class AiSettingsPage
 
         add_settings_field(
             'timeout',
-            __('Request timeout (s)', 'kerbcycle'),
-            [$this, 'render_timeout_field'],
+            __( 'Request timeout (s)', 'kerbcycle-qr-code-manager' ),
+            array( $this, 'render_timeout_field' ),
             self::OPTION_KEY,
             'kc_ai_main'
         );
@@ -135,21 +130,20 @@ class AiSettingsPage
      *
      * @param array $input Raw options.
      */
-    public function sanitize_options($input)
-    {
-        $input = is_array($input) ? $input : [];
+    public function sanitize_options( $input ) {
+        $input    = is_array( $input ) ? $input : array();
         $defaults = AiSettingsService::defaults();
 
-        $output = [];
-        $env = isset($input['env']) ? $input['env'] : $defaults['env'];
-        $output['env'] = in_array($env, ['dev', 'stage', 'prod'], true) ? $env : $defaults['env'];
+        $output        = array();
+        $env           = isset( $input['env'] ) ? $input['env'] : $defaults['env'];
+        $output['env'] = in_array( $env, array( 'dev', 'stage', 'prod' ), true ) ? $env : $defaults['env'];
 
-        foreach (['webhook_url_dev', 'webhook_url_stage', 'webhook_url_prod'] as $key) {
-            $output[$key] = esc_url_raw(trim($input[$key] ?? ''));
+        foreach ( array( 'webhook_url_dev', 'webhook_url_stage', 'webhook_url_prod' ) as $key ) {
+            $output[ $key ] = esc_url_raw( trim( $input[ $key ] ?? '' ) );
         }
 
-        $timeout = isset($input['timeout']) ? (int) $input['timeout'] : $defaults['timeout'];
-        $output['timeout'] = max(1, min(60, $timeout));
+        $timeout           = isset( $input['timeout'] ) ? (int) $input['timeout'] : $defaults['timeout'];
+        $output['timeout'] = max( 1, min( 60, $timeout ) );
 
         return $output;
     }
@@ -157,14 +151,13 @@ class AiSettingsPage
     /**
      * Render environment selector.
      */
-    public function render_environment_field()
-    {
+    public function render_environment_field() {
         $options = AiSettingsService::get_options();
         ?>
         <select name="<?php echo esc_attr(self::OPTION_KEY); ?>[env]">
-            <option value="dev" <?php selected($options['env'], 'dev'); ?>><?php esc_html_e('Development', 'kerbcycle'); ?></option>
-            <option value="stage" <?php selected($options['env'], 'stage'); ?>><?php esc_html_e('Staging', 'kerbcycle'); ?></option>
-            <option value="prod" <?php selected($options['env'], 'prod'); ?>><?php esc_html_e('Production', 'kerbcycle'); ?></option>
+            <option value="dev" <?php selected( $options['env'], 'dev' ); ?>><?php esc_html_e( 'Development', 'kerbcycle-qr-code-manager' ); ?></option>
+            <option value="stage" <?php selected( $options['env'], 'stage' ); ?>><?php esc_html_e( 'Staging', 'kerbcycle-qr-code-manager' ); ?></option>
+            <option value="prod" <?php selected( $options['env'], 'prod' ); ?>><?php esc_html_e( 'Production', 'kerbcycle-qr-code-manager' ); ?></option>
         </select>
         <?php
     }
@@ -172,27 +165,25 @@ class AiSettingsPage
     /**
      * Render webhook URL input field.
      */
-    private function render_webhook_url_field($key)
-    {
+    private function render_webhook_url_field( $key ) {
         $options = AiSettingsService::get_options();
         printf(
             '<input type="url" size="60" name="%1$s[%2$s]" value="%3$s" placeholder="https://your-n8n.example.com/webhook/..." />',
-            esc_attr(self::OPTION_KEY),
-            esc_attr($key),
-            esc_attr($options[$key])
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $key ),
+            esc_attr( $options[ $key ] )
         );
     }
 
     /**
      * Render timeout field.
      */
-    public function render_timeout_field()
-    {
+    public function render_timeout_field() {
         $options = AiSettingsService::get_options();
         printf(
             '<input type="number" min="1" max="60" name="%1$s[timeout]" value="%2$s" />',
-            esc_attr(self::OPTION_KEY),
-            esc_attr($options['timeout'])
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $options['timeout'] )
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Fix PHPCS-reported whitespace, brace, and array/key spacing issues in `includes/Admin/Pages/AiSettingsPage.php` without changing behavior or public APIs. 
- Ensure the correct i18n text domain is used in this file by replacing the mismatched `'kerbcycle'` domain with `'kerbcycle-qr-code-manager'`.

### Description
- Modified only `includes/Admin/Pages/AiSettingsPage.php` to adjust ABSPATH guard spacing, class/function opening-brace placement, function call/parenthesis spacing, indentation, single-line array spacing, assignment alignment, and array key spacing. 
- Replaced text-domain arguments in this file from `'kerbcycle'` to `'kerbcycle-qr-code-manager'` while preserving all translated string text and visible labels exactly. 
- No changes were made to namespace, class name, method names, option keys, field names, form action, nonces, submit behavior, service calls, or any files outside `AiSettingsPage.php`.

### Testing
- `git diff --name-only` output: `includes/Admin/Pages/AiSettingsPage.php` (only the intended file was modified).
- `php -l includes/Admin/Pages/AiSettingsPage.php` output: `No syntax errors detected in includes/Admin/Pages/AiSettingsPage.php`.
- `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Admin/Pages/AiSettingsPage.php -s` output: `/bin/bash: line 1: vendor/bin/phpcs: No such file or directory` (PHPCS is not present in this environment; file-specific PHPCS verification is blocked and should be run in a Codespace or CI with project dependencies installed).
- All automated checks that were runnable (`php -l`) passed; PHPCS checks remain to be run in an environment with `vendor/bin/phpcs` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7bd38b40832da28f60c6426d0ac7)