### PR TITLE
PHPCS cleanup for HistoryPage: request sanitization, SQL audit, text-domain, and pagination escaping

### DIFF
--- a/includes/Admin/Pages/HistoryPage.php
+++ b/includes/Admin/Pages/HistoryPage.php
@@ -55,7 +55,7 @@ class HistoryPage {
         }
 
         if ( $search ) {
-            $like      = '%' . $wpdb->esc_like( $search ) . '%';
+            $like     = '%' . $wpdb->esc_like( $search ) . '%';
             $where   .= ' AND (CAST(id AS CHAR) LIKE %s OR qr_code LIKE %s OR CAST(user_id AS CHAR) LIKE %s OR CAST(changed_at AS CHAR) LIKE %s)';
             $params[] = $like;
             $params[] = $like;
@@ -63,10 +63,10 @@ class HistoryPage {
             $params[] = $like;
         }
 
-        $count_sql    = "SELECT COUNT(*) FROM $table_name WHERE $where";
+        $count_sql   = "SELECT COUNT(*) FROM $table_name WHERE $where";
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments; dynamic values are prepared before execution.
         $total_items = (int) ( $params ? $wpdb->get_var( $wpdb->prepare( $count_sql, $params ) ) : $wpdb->get_var( $count_sql ) );
-        $total_pages  = (int) ceil( $total_items / $per_page );
+        $total_pages = (int) ceil( $total_items / $per_page );
 
         $pagination_links = $total_pages > 1 ? paginate_links(
             [
@@ -82,7 +82,7 @@ class HistoryPage {
         $select_sql = "SELECT * FROM $table_name WHERE $where ORDER BY changed_at DESC LIMIT %d OFFSET %d";
         $query_args = array_merge( $params, [ $per_page, $offset ] );
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments; dynamic values are prepared before execution.
-        $qr_codes    = $wpdb->get_results( $wpdb->prepare( $select_sql, $query_args ) );
+        $qr_codes   = $wpdb->get_results( $wpdb->prepare( $select_sql, $query_args ) );
         ?>
         <div class="wrap">
             <h1>QR Code History</h1>

--- a/includes/Admin/Pages/HistoryPage.php
+++ b/includes/Admin/Pages/HistoryPage.php
@@ -25,7 +25,7 @@ class HistoryPage {
         $per_page     = (int) get_option( 'kerbcycle_history_per_page', 20 );
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
         $current_page = isset( $_GET['paged'] ) ? max( 1, absint( wp_unslash( $_GET['paged'] ) ) ) : 1;
-        $offset       = ($current_page - 1) * $per_page;
+        $offset       = ( $current_page - 1 ) * $per_page;
 
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
         $status_filter = isset( $_GET['status_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['status_filter'] ) ) : '';
@@ -39,23 +39,23 @@ class HistoryPage {
         $where  = '1=1';
         $params = [];
 
-        if ($status_filter) {
+        if ( $status_filter ) {
             $where   .= ' AND status = %s';
             $params[] = $status_filter;
         }
 
-        if ($start_date) {
+        if ( $start_date ) {
             $where   .= ' AND DATE(changed_at) >= %s';
             $params[] = $start_date;
         }
 
-        if ($end_date) {
+        if ( $end_date ) {
             $where   .= ' AND DATE(changed_at) <= %s';
             $params[] = $end_date;
         }
 
-        if ($search) {
-            $like     = '%' . $wpdb->esc_like($search) . '%';
+        if ( $search ) {
+            $like      = '%' . $wpdb->esc_like( $search ) . '%';
             $where   .= ' AND (CAST(id AS CHAR) LIKE %s OR qr_code LIKE %s OR CAST(user_id AS CHAR) LIKE %s OR CAST(changed_at AS CHAR) LIKE %s)';
             $params[] = $like;
             $params[] = $like;
@@ -63,26 +63,26 @@ class HistoryPage {
             $params[] = $like;
         }
 
-        $count_sql   = "SELECT COUNT(*) FROM $table_name WHERE $where";
+        $count_sql    = "SELECT COUNT(*) FROM $table_name WHERE $where";
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments; dynamic values are prepared before execution.
         $total_items = (int) ( $params ? $wpdb->get_var( $wpdb->prepare( $count_sql, $params ) ) : $wpdb->get_var( $count_sql ) );
-        $total_pages  = (int) ceil($total_items / $per_page);
+        $total_pages  = (int) ceil( $total_items / $per_page );
 
         $pagination_links = $total_pages > 1 ? paginate_links(
             [
-            'base'      => add_query_arg( 'paged', '%#%' ),
-            'format'    => '',
-            'prev_text' => '&laquo;',
-            'next_text' => '&raquo;',
-            'total'     => $total_pages,
-            'current'   => $current_page,
+                'base'      => add_query_arg( 'paged', '%#%' ),
+                'format'    => '',
+                'prev_text' => '&laquo;',
+                'next_text' => '&raquo;',
+                'total'     => $total_pages,
+                'current'   => $current_page,
             ]
         ) : '';
 
         $select_sql = "SELECT * FROM $table_name WHERE $where ORDER BY changed_at DESC LIMIT %d OFFSET %d";
         $query_args = array_merge( $params, [ $per_page, $offset ] );
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments; dynamic values are prepared before execution.
-        $qr_codes   = $wpdb->get_results( $wpdb->prepare( $select_sql, $query_args ) );
+        $qr_codes    = $wpdb->get_results( $wpdb->prepare( $select_sql, $query_args ) );
         ?>
         <div class="wrap">
             <h1>QR Code History</h1>
@@ -102,7 +102,7 @@ class HistoryPage {
                 <a href="<?php echo esc_url( admin_url( 'admin.php?page=kerbcycle-qr-history' ) ); ?>" class="button"><?php esc_html_e( 'Reset', 'kerbcycle-qr-code-manager' ); ?></a>
             </form>
             <p class="description">Recent QR code activity</p>
-            <?php if ($pagination_links) : ?>
+            <?php if ( $pagination_links ) : ?>
                 <div class="tablenav">
                     <div class="tablenav-pages">
                         <?php echo wp_kses_post( $pagination_links ); ?>
@@ -121,7 +121,7 @@ class HistoryPage {
                 </thead>
                 <tbody>
                     <?php if ( ! empty( $qr_codes ) ) : ?>
-                        <?php foreach ($qr_codes as $qr) : ?>
+                        <?php foreach ( $qr_codes as $qr ) : ?>
                             <tr>
                                 <td><?php echo esc_html( $qr->id ); ?></td>
                                 <td><?php echo esc_html( $qr->qr_code ); ?></td>
@@ -135,7 +135,7 @@ class HistoryPage {
                     <?php endif; ?>
                 </tbody>
             </table>
-            <?php if ($pagination_links) : ?>
+            <?php if ( $pagination_links ) : ?>
                 <div class="tablenav">
                     <div class="tablenav-pages">
                         <?php echo wp_kses_post( $pagination_links ); ?>

--- a/includes/Admin/Pages/HistoryPage.php
+++ b/includes/Admin/Pages/HistoryPage.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode\Admin\Pages;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -13,25 +13,28 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Admin\Pages
  */
-class HistoryPage
-{
+class HistoryPage {
     /**
      * Render the history page.
      *
      * @since    1.0.0
      */
-    public function render()
-    {
+    public function render() {
         global $wpdb;
         $table_name   = $wpdb->prefix . 'kerbcycle_qr_code_history';
-        $per_page     = (int) get_option('kerbcycle_history_per_page', 20);
-        $current_page = isset($_GET['paged']) ? max(1, absint($_GET['paged'])) : 1;
+        $per_page     = (int) get_option( 'kerbcycle_history_per_page', 20 );
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
+        $current_page = isset( $_GET['paged'] ) ? max( 1, absint( wp_unslash( $_GET['paged'] ) ) ) : 1;
         $offset       = ($current_page - 1) * $per_page;
 
-        $status_filter = isset($_GET['status_filter']) ? sanitize_text_field(wp_unslash($_GET['status_filter'])) : '';
-        $start_date    = isset($_GET['start_date']) ? sanitize_text_field(wp_unslash($_GET['start_date'])) : '';
-        $end_date      = isset($_GET['end_date']) ? sanitize_text_field(wp_unslash($_GET['end_date'])) : '';
-        $search        = isset($_GET['s']) ? sanitize_text_field(wp_unslash($_GET['s'])) : '';
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
+        $status_filter = isset( $_GET['status_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['status_filter'] ) ) : '';
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
+        $start_date    = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : '';
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
+        $end_date      = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : '';
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
+        $search        = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
 
         $where  = '1=1';
         $params = [];
@@ -61,44 +64,48 @@ class HistoryPage
         }
 
         $count_sql   = "SELECT COUNT(*) FROM $table_name WHERE $where";
-        $total_items = (int) ($params ? $wpdb->get_var($wpdb->prepare($count_sql, $params)) : $wpdb->get_var($count_sql));
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments; dynamic values are prepared before execution.
+        $total_items = (int) ( $params ? $wpdb->get_var( $wpdb->prepare( $count_sql, $params ) ) : $wpdb->get_var( $count_sql ) );
         $total_pages  = (int) ceil($total_items / $per_page);
 
-        $pagination_links = $total_pages > 1 ? paginate_links([
-            'base'      => add_query_arg('paged', '%#%'),
+        $pagination_links = $total_pages > 1 ? paginate_links(
+            [
+            'base'      => add_query_arg( 'paged', '%#%' ),
             'format'    => '',
             'prev_text' => '&laquo;',
             'next_text' => '&raquo;',
             'total'     => $total_pages,
             'current'   => $current_page,
-        ]) : '';
+            ]
+        ) : '';
 
         $select_sql = "SELECT * FROM $table_name WHERE $where ORDER BY changed_at DESC LIMIT %d OFFSET %d";
-        $query_args = array_merge($params, [$per_page, $offset]);
-        $qr_codes   = $wpdb->get_results($wpdb->prepare($select_sql, $query_args));
+        $query_args = array_merge( $params, [ $per_page, $offset ] );
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments; dynamic values are prepared before execution.
+        $qr_codes   = $wpdb->get_results( $wpdb->prepare( $select_sql, $query_args ) );
         ?>
         <div class="wrap">
             <h1>QR Code History</h1>
             <form method="get" class="qr-filters" style="margin-bottom:15px;">
                 <input type="hidden" name="page" value="kerbcycle-qr-history" />
                 <select name="status_filter">
-                    <option value=""><?php esc_html_e('All Statuses', 'kerbcycle'); ?></option>
-                    <option value="assigned" <?php selected($status_filter, 'assigned'); ?>><?php esc_html_e('Assigned', 'kerbcycle'); ?></option>
-                    <option value="released" <?php selected($status_filter, 'released'); ?>><?php esc_html_e('Released', 'kerbcycle'); ?></option>
-                    <option value="deleted" <?php selected($status_filter, 'deleted'); ?>><?php esc_html_e('Deleted', 'kerbcycle'); ?></option>
-                    <option value="added" <?php selected($status_filter, 'added'); ?>><?php esc_html_e('Added', 'kerbcycle'); ?></option>
+                    <option value=""><?php esc_html_e( 'All Statuses', 'kerbcycle-qr-code-manager' ); ?></option>
+                    <option value="assigned" <?php selected( $status_filter, 'assigned' ); ?>><?php esc_html_e( 'Assigned', 'kerbcycle-qr-code-manager' ); ?></option>
+                    <option value="released" <?php selected( $status_filter, 'released' ); ?>><?php esc_html_e( 'Released', 'kerbcycle-qr-code-manager' ); ?></option>
+                    <option value="deleted" <?php selected( $status_filter, 'deleted' ); ?>><?php esc_html_e( 'Deleted', 'kerbcycle-qr-code-manager' ); ?></option>
+                    <option value="added" <?php selected( $status_filter, 'added' ); ?>><?php esc_html_e( 'Added', 'kerbcycle-qr-code-manager' ); ?></option>
                 </select>
-                <input type="date" name="start_date" value="<?= esc_attr($start_date); ?>" />
-                <input type="date" name="end_date" value="<?= esc_attr($end_date); ?>" />
-                <input type="search" name="s" value="<?= esc_attr($search); ?>" placeholder="<?php esc_attr_e('Search', 'kerbcycle'); ?>" />
-                <button class="button"><?php esc_html_e('Filter', 'kerbcycle'); ?></button>
-                <a href="<?php echo esc_url(admin_url('admin.php?page=kerbcycle-qr-history')); ?>" class="button"><?php esc_html_e('Reset', 'kerbcycle'); ?></a>
+                <input type="date" name="start_date" value="<?php echo esc_attr( $start_date ); ?>" />
+                <input type="date" name="end_date" value="<?php echo esc_attr( $end_date ); ?>" />
+                <input type="search" name="s" value="<?php echo esc_attr( $search ); ?>" placeholder="<?php esc_attr_e( 'Search', 'kerbcycle-qr-code-manager' ); ?>" />
+                <button class="button"><?php esc_html_e( 'Filter', 'kerbcycle-qr-code-manager' ); ?></button>
+                <a href="<?php echo esc_url( admin_url( 'admin.php?page=kerbcycle-qr-history' ) ); ?>" class="button"><?php esc_html_e( 'Reset', 'kerbcycle-qr-code-manager' ); ?></a>
             </form>
             <p class="description">Recent QR code activity</p>
             <?php if ($pagination_links) : ?>
                 <div class="tablenav">
                     <div class="tablenav-pages">
-                        <?= $pagination_links; ?>
+                        <?php echo wp_kses_post( $pagination_links ); ?>
                     </div>
                 </div>
             <?php endif; ?>
@@ -113,14 +120,14 @@ class HistoryPage
                     </tr>
                 </thead>
                 <tbody>
-                    <?php if (!empty($qr_codes)) : ?>
+                    <?php if ( ! empty( $qr_codes ) ) : ?>
                         <?php foreach ($qr_codes as $qr) : ?>
                             <tr>
-                                <td><?= esc_html($qr->id) ?></td>
-                                <td><?= esc_html($qr->qr_code) ?></td>
-                                <td><?= $qr->user_id ? esc_html($qr->user_id) : '—' ?></td>
-                                <td><?= esc_html(ucfirst($qr->status)) ?></td>
-                                <td><?= $qr->changed_at ? esc_html($qr->changed_at) : '—' ?></td>
+                                <td><?php echo esc_html( $qr->id ); ?></td>
+                                <td><?php echo esc_html( $qr->qr_code ); ?></td>
+                                <td><?php echo $qr->user_id ? esc_html( $qr->user_id ) : '—'; ?></td>
+                                <td><?php echo esc_html( ucfirst( $qr->status ) ); ?></td>
+                                <td><?php echo $qr->changed_at ? esc_html( $qr->changed_at ) : '—'; ?></td>
                             </tr>
                         <?php endforeach; ?>
                     <?php else : ?>
@@ -131,7 +138,7 @@ class HistoryPage
             <?php if ($pagination_links) : ?>
                 <div class="tablenav">
                     <div class="tablenav-pages">
-                        <?= $pagination_links; ?>
+                        <?php echo wp_kses_post( $pagination_links ); ?>
                     </div>
                 </div>
             <?php endif; ?>

--- a/includes/Admin/Pages/HistoryPage.php
+++ b/includes/Admin/Pages/HistoryPage.php
@@ -30,11 +30,11 @@ class HistoryPage {
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
         $status_filter = isset( $_GET['status_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['status_filter'] ) ) : '';
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
-        $start_date    = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : '';
+        $start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : '';
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
-        $end_date      = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : '';
+        $end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : '';
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
-        $search        = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+        $search = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
 
         $where  = '1=1';
         $params = [];

--- a/includes/Admin/Pages/HistoryPage.php
+++ b/includes/Admin/Pages/HistoryPage.php
@@ -21,8 +21,8 @@ class HistoryPage {
      */
     public function render() {
         global $wpdb;
-        $table_name   = $wpdb->prefix . 'kerbcycle_qr_code_history';
-        $per_page     = (int) get_option( 'kerbcycle_history_per_page', 20 );
+        $table_name = $wpdb->prefix . 'kerbcycle_qr_code_history';
+        $per_page   = (int) get_option( 'kerbcycle_history_per_page', 20 );
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only history filter/pagination state; no server-side state is changed here.
         $current_page = isset( $_GET['paged'] ) ? max( 1, absint( wp_unslash( $_GET['paged'] ) ) ) : 1;
         $offset       = ( $current_page - 1 ) * $per_page;
@@ -63,7 +63,7 @@ class HistoryPage {
             $params[] = $like;
         }
 
-        $count_sql   = "SELECT COUNT(*) FROM $table_name WHERE $where";
+        $count_sql = "SELECT COUNT(*) FROM $table_name WHERE $where";
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments; dynamic values are prepared before execution.
         $total_items = (int) ( $params ? $wpdb->get_var( $wpdb->prepare( $count_sql, $params ) ) : $wpdb->get_var( $count_sql ) );
         $total_pages = (int) ceil( $total_items / $per_page );
@@ -82,7 +82,7 @@ class HistoryPage {
         $select_sql = "SELECT * FROM $table_name WHERE $where ORDER BY changed_at DESC LIMIT %d OFFSET %d";
         $query_args = array_merge( $params, [ $per_page, $offset ] );
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments; dynamic values are prepared before execution.
-        $qr_codes   = $wpdb->get_results( $wpdb->prepare( $select_sql, $query_args ) );
+        $qr_codes = $wpdb->get_results( $wpdb->prepare( $select_sql, $query_args ) );
         ?>
         <div class="wrap">
             <h1>QR Code History</h1>


### PR DESCRIPTION
### Motivation
- Fix PHPCS/style and security scanner findings in `includes/Admin/Pages/HistoryPage.php` without changing page behavior, pagination, SQL semantics, or visible text. 
- Address nonce warnings for request-derived filters, SQL prepared-statement warnings, text-domain inconsistencies, and short-echo/escaping findings reported for this file.

### Description
- Normalized ABSPATH guard spacing, class/function brace placement, and function-call/array formatting in `includes/Admin/Pages/HistoryPage.php` to satisfy style concerns. 
- Treated `paged`, `status_filter`, `start_date`, `end_date`, and `s` as read-only filter/pagination/display state, added `wp_unslash()` + `sanitize_text_field()` and narrow PHPCS nonce-warning suppressions with inline rationale. 
- Kept SQL assembly unchanged but ensured dynamic values are passed to `$wpdb->prepare()` and added narrow `WordPress.DB.PreparedSQL.NotPrepared` suppressions at the execution points where the SQL is assembled from fixed fragments and prepared arguments. 
- Replaced short-echo tags with explicit `<?php echo ...; ?>`, changed in-file text-domain occurrences from `'kerbcycle'` to `'kerbcycle-qr-code-manager'`, and escaped pagination output using `wp_kses_post( $pagination_links )` to preserve link markup while satisfying escaping rules. 
- No namespace, class, method, filter names, SQL columns/WHERE/ORDER/LIMIT semantics, pagination behavior, or visible string text were changed, and only `includes/Admin/Pages/HistoryPage.php` was modified. 

### Testing
- Ran `git diff --name-only` and confirmed only `includes/Admin/Pages/HistoryPage.php` changed (`includes/Admin/Pages/HistoryPage.php`).
- Ran `php -l includes/Admin/Pages/HistoryPage.php` and received `No syntax errors detected in includes/Admin/Pages/HistoryPage.php` indicating the file is syntactically valid.
- Attempted `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Admin/Pages/HistoryPage.php -s` but the environment lacks PHPCS (`vendor/bin/phpcs: No such file or directory`), so file-specific PHPCS must be run in CI/Codespace; local PHPCS validation is therefore blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea2a2f488832d9b19c8433cf1962a)