### PR TITLE
PHPCS cleanup for MessageLogRepository formatting and SQL scanner warnings

### DIFF
--- a/includes/Data/Repositories/MessageLogRepository.php
+++ b/includes/Data/Repositories/MessageLogRepository.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Data\Repositories;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 /**
@@ -13,139 +13,148 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Data\Repositories
  */
-class MessageLogRepository
-{
-    private $table;
+class MessageLogRepository {
+	private $table;
 
-    public function __construct()
-    {
-        global $wpdb;
-        $this->table = $wpdb->prefix . 'kerbcycle_message_logs';
-    }
+	public function __construct() {
+		global $wpdb;
+		$this->table = $wpdb->prefix . 'kerbcycle_message_logs';
+	}
 
-    /**
-     * Public helper to record a message log
-     */
-    public static function log_message($args)
-    {
-        global $wpdb;
+	/**
+	 * Public helper to record a message log
+	 */
+	public static function log_message( $args ) {
+		global $wpdb;
 
-        $defaults = [
-            'type'     => '',
-            'to'       => '',
-            'subject'  => '',
-            'body'     => '',
-            'status'   => '',
-            'provider' => '',
-            'response' => '',
-        ];
-        $data = wp_parse_args($args, $defaults);
+		$defaults = array(
+			'type'     => '',
+			'to'       => '',
+			'subject'  => '',
+			'body'     => '',
+			'status'   => '',
+			'provider' => '',
+			'response' => '',
+		);
+		$data     = wp_parse_args( $args, $defaults );
 
-        $row = [
-            'type'       => in_array($data['type'], ['sms', 'email'], true) ? $data['type'] : 'sms',
-            'recipient'  => sanitize_text_field($data['to']),
-            'subject'    => sanitize_text_field($data['subject']),
-            'body'       => wp_kses_post($data['body']),
-            'status'     => sanitize_text_field($data['status']),
-            'provider'   => sanitize_text_field($data['provider']),
-            'response'   => is_scalar($data['response']) ? wp_kses_post((string)$data['response']) : wp_json_encode($data['response']),
-            'created_at' => current_time('mysql', true), // UTC
-        ];
+		$row = array(
+			'type'       => in_array( $data['type'], array( 'sms', 'email' ), true ) ? $data['type'] : 'sms',
+			'recipient'  => sanitize_text_field( $data['to'] ),
+			'subject'    => sanitize_text_field( $data['subject'] ),
+			'body'       => wp_kses_post( $data['body'] ),
+			'status'     => sanitize_text_field( $data['status'] ),
+			'provider'   => sanitize_text_field( $data['provider'] ),
+			'response'   => is_scalar( $data['response'] ) ? wp_kses_post( (string) $data['response'] ) : wp_json_encode( $data['response'] ),
+			'created_at' => current_time( 'mysql', true ), // UTC.
+		);
 
-        $table = $wpdb->prefix . 'kerbcycle_message_logs';
-        $wpdb->insert($table, $row, ['%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s']);
-    }
+		$table = $wpdb->prefix . 'kerbcycle_message_logs';
+		$wpdb->insert( $table, $row, array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' ) );
+	}
 
-    /**
-     * Get logs from the database.
-     */
-    public function get_logs($type, $search, $from, $to, $paged, $per_page)
-    {
-        global $wpdb;
+	/**
+	 * Get logs from the database.
+	 */
+	public function get_logs( $type, $search, $from, $to, $paged, $per_page ) {
+		global $wpdb;
 
-        $where   = ['type = %s'];
-        $params  = [$type];
+		$where  = array( 'type = %s' );
+		$params = array( $type );
 
-        if ($search !== '') {
-            $like   = '%' . $wpdb->esc_like($search) . '%';
-            $where[] = '(recipient LIKE %s OR subject LIKE %s OR body LIKE %s OR status LIKE %s OR provider LIKE %s)';
-            array_push($params, $like, $like, $like, $like, $like);
-        }
-        if ($from) {
-            $where[] = 'DATE(created_at) >= %s';
-            $params[] = $from;
-        }
-        if ($to) {
-            $where[] = 'DATE(created_at) <= %s';
-            $params[] = $to;
-        }
+		if ( '' !== $search ) {
+			$like    = '%' . $wpdb->esc_like( $search ) . '%';
+			$where[] = '(recipient LIKE %s OR subject LIKE %s OR body LIKE %s OR status LIKE %s OR provider LIKE %s)';
+			array_push( $params, $like, $like, $like, $like, $like );
+		}
+		if ( $from ) {
+			$where[]  = 'DATE(created_at) >= %s';
+			$params[] = $from;
+		}
+		if ( $to ) {
+			$where[]  = 'DATE(created_at) <= %s';
+			$params[] = $to;
+		}
 
-        $offset = ($paged - 1) * $per_page;
-        $sql = "SELECT * FROM {$this->table} WHERE " . implode(' AND ', $where) . " ORDER BY id DESC LIMIT %d OFFSET %d";
-        $params[] = $per_page;
-        $params[] = $offset;
+		$offset   = ( $paged - 1 ) * $per_page;
+		$sql      = "SELECT * FROM {$this->table} WHERE " . implode( ' AND ', $where ) . ' ORDER BY id DESC LIMIT %d OFFSET %d';
+		$params[] = $per_page;
+		$params[] = $offset;
 
-        return $wpdb->get_results($wpdb->prepare($sql, $params));
-    }
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments and internally derived table name; dynamic values are prepared before execution.
+		return $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
+	}
 
-    /**
-     * Count logs in the database.
-     */
-    public function count_logs($type, $search, $from, $to)
-    {
-        global $wpdb;
+	/**
+	 * Count logs in the database.
+	 */
+	public function count_logs( $type, $search, $from, $to ) {
+		global $wpdb;
 
-        $where   = ['type = %s'];
-        $params  = [$type];
+		$where  = array( 'type = %s' );
+		$params = array( $type );
 
-        if ($search !== '') {
-            $like   = '%' . $wpdb->esc_like($search) . '%';
-            $where[] = '(recipient LIKE %s OR subject LIKE %s OR body LIKE %s OR status LIKE %s OR provider LIKE %s)';
-            array_push($params, $like, $like, $like, $like, $like);
-        }
-        if ($from) {
-            $where[] = 'DATE(created_at) >= %s';
-            $params[] = $from;
-        }
-        if ($to) {
-            $where[] = 'DATE(created_at) <= %s';
-            $params[] = $to;
-        }
+		if ( '' !== $search ) {
+			$like    = '%' . $wpdb->esc_like( $search ) . '%';
+			$where[] = '(recipient LIKE %s OR subject LIKE %s OR body LIKE %s OR status LIKE %s OR provider LIKE %s)';
+			array_push( $params, $like, $like, $like, $like, $like );
+		}
+		if ( $from ) {
+			$where[]  = 'DATE(created_at) >= %s';
+			$params[] = $from;
+		}
+		if ( $to ) {
+			$where[]  = 'DATE(created_at) <= %s';
+			$params[] = $to;
+		}
 
-        $sql = "SELECT COUNT(*) FROM {$this->table} WHERE " . implode(' AND ', $where);
-        return (int) $wpdb->get_var($wpdb->prepare($sql, $params));
-    }
+		$sql = "SELECT COUNT(*) FROM {$this->table} WHERE " . implode( ' AND ', $where );
 
-    /**
-     * Quick structural validation (are the expected columns present?)
-     */
-    public function table_is_valid()
-    {
-        global $wpdb;
-        $expected = [
-            'id', 'type', 'recipient', 'subject', 'body', 'status', 'provider', 'response', 'created_at'
-        ];
-        $cols = $wpdb->get_col("SHOW COLUMNS FROM {$this->table}", 0);
-        if (empty($cols) || !is_array($cols)) {
-            return false;
-        }
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments and internally derived table name; dynamic values are prepared before execution.
+		return (int) $wpdb->get_var( $wpdb->prepare( $sql, $params ) );
+	}
 
-        foreach ($expected as $c) {
-            if (!in_array($c, $cols, true)) {
-                return false;
-            }
-        }
-        return true;
-    }
+	/**
+	 * Quick structural validation (are the expected columns present?)
+	 */
+	public function table_is_valid() {
+		global $wpdb;
+		$expected = array(
+			'id',
+			'type',
+			'recipient',
+			'subject',
+			'body',
+			'status',
+			'provider',
+			'response',
+			'created_at',
+		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
+		$cols = $wpdb->get_col( "SHOW COLUMNS FROM {$this->table}", 0 );
+		if ( empty( $cols ) || ! is_array( $cols ) ) {
+			return false;
+		}
 
-    public function delete_by_ids(array $ids)
-    {
-        if (empty($ids)) {
-            return 0;
-        }
+		foreach ( $expected as $c ) {
+			if ( ! in_array( $c, $cols, true ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-        global $wpdb;
-        $placeholders = implode(',', array_fill(0, count($ids), '%d'));
-        return $wpdb->query($wpdb->prepare("DELETE FROM {$this->table} WHERE id IN ($placeholders)", $ids));
-    }
+	public function delete_by_ids( array $ids ) {
+		if ( empty( $ids ) ) {
+			return 0;
+		}
+
+		global $wpdb;
+		$ids          = array_map( 'absint', $ids );
+		$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+		$sql          = "DELETE FROM {$this->table} WHERE id IN ($placeholders)";
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived and IDs are absint-normalized then passed to prepare with generated placeholders.
+		return $wpdb->query( $wpdb->prepare( $sql, $ids ) );
+	}
 }


### PR DESCRIPTION
### Motivation
- Apply a targeted, one-file PHPCS cleanup to `MessageLogRepository` to fix spacing/formatting issues and resolve SQL scanner findings without changing behavior. 
- Keep all KerbCycle invariants intact (no renames, no table-suffix changes, no API or behavior changes). 

### Description
- Modified only `includes/Data/Repositories/MessageLogRepository.php` to normalize ABSPATH guard spacing, brace placement, function/call spacing, array formatting, cast/parenthesis spacing, and multi-line arrays. 
- Audited each SQL scanner finding and added narrow `phpcs:ignore` comments where safe: `get_logs()` and `count_logs()` now have targeted `WordPress.DB.PreparedSQL.NotPrepared` ignores because SQL is assembled from fixed fragments, uses an internally-derived table name, and values are passed to `$wpdb->prepare()`. 
- Added a targeted `WordPress.DB.PreparedSQL.InterpolatedNotPrepared` ignore for the `SHOW COLUMNS FROM {$this->table}` call because the table name is derived from `$wpdb->prefix` plus a fixed suffix and the query has no user-supplied fragments. 
- For `delete_by_ids()` preserved delete semantics while adding `array_map('absint', $ids)` to normalize IDs, kept generated `%d` placeholders, passed IDs to `$wpdb->prepare()`, and added a narrow suppression for the interpolation/placeholder scanner warnings. 

### Testing
- `git diff --name-only` output confirming file changed: `includes/Data/Repositories/MessageLogRepository.php`. 
- PHP syntax check: `php -l includes/Data/Repositories/MessageLogRepository.php` returned: `No syntax errors detected in includes/Data/Repositories/MessageLogRepository.php`. 
- PHPCS was not available in this environment and returned: `/bin/bash: line 1: vendor/bin/phpcs: No such file or directory`, so file-specific PHPCS validation is blocked and must be rerun in CI/Codespace with dependencies installed. 
- Remaining findings: automated PHPCS checks could not be completed here due to the missing `phpcs` binary and are therefore classified as blocked and must be verified in the CI/Codespace before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd82104c38832d82a9c74fe47db90a)