### PR TITLE
PHPCS: SettingsPage formatting and text-domain fixes

### DIFF
--- a/includes/Admin/Pages/SettingsPage.php
+++ b/includes/Admin/Pages/SettingsPage.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode\Admin\Pages;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -13,16 +13,14 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Admin\Pages
  */
-class SettingsPage
-{
+class SettingsPage {
     /**
      * Initialize the class and set its properties.
      *
      * @since    1.0.0
      */
-    public function __construct()
-    {
-        add_action('admin_init', [$this, 'register_settings']);
+    public function __construct() {
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
     }
 
     /**
@@ -30,8 +28,7 @@ class SettingsPage
      *
      * @since    1.0.0
      */
-    public function render()
-    {
+    public function render() {
         ?>
         <div class="wrap">
             <h1><?php esc_html_e( 'KerbCycle QR Settings', 'kerbcycle-qr-code-manager' ); ?></h1>
@@ -51,17 +48,16 @@ class SettingsPage
      *
      * @since    1.0.0
      */
-    public function register_settings()
-    {
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_email');
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_sms');
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_reminders');
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_enable_scanner');
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_disable_drag_drop');
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_qr_codes_per_page');
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_history_per_page');
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_sms_history_per_page');
-        register_setting('kerbcycle_qr_settings', 'kerbcycle_email_history_per_page');
+    public function register_settings() {
+        register_setting( 'kerbcycle_qr_settings', 'kerbcycle_qr_enable_email' );
+        register_setting( 'kerbcycle_qr_settings', 'kerbcycle_qr_enable_sms' );
+        register_setting( 'kerbcycle_qr_settings', 'kerbcycle_qr_enable_reminders' );
+        register_setting( 'kerbcycle_qr_settings', 'kerbcycle_qr_enable_scanner' );
+        register_setting( 'kerbcycle_qr_settings', 'kerbcycle_qr_disable_drag_drop' );
+        register_setting( 'kerbcycle_qr_settings', 'kerbcycle_qr_codes_per_page' );
+        register_setting( 'kerbcycle_qr_settings', 'kerbcycle_history_per_page' );
+        register_setting( 'kerbcycle_qr_settings', 'kerbcycle_sms_history_per_page' );
+        register_setting( 'kerbcycle_qr_settings', 'kerbcycle_email_history_per_page' );
 
         add_settings_section(
             'kerbcycle_qr_main',
@@ -143,81 +139,72 @@ class SettingsPage
         );
     }
 
-    public function render_enable_email_field()
-    {
-        $value = get_option('kerbcycle_qr_enable_email', 1);
+    public function render_enable_email_field() {
+        $value = get_option( 'kerbcycle_qr_enable_email', 1 );
         ?>
         <input type="checkbox" name="kerbcycle_qr_enable_email" value="1" <?php checked( 1, $value ); ?> />
         <span class="description"><?php esc_html_e( 'Send email when QR codes are assigned', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
-    public function render_enable_sms_field()
-    {
-        $value = get_option('kerbcycle_qr_enable_sms', 0);
+    public function render_enable_sms_field() {
+        $value = get_option( 'kerbcycle_qr_enable_sms', 0 );
         ?>
         <input type="checkbox" name="kerbcycle_qr_enable_sms" value="1" <?php checked( 1, $value ); ?> />
         <span class="description"><?php esc_html_e( 'Send SMS when QR codes are assigned', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
-    public function render_enable_reminders_field()
-    {
-        $value = get_option('kerbcycle_qr_enable_reminders', 0);
+    public function render_enable_reminders_field() {
+        $value = get_option( 'kerbcycle_qr_enable_reminders', 0 );
         ?>
         <input type="checkbox" name="kerbcycle_qr_enable_reminders" value="1" <?php checked( 1, $value ); ?> />
         <span class="description"><?php esc_html_e( 'Schedule automated reminders after assignment', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
-    public function render_enable_scanner_field()
-    {
-        $value = get_option('kerbcycle_qr_enable_scanner', 1);
+    public function render_enable_scanner_field() {
+        $value = get_option( 'kerbcycle_qr_enable_scanner', 1 );
         ?>
         <input type="checkbox" name="kerbcycle_qr_enable_scanner" value="1" <?php checked( 1, $value ); ?> />
         <span class="description"><?php esc_html_e( 'Allow camera use on the dashboard scanner', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
-    public function render_disable_drag_drop_field()
-    {
-        $value = get_option('kerbcycle_qr_disable_drag_drop', 0);
+    public function render_disable_drag_drop_field() {
+        $value = get_option( 'kerbcycle_qr_disable_drag_drop', 0 );
         ?>
         <input type="checkbox" name="kerbcycle_qr_disable_drag_drop" value="1" <?php checked( 1, $value ); ?> />
         <span class="description"><?php esc_html_e( 'Prevent drag-and-drop reordering on the QR Codes table', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
-    public function render_codes_per_page_field()
-    {
-        $value = get_option('kerbcycle_qr_codes_per_page', 20);
+    public function render_codes_per_page_field() {
+        $value = get_option( 'kerbcycle_qr_codes_per_page', 20 );
         ?>
         <input type="number" min="1" name="kerbcycle_qr_codes_per_page" value="<?php echo esc_attr( $value ); ?>" />
         <span class="description"><?php esc_html_e( 'Number of QR codes displayed per page', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
-    public function render_history_per_page_field()
-    {
-        $value = get_option('kerbcycle_history_per_page', 20);
+    public function render_history_per_page_field() {
+        $value = get_option( 'kerbcycle_history_per_page', 20 );
         ?>
         <input type="number" min="1" name="kerbcycle_history_per_page" value="<?php echo esc_attr( $value ); ?>" />
         <span class="description"><?php esc_html_e( 'Number of history entries displayed per page', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
-    public function render_sms_history_per_page_field()
-    {
-        $value = get_option('kerbcycle_sms_history_per_page', 20);
+    public function render_sms_history_per_page_field() {
+        $value = get_option( 'kerbcycle_sms_history_per_page', 20 );
         ?>
         <input type="number" min="1" name="kerbcycle_sms_history_per_page" value="<?php echo esc_attr( $value ); ?>" />
         <span class="description"><?php esc_html_e( 'Number of SMS history entries displayed per page', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
-    public function render_email_history_per_page_field()
-    {
-        $value = get_option('kerbcycle_email_history_per_page', 20);
+    public function render_email_history_per_page_field() {
+        $value = get_option( 'kerbcycle_email_history_per_page', 20 );
         ?>
         <input type="number" min="1" name="kerbcycle_email_history_per_page" value="<?php echo esc_attr( $value ); ?>" />
         <span class="description"><?php esc_html_e( 'Number of email history entries displayed per page', 'kerbcycle-qr-code-manager' ); ?></span>

--- a/includes/Admin/Pages/SettingsPage.php
+++ b/includes/Admin/Pages/SettingsPage.php
@@ -34,13 +34,13 @@ class SettingsPage
     {
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e('KerbCycle QR Settings', 'kerbcycle'); ?></h1>
+            <h1><?php esc_html_e( 'KerbCycle QR Settings', 'kerbcycle-qr-code-manager' ); ?></h1>
             <form method="post" action="options.php">
                 <?php
-                settings_fields('kerbcycle_qr_settings');
-        do_settings_sections('kerbcycle_qr_settings');
-        submit_button();
-        ?>
+                settings_fields( 'kerbcycle_qr_settings' );
+                do_settings_sections( 'kerbcycle_qr_settings' );
+                submit_button();
+                ?>
             </form>
         </div>
         <?php
@@ -65,79 +65,79 @@ class SettingsPage
 
         add_settings_section(
             'kerbcycle_qr_main',
-            __('General Settings', 'kerbcycle'),
+            __( 'General Settings', 'kerbcycle-qr-code-manager' ),
             '__return_false',
             'kerbcycle_qr_settings'
         );
 
         add_settings_field(
             'kerbcycle_qr_enable_email',
-            __('Enable Email Notifications', 'kerbcycle'),
-            [$this, 'render_enable_email_field'],
+            __( 'Enable Email Notifications', 'kerbcycle-qr-code-manager' ),
+            [ $this, 'render_enable_email_field' ],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
 
         add_settings_field(
             'kerbcycle_qr_enable_sms',
-            __('Enable SMS Notifications', 'kerbcycle'),
-            [$this, 'render_enable_sms_field'],
+            __( 'Enable SMS Notifications', 'kerbcycle-qr-code-manager' ),
+            [ $this, 'render_enable_sms_field' ],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
 
         add_settings_field(
             'kerbcycle_qr_enable_reminders',
-            __('Enable Automated Reminders', 'kerbcycle'),
-            [$this, 'render_enable_reminders_field'],
+            __( 'Enable Automated Reminders', 'kerbcycle-qr-code-manager' ),
+            [ $this, 'render_enable_reminders_field' ],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
 
         add_settings_field(
             'kerbcycle_qr_enable_scanner',
-            __('Enable Dashboard QR Scanner Camera', 'kerbcycle'),
-            [$this, 'render_enable_scanner_field'],
+            __( 'Enable Dashboard QR Scanner Camera', 'kerbcycle-qr-code-manager' ),
+            [ $this, 'render_enable_scanner_field' ],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
 
         add_settings_field(
             'kerbcycle_qr_disable_drag_drop',
-            __('Disable Drag and Drop Reordering', 'kerbcycle'),
-            [$this, 'render_disable_drag_drop_field'],
+            __( 'Disable Drag and Drop Reordering', 'kerbcycle-qr-code-manager' ),
+            [ $this, 'render_disable_drag_drop_field' ],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
 
         add_settings_field(
             'kerbcycle_qr_codes_per_page',
-            __('QR Codes per Page', 'kerbcycle'),
-            [$this, 'render_codes_per_page_field'],
+            __( 'QR Codes per Page', 'kerbcycle-qr-code-manager' ),
+            [ $this, 'render_codes_per_page_field' ],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
 
         add_settings_field(
             'kerbcycle_history_per_page',
-            __('History Entries per Page', 'kerbcycle'),
-            [$this, 'render_history_per_page_field'],
+            __( 'History Entries per Page', 'kerbcycle-qr-code-manager' ),
+            [ $this, 'render_history_per_page_field' ],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
 
         add_settings_field(
             'kerbcycle_sms_history_per_page',
-            __('SMS History Entries per Page', 'kerbcycle'),
-            [$this, 'render_sms_history_per_page_field'],
+            __( 'SMS History Entries per Page', 'kerbcycle-qr-code-manager' ),
+            [ $this, 'render_sms_history_per_page_field' ],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
 
         add_settings_field(
             'kerbcycle_email_history_per_page',
-            __('Email History Entries per Page', 'kerbcycle'),
-            [$this, 'render_email_history_per_page_field'],
+            __( 'Email History Entries per Page', 'kerbcycle-qr-code-manager' ),
+            [ $this, 'render_email_history_per_page_field' ],
             'kerbcycle_qr_settings',
             'kerbcycle_qr_main'
         );
@@ -147,8 +147,8 @@ class SettingsPage
     {
         $value = get_option('kerbcycle_qr_enable_email', 1);
         ?>
-        <input type="checkbox" name="kerbcycle_qr_enable_email" value="1" <?php checked(1, $value); ?> />
-        <span class="description"><?php esc_html_e('Send email when QR codes are assigned', 'kerbcycle'); ?></span>
+        <input type="checkbox" name="kerbcycle_qr_enable_email" value="1" <?php checked( 1, $value ); ?> />
+        <span class="description"><?php esc_html_e( 'Send email when QR codes are assigned', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
@@ -156,8 +156,8 @@ class SettingsPage
     {
         $value = get_option('kerbcycle_qr_enable_sms', 0);
         ?>
-        <input type="checkbox" name="kerbcycle_qr_enable_sms" value="1" <?php checked(1, $value); ?> />
-        <span class="description"><?php esc_html_e('Send SMS when QR codes are assigned', 'kerbcycle'); ?></span>
+        <input type="checkbox" name="kerbcycle_qr_enable_sms" value="1" <?php checked( 1, $value ); ?> />
+        <span class="description"><?php esc_html_e( 'Send SMS when QR codes are assigned', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
@@ -165,8 +165,8 @@ class SettingsPage
     {
         $value = get_option('kerbcycle_qr_enable_reminders', 0);
         ?>
-        <input type="checkbox" name="kerbcycle_qr_enable_reminders" value="1" <?php checked(1, $value); ?> />
-        <span class="description"><?php esc_html_e('Schedule automated reminders after assignment', 'kerbcycle'); ?></span>
+        <input type="checkbox" name="kerbcycle_qr_enable_reminders" value="1" <?php checked( 1, $value ); ?> />
+        <span class="description"><?php esc_html_e( 'Schedule automated reminders after assignment', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
@@ -174,8 +174,8 @@ class SettingsPage
     {
         $value = get_option('kerbcycle_qr_enable_scanner', 1);
         ?>
-        <input type="checkbox" name="kerbcycle_qr_enable_scanner" value="1" <?php checked(1, $value); ?> />
-        <span class="description"><?php esc_html_e('Allow camera use on the dashboard scanner', 'kerbcycle'); ?></span>
+        <input type="checkbox" name="kerbcycle_qr_enable_scanner" value="1" <?php checked( 1, $value ); ?> />
+        <span class="description"><?php esc_html_e( 'Allow camera use on the dashboard scanner', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
@@ -183,8 +183,8 @@ class SettingsPage
     {
         $value = get_option('kerbcycle_qr_disable_drag_drop', 0);
         ?>
-        <input type="checkbox" name="kerbcycle_qr_disable_drag_drop" value="1" <?php checked(1, $value); ?> />
-        <span class="description"><?php esc_html_e('Prevent drag-and-drop reordering on the QR Codes table', 'kerbcycle'); ?></span>
+        <input type="checkbox" name="kerbcycle_qr_disable_drag_drop" value="1" <?php checked( 1, $value ); ?> />
+        <span class="description"><?php esc_html_e( 'Prevent drag-and-drop reordering on the QR Codes table', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
@@ -192,8 +192,8 @@ class SettingsPage
     {
         $value = get_option('kerbcycle_qr_codes_per_page', 20);
         ?>
-        <input type="number" min="1" name="kerbcycle_qr_codes_per_page" value="<?= esc_attr($value); ?>" />
-        <span class="description"><?php esc_html_e('Number of QR codes displayed per page', 'kerbcycle'); ?></span>
+        <input type="number" min="1" name="kerbcycle_qr_codes_per_page" value="<?php echo esc_attr( $value ); ?>" />
+        <span class="description"><?php esc_html_e( 'Number of QR codes displayed per page', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
@@ -201,8 +201,8 @@ class SettingsPage
     {
         $value = get_option('kerbcycle_history_per_page', 20);
         ?>
-        <input type="number" min="1" name="kerbcycle_history_per_page" value="<?= esc_attr($value); ?>" />
-        <span class="description"><?php esc_html_e('Number of history entries displayed per page', 'kerbcycle'); ?></span>
+        <input type="number" min="1" name="kerbcycle_history_per_page" value="<?php echo esc_attr( $value ); ?>" />
+        <span class="description"><?php esc_html_e( 'Number of history entries displayed per page', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
@@ -210,8 +210,8 @@ class SettingsPage
     {
         $value = get_option('kerbcycle_sms_history_per_page', 20);
         ?>
-        <input type="number" min="1" name="kerbcycle_sms_history_per_page" value="<?= esc_attr($value); ?>" />
-        <span class="description"><?php esc_html_e('Number of SMS history entries displayed per page', 'kerbcycle'); ?></span>
+        <input type="number" min="1" name="kerbcycle_sms_history_per_page" value="<?php echo esc_attr( $value ); ?>" />
+        <span class="description"><?php esc_html_e( 'Number of SMS history entries displayed per page', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 
@@ -219,8 +219,8 @@ class SettingsPage
     {
         $value = get_option('kerbcycle_email_history_per_page', 20);
         ?>
-        <input type="number" min="1" name="kerbcycle_email_history_per_page" value="<?= esc_attr($value); ?>" />
-        <span class="description"><?php esc_html_e('Number of email history entries displayed per page', 'kerbcycle'); ?></span>
+        <input type="number" min="1" name="kerbcycle_email_history_per_page" value="<?php echo esc_attr( $value ); ?>" />
+        <span class="description"><?php esc_html_e( 'Number of email history entries displayed per page', 'kerbcycle-qr-code-manager' ); ?></span>
         <?php
     }
 }


### PR DESCRIPTION
### Motivation
- Address file-specific PHPCS findings in `includes/Admin/Pages/SettingsPage.php` (whitespace/brace/call-signature/array/short-echo/text-domain issues) without changing runtime behavior or settings.

### Description
- Files changed: `includes/Admin/Pages/SettingsPage.php` only.
- Fixed formatting and spacing for function calls, array notation, indentation and opening brace placement where applicable, and normalized single-line arrays and call signatures.
- Expanded short echo tags (e.g. `<?= esc_attr($value); ?>`) to explicit PHP echo form (`<?php echo esc_attr( $value ); ?>`).
- Replaced text-domain arguments from `'kerbcycle'` to `'kerbcycle-qr-code-manager'` while preserving translated string text exactly.
- No namespace, class, method, option key, field name, form action, nonce, or behavior changes were made.

### Testing
- Commands run and outputs:

`git diff --name-only`
```
includes/Admin/Pages/SettingsPage.php
```

`php -l includes/Admin/Pages/SettingsPage.php`
```
No syntax errors detected in includes/Admin/Pages/SettingsPage.php
```

`vendor/bin/phpcs --standard=phpcs.xml.dist includes/Admin/Pages/SettingsPage.php -s`
```
/bin/bash: line 1: vendor/bin/phpcs: No such file or directory
```

- Validation status: `php -l` passed, but PHPCS verification is blocked in this environment because `vendor/bin/phpcs` is unavailable and must be run in the Codespace/CI before merge.
- Remaining findings: PHPCS verification is currently blocked and therefore any remaining file-specific PHPCS findings are classified as "In scope / must be fixed before this pass is complete."

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd8acea668832d8c44ff46a2d5e732)