### PR TITLE
PHPCS Pass 3B.27A: clean QrCodeRepository formatting and annotate safe SQL patterns

### DIFF
--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -126,9 +126,9 @@ class QrCodeRepository {
 		global $wpdb;
 		$released_count = 0;
 		foreach ( $codes as $code ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
 			$row = $wpdb->get_row(
 				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
 					"SELECT id, user_id FROM $this->table WHERE qr_code = %s AND status = 'assigned' ORDER BY id DESC LIMIT 1",
 					$code
 				)
@@ -165,8 +165,8 @@ class QrCodeRepository {
 		}
 
 		$placeholders = implode( ',', array_fill( 0, count( $codes ), '%s' ) );
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived; placeholder list is generated from sanitized value count and query values are prepared below.
 		$query = $wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived; placeholder list is generated from value count and query values are prepared.
 			"SELECT qr_code FROM {$this->table} WHERE status = 'available' AND qr_code IN ($placeholders)",
 			$codes
 		);
@@ -178,8 +178,8 @@ class QrCodeRepository {
 		}
 
 		$placeholders = implode( ',', array_fill( 0, count( $existing ), '%s' ) );
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived; placeholder list is generated from sanitized value count and query values are prepared below.
 		$delete_query = $wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived; placeholder list is generated from value count and query values are prepared.
 			"DELETE FROM {$this->table} WHERE status = 'available' AND qr_code IN ($placeholders)",
 			$existing
 		);
@@ -219,9 +219,9 @@ class QrCodeRepository {
 
 	public function find_latest_by_status( $qr_code, $status ) {
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
 		return $wpdb->get_row(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
 				"SELECT * FROM $this->table WHERE qr_code = %s AND status = %s ORDER BY id DESC LIMIT 1",
 				$qr_code,
 				$status
@@ -231,9 +231,9 @@ class QrCodeRepository {
 
 	public function count_by_status( $qr_code, $status ) {
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
 		return (int) $wpdb->get_var(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
 				"SELECT COUNT(*) FROM $this->table WHERE qr_code = %s AND status = %s",
 				$qr_code,
 				$status
@@ -249,9 +249,9 @@ class QrCodeRepository {
 
 	public function list_assigned_by_user( $user_id ) {
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
 		return $wpdb->get_col(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
 				"SELECT qr_code FROM {$this->table} WHERE status = 'assigned' AND user_id = %d ORDER BY id DESC",
 				$user_id
 			)
@@ -260,8 +260,8 @@ class QrCodeRepository {
 
 	public function list_all() {
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
 		return $wpdb->get_results(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
 			"SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $this->table" .
 			' ORDER BY assigned_at DESC, id DESC'
 		);

--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -165,7 +165,7 @@ class QrCodeRepository {
 		}
 
 		$placeholders = implode( ',', array_fill( 0, count( $codes ), '%s' ) );
-		$query = $wpdb->prepare(
+		$query        = $wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived; placeholder list is generated from value count and query values are prepared.
 			"SELECT qr_code FROM {$this->table} WHERE status = 'available' AND qr_code IN ($placeholders)",
 			$codes

--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -2,8 +2,8 @@
 
 namespace Kerbcycle\QrCode\Data\Repositories;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 /**
@@ -13,314 +13,290 @@ if (!defined('ABSPATH')) {
  * @package    Kerbcycle\QrCode
  * @subpackage Kerbcycle\QrCode\Data\Repositories
  */
-class QrCodeRepository
-{
-    private $table;
-    private $history;
+class QrCodeRepository {
+	private $table;
+	private $history;
 
-    public function __construct()
-    {
-        global $wpdb;
-        $this->table   = $wpdb->prefix . 'kerbcycle_qr_codes';
-        $this->history = new QrCodeHistoryRepository();
-    }
+	public function __construct() {
+		global $wpdb;
+		$this->table   = $wpdb->prefix . 'kerbcycle_qr_codes';
+		$this->history = new QrCodeHistoryRepository();
+	}
 
-    public function insert_available($qr_code)
-    {
-        global $wpdb;
-        $result = $wpdb->insert(
-            $this->table,
-            [
-                'qr_code' => $qr_code,
-                'status'  => 'available',
-            ],
-            ['%s', '%s']
-        );
+	public function insert_available( $qr_code ) {
+		global $wpdb;
+		$result = $wpdb->insert(
+			$this->table,
+			[
+				'qr_code' => $qr_code,
+				'status'  => 'available',
+			],
+			[ '%s', '%s' ]
+		);
 
-        if ($result !== false) {
-            $this->history->log($qr_code, null, 'added');
-        }
+		if ( false !== $result ) {
+			$this->history->log( $qr_code, null, 'added' );
+		}
 
-        return $result;
-    }
+		return $result;
+	}
 
-    public function update_available_to_assigned($qr_code, $user_id, $display_name)
-    {
-        global $wpdb;
-        $row = $this->find_latest_by_status($qr_code, 'available');
-        if ( ! $row || empty($row->id) ) {
-            return 0;
-        }
+	public function update_available_to_assigned( $qr_code, $user_id, $display_name ) {
+		global $wpdb;
+		$row = $this->find_latest_by_status( $qr_code, 'available' );
+		if ( ! $row || empty( $row->id ) ) {
+			return 0;
+		}
 
-        $result = $wpdb->update(
-            $this->table,
-            [
-                'user_id'      => $user_id,
-                'display_name' => $display_name,
-                'status'       => 'assigned',
-                'assigned_at'  => current_time('mysql'),
-            ],
-            [
-                'id'      => (int) $row->id,
-                'status'  => 'available',
-            ],
-            ['%d', '%s', '%s', '%s'],
-            ['%d', '%s']
-        );
+		$result = $wpdb->update(
+			$this->table,
+			[
+				'user_id'      => $user_id,
+				'display_name' => $display_name,
+				'status'       => 'assigned',
+				'assigned_at'  => current_time( 'mysql' ),
+			],
+			[
+				'id'     => (int) $row->id,
+				'status' => 'available',
+			],
+			[ '%d', '%s', '%s', '%s' ],
+			[ '%d', '%s' ]
+		);
 
-        if ($result !== false) {
-            $this->history->log($qr_code, $user_id, 'assigned');
-        }
+		if ( false !== $result ) {
+			$this->history->log( $qr_code, $user_id, 'assigned' );
+		}
 
-        return $result;
-    }
+		return $result;
+	}
 
-    public function insert_assigned($qr_code, $user_id, $display_name)
-    {
-        global $wpdb;
-        $result = $wpdb->insert(
-            $this->table,
-            [
-                'qr_code'      => $qr_code,
-                'user_id'     => $user_id,
-                'display_name' => $display_name,
-                'status'      => 'assigned',
-                'assigned_at' => current_time('mysql'),
-            ],
-            ['%s', '%d', '%s', '%s', '%s']
-        );
+	public function insert_assigned( $qr_code, $user_id, $display_name ) {
+		global $wpdb;
+		$result = $wpdb->insert(
+			$this->table,
+			[
+				'qr_code'      => $qr_code,
+				'user_id'      => $user_id,
+				'display_name' => $display_name,
+				'status'       => 'assigned',
+				'assigned_at'  => current_time( 'mysql' ),
+			],
+			[ '%s', '%d', '%s', '%s', '%s' ]
+		);
 
-        if ($result !== false) {
-            $this->history->log($qr_code, $user_id, 'assigned');
-        }
+		if ( false !== $result ) {
+			$this->history->log( $qr_code, $user_id, 'assigned' );
+		}
 
-        return $result;
-    }
+		return $result;
+	}
 
-    public function release_latest_assigned($qr_code)
-    {
-        global $wpdb;
-        $row = $this->find_latest_by_status($qr_code, 'assigned');
+	public function release_latest_assigned( $qr_code ) {
+		global $wpdb;
+		$row = $this->find_latest_by_status( $qr_code, 'assigned' );
 
-        if ( $row ) {
-            $result = $wpdb->update(
-                $this->table,
-                [
-                    'user_id'      => null,
-                    'status'       => 'available',
-                    'assigned_at'  => null,
-                    'display_name' => null,
-                ],
-                [
-                    'id'     => (int) $row->id,
-                    'status' => 'assigned',
-                ],
-                ['%d', '%s', '%s', '%s'],
-                ['%d', '%s']
-            );
+		if ( $row ) {
+			$result = $wpdb->update(
+				$this->table,
+				[
+					'user_id'      => null,
+					'status'       => 'available',
+					'assigned_at'  => null,
+					'display_name' => null,
+				],
+				[
+					'id'     => (int) $row->id,
+					'status' => 'assigned',
+				],
+				[ '%d', '%s', '%s', '%s' ],
+				[ '%d', '%s' ]
+			);
 
-            if ( false !== $result ) {
-                $this->history->log($qr_code, $row->user_id, 'released');
-            }
+			if ( false !== $result ) {
+				$this->history->log( $qr_code, $row->user_id, 'released' );
+			}
 
-            return $result;
-        }
-        return false;
-    }
+			return $result;
+		}
+		return false;
+	}
 
-    public function bulk_release(array $codes)
-    {
-        global $wpdb;
-        $released_count = 0;
-        foreach ($codes as $code) {
-            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
-            $row = $wpdb->get_row(
-                $wpdb->prepare(
-                    "SELECT id, user_id FROM $this->table WHERE qr_code = %s AND status = 'assigned' ORDER BY id DESC LIMIT 1",
-                    $code
-                )
-            );
+	public function bulk_release( array $codes ) {
+		global $wpdb;
+		$released_count = 0;
+		foreach ( $codes as $code ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
+			$row = $wpdb->get_row(
+				$wpdb->prepare(
+					"SELECT id, user_id FROM $this->table WHERE qr_code = %s AND status = 'assigned' ORDER BY id DESC LIMIT 1",
+					$code
+				)
+			);
 
-            if ( $row ) {
-                $result = $wpdb->update(
-                    $this->table,
-                    [
-                        'user_id'      => null,
-                        'status'       => 'available',
-                        'assigned_at'  => null,
-                        'display_name' => null,
-                    ],
-                    ['id' => (int) $row->id],
-                    ['%d', '%s', '%s', '%s'],
-                    ['%d']
-                );
+			if ( $row ) {
+				$result = $wpdb->update(
+					$this->table,
+					[
+						'user_id'      => null,
+						'status'       => 'available',
+						'assigned_at'  => null,
+						'display_name' => null,
+					],
+					[ 'id' => (int) $row->id ],
+					[ '%d', '%s', '%s', '%s' ],
+					[ '%d' ]
+				);
 
-                if ( false !== $result ) {
-                    $this->history->log($code, $row->user_id, 'released');
-                    $released_count += $result;
-                }
-            }
-        }
+				if ( false !== $result ) {
+					$this->history->log( $code, $row->user_id, 'released' );
+					$released_count += $result;
+				}
+			}
+		}
 
-        return $released_count;
-    }
+		return $released_count;
+	}
 
-    public function bulk_delete_available(array $codes)
-    {
-        global $wpdb;
-        if ( empty($codes) ) {
-            return 0;
-        }
+	public function bulk_delete_available( array $codes ) {
+		global $wpdb;
+		if ( empty( $codes ) ) {
+			return 0;
+		}
 
-        $placeholders = implode(',', array_fill(0, count($codes), '%s'));
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived; placeholder list is generated from sanitized value count and prepared below.
-        $query = $wpdb->prepare(
-            "SELECT qr_code FROM {$this->table} WHERE status = 'available' AND qr_code IN ($placeholders)",
-            $codes
-        );
-        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments and internally derived table name; dynamic values are prepared before execution.
-        $existing = $wpdb->get_col($query);
+		$placeholders = implode( ',', array_fill( 0, count( $codes ), '%s' ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived; placeholder list is generated from sanitized value count and query values are prepared below.
+		$query = $wpdb->prepare(
+			"SELECT qr_code FROM {$this->table} WHERE status = 'available' AND qr_code IN ($placeholders)",
+			$codes
+		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments and internally derived table name; dynamic values are prepared before execution.
+		$existing = $wpdb->get_col( $query );
 
-        if ( empty($existing) ) {
-            return 0;
-        }
+		if ( empty( $existing ) ) {
+			return 0;
+		}
 
-        $placeholders = implode(',', array_fill(0, count($existing), '%s'));
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived; placeholder list is generated from sanitized value count and prepared below.
-        $delete_query = $wpdb->prepare(
-            "DELETE FROM {$this->table} WHERE status = 'available' AND qr_code IN ($placeholders)",
-            $existing
-        );
-        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments and internally derived table name; dynamic values are prepared before execution.
-        $deleted_count = $wpdb->query($delete_query);
+		$placeholders = implode( ',', array_fill( 0, count( $existing ), '%s' ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived; placeholder list is generated from sanitized value count and query values are prepared below.
+		$delete_query = $wpdb->prepare(
+			"DELETE FROM {$this->table} WHERE status = 'available' AND qr_code IN ($placeholders)",
+			$existing
+		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments and internally derived table name; dynamic values are prepared before execution.
+		$deleted_count = $wpdb->query( $delete_query );
 
-        if ( $deleted_count ) {
-            foreach ($existing as $code) {
-                $this->history->log($code, null, 'deleted');
-            }
-        }
+		if ( $deleted_count ) {
+			foreach ( $existing as $code ) {
+				$this->history->log( $code, null, 'deleted' );
+			}
+		}
 
-        return (int) $deleted_count;
-    }
+		return (int) $deleted_count;
+	}
 
-    public function update_code($old_code, $new_code)
-    {
-        global $wpdb;
-        return $wpdb->update(
-            $this->table,
-            ['qr_code' => $new_code],
-            ['qr_code' => $old_code],
-            ['%s'],
-            ['%s']
-        );
-    }
+	public function update_code( $old_code, $new_code ) {
+		global $wpdb;
+		return $wpdb->update(
+			$this->table,
+			[ 'qr_code' => $new_code ],
+			[ 'qr_code' => $old_code ],
+			[ '%s' ],
+			[ '%s' ]
+		);
+	}
 
-    public function find_by_qr_code($qr_code)
-    {
-        global $wpdb;
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
-        return $wpdb->get_row($wpdb->prepare("SELECT * FROM $this->table WHERE qr_code = %s ORDER BY id DESC LIMIT 1", $qr_code));
-    }
+	public function find_by_qr_code( $qr_code ) {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
+		return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $this->table WHERE qr_code = %s ORDER BY id DESC LIMIT 1", $qr_code ) );
+	}
 
-    public function available_exists($qr_code)
-    {
-        global $wpdb;
-        return $this->count_by_status($qr_code, 'available') > 0;
-    }
+	public function available_exists( $qr_code ) {
+		global $wpdb;
+		return $this->count_by_status( $qr_code, 'available' ) > 0;
+	}
 
-    public function find_latest_by_status($qr_code, $status)
-    {
-        global $wpdb;
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
-        return $wpdb->get_row(
-            $wpdb->prepare(
-                "SELECT * FROM $this->table WHERE qr_code = %s AND status = %s ORDER BY id DESC LIMIT 1",
-                $qr_code,
-                $status
-            )
-        );
-    }
+	public function find_latest_by_status( $qr_code, $status ) {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM $this->table WHERE qr_code = %s AND status = %s ORDER BY id DESC LIMIT 1",
+				$qr_code,
+				$status
+			)
+		);
+	}
 
-    public function count_by_status($qr_code, $status)
-    {
-        global $wpdb;
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
-        return (int) $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT COUNT(*) FROM $this->table WHERE qr_code = %s AND status = %s",
-                $qr_code,
-                $status
-            )
-        );
-    }
+	public function count_by_status( $qr_code, $status ) {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM $this->table WHERE qr_code = %s AND status = %s",
+				$qr_code,
+				$status
+			)
+		);
+	}
 
-    public function list_available()
-    {
-        global $wpdb;
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
-        return $wpdb->get_results("SELECT qr_code FROM $this->table WHERE status = 'available' ORDER BY id DESC");
-    }
+	public function list_available() {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
+		return $wpdb->get_results( "SELECT qr_code FROM $this->table WHERE status = 'available' ORDER BY id DESC" );
+	}
 
-    public function list_assigned_by_user($user_id)
-    {
-        global $wpdb;
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
-        return $wpdb->get_col(
-            $wpdb->prepare(
-                "SELECT qr_code FROM {$this->table} WHERE status = 'assigned' AND user_id = %d ORDER BY id DESC",
-                $user_id
-            )
-        );
-    }
+	public function list_assigned_by_user( $user_id ) {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
+		return $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT qr_code FROM {$this->table} WHERE status = 'assigned' AND user_id = %d ORDER BY id DESC",
+				$user_id
+			)
+		);
+	}
 
-    public function list_all()
-    {
-        global $wpdb;
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
-        return $wpdb->get_results(
-            "SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $this->table"
-            . " ORDER BY assigned_at DESC, id DESC"
-        );
-    }
+	public function list_all() {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
+		return $wpdb->get_results(
+			"SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $this->table" .
+			' ORDER BY assigned_at DESC, id DESC'
+		);
+	}
 
-    public function recent_history($limit)
-    {
-        return $this->history->recent($limit);
-    }
+	public function recent_history( $limit ) {
+		return $this->history->recent( $limit );
+	}
 
-    // Legacy wrappers
-    public function assign($qr_code, $user_id, $display_name = '')
-    {
-        return $this->insert_assigned($qr_code, $user_id, $display_name);
-    }
+	// Legacy wrappers
+	public function assign( $qr_code, $user_id, $display_name = '' ) {
+		return $this->insert_assigned( $qr_code, $user_id, $display_name );
+	}
 
-    public function add($qr_code)
-    {
-        return $this->insert_available($qr_code);
-    }
+	public function add( $qr_code ) {
+		return $this->insert_available( $qr_code );
+	}
 
-    public function release($qr_code)
-    {
-        return $this->release_latest_assigned($qr_code);
-    }
+	public function release( $qr_code ) {
+		return $this->release_latest_assigned( $qr_code );
+	}
 
-    public function update($old_code, $new_code)
-    {
-        return $this->update_code($old_code, $new_code);
-    }
+	public function update( $old_code, $new_code ) {
+		return $this->update_code( $old_code, $new_code );
+	}
 
-    public function get_available_codes()
-    {
-        return $this->list_available();
-    }
+	public function get_available_codes() {
+		return $this->list_available();
+	}
 
-    public function get_assigned_codes_by_user($user_id)
-    {
-        return $this->list_assigned_by_user($user_id);
-    }
+	public function get_assigned_codes_by_user( $user_id ) {
+		return $this->list_assigned_by_user( $user_id );
+	}
 
-    public function get_all_codes()
-    {
-        return $this->list_all();
-    }
+	public function get_all_codes() {
+		return $this->list_all();
+	}
 }

--- a/includes/Data/Repositories/QrCodeRepository.php
+++ b/includes/Data/Repositories/QrCodeRepository.php
@@ -48,21 +48,21 @@ class QrCodeRepository
     {
         global $wpdb;
         $row = $this->find_latest_by_status($qr_code, 'available');
-        if (!$row || empty($row->id)) {
+        if ( ! $row || empty($row->id) ) {
             return 0;
         }
 
         $result = $wpdb->update(
             $this->table,
             [
-                'user_id'     => $user_id,
+                'user_id'      => $user_id,
                 'display_name' => $display_name,
-                'status'      => 'assigned',
-                'assigned_at' => current_time('mysql')
+                'status'       => 'assigned',
+                'assigned_at'  => current_time('mysql'),
             ],
             [
                 'id'      => (int) $row->id,
-                'status'  => 'available'
+                'status'  => 'available',
             ],
             ['%d', '%s', '%s', '%s'],
             ['%d', '%s']
@@ -81,11 +81,11 @@ class QrCodeRepository
         $result = $wpdb->insert(
             $this->table,
             [
-                'qr_code'     => $qr_code,
+                'qr_code'      => $qr_code,
                 'user_id'     => $user_id,
                 'display_name' => $display_name,
                 'status'      => 'assigned',
-                'assigned_at' => current_time('mysql')
+                'assigned_at' => current_time('mysql'),
             ],
             ['%s', '%d', '%s', '%s', '%s']
         );
@@ -102,7 +102,7 @@ class QrCodeRepository
         global $wpdb;
         $row = $this->find_latest_by_status($qr_code, 'assigned');
 
-        if ($row) {
+        if ( $row ) {
             $result = $wpdb->update(
                 $this->table,
                 [
@@ -112,14 +112,14 @@ class QrCodeRepository
                     'display_name' => null,
                 ],
                 [
-                    'id' => (int) $row->id,
+                    'id'     => (int) $row->id,
                     'status' => 'assigned',
                 ],
                 ['%d', '%s', '%s', '%s'],
                 ['%d', '%s']
             );
 
-            if ($result !== false) {
+            if ( false !== $result ) {
                 $this->history->log($qr_code, $row->user_id, 'released');
             }
 
@@ -133,6 +133,7 @@ class QrCodeRepository
         global $wpdb;
         $released_count = 0;
         foreach ($codes as $code) {
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
             $row = $wpdb->get_row(
                 $wpdb->prepare(
                     "SELECT id, user_id FROM $this->table WHERE qr_code = %s AND status = 'assigned' ORDER BY id DESC LIMIT 1",
@@ -140,7 +141,7 @@ class QrCodeRepository
                 )
             );
 
-            if ($row) {
+            if ( $row ) {
                 $result = $wpdb->update(
                     $this->table,
                     [
@@ -149,46 +150,51 @@ class QrCodeRepository
                         'assigned_at'  => null,
                         'display_name' => null,
                     ],
-                    ['id' => $row->id],
+                    ['id' => (int) $row->id],
                     ['%d', '%s', '%s', '%s'],
                     ['%d']
                 );
 
-                if ($result !== false) {
+                if ( false !== $result ) {
                     $this->history->log($code, $row->user_id, 'released');
                     $released_count += $result;
                 }
             }
         }
+
         return $released_count;
     }
 
     public function bulk_delete_available(array $codes)
     {
         global $wpdb;
-        if (empty($codes)) {
+        if ( empty($codes) ) {
             return 0;
         }
 
         $placeholders = implode(',', array_fill(0, count($codes), '%s'));
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived; placeholder list is generated from sanitized value count and prepared below.
         $query = $wpdb->prepare(
             "SELECT qr_code FROM {$this->table} WHERE status = 'available' AND qr_code IN ($placeholders)",
             $codes
         );
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments and internally derived table name; dynamic values are prepared before execution.
         $existing = $wpdb->get_col($query);
 
-        if (empty($existing)) {
+        if ( empty($existing) ) {
             return 0;
         }
 
         $placeholders = implode(',', array_fill(0, count($existing), '%s'));
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name is internally derived; placeholder list is generated from sanitized value count and prepared below.
         $delete_query = $wpdb->prepare(
             "DELETE FROM {$this->table} WHERE status = 'available' AND qr_code IN ($placeholders)",
             $existing
         );
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is assembled from fixed fragments and internally derived table name; dynamic values are prepared before execution.
         $deleted_count = $wpdb->query($delete_query);
 
-        if ($deleted_count) {
+        if ( $deleted_count ) {
             foreach ($existing as $code) {
                 $this->history->log($code, null, 'deleted');
             }
@@ -212,6 +218,7 @@ class QrCodeRepository
     public function find_by_qr_code($qr_code)
     {
         global $wpdb;
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
         return $wpdb->get_row($wpdb->prepare("SELECT * FROM $this->table WHERE qr_code = %s ORDER BY id DESC LIMIT 1", $qr_code));
     }
 
@@ -224,6 +231,7 @@ class QrCodeRepository
     public function find_latest_by_status($qr_code, $status)
     {
         global $wpdb;
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
         return $wpdb->get_row(
             $wpdb->prepare(
                 "SELECT * FROM $this->table WHERE qr_code = %s AND status = %s ORDER BY id DESC LIMIT 1",
@@ -236,6 +244,7 @@ class QrCodeRepository
     public function count_by_status($qr_code, $status)
     {
         global $wpdb;
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
         return (int) $wpdb->get_var(
             $wpdb->prepare(
                 "SELECT COUNT(*) FROM $this->table WHERE qr_code = %s AND status = %s",
@@ -248,12 +257,14 @@ class QrCodeRepository
     public function list_available()
     {
         global $wpdb;
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
         return $wpdb->get_results("SELECT qr_code FROM $this->table WHERE status = 'available' ORDER BY id DESC");
     }
 
     public function list_assigned_by_user($user_id)
     {
         global $wpdb;
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query values are prepared.
         return $wpdb->get_col(
             $wpdb->prepare(
                 "SELECT qr_code FROM {$this->table} WHERE status = 'assigned' AND user_id = %d ORDER BY id DESC",
@@ -265,6 +276,7 @@ class QrCodeRepository
     public function list_all()
     {
         global $wpdb;
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; query has no user-supplied SQL fragments.
         return $wpdb->get_results(
             "SELECT id, qr_code, user_id, display_name, status, assigned_at FROM $this->table"
             . " ORDER BY assigned_at DESC, id DESC"


### PR DESCRIPTION
### Motivation
- Resolve file-scoped PHPCS formatting issues and address SQL scanner warnings in `QrCodeRepository.php` while preserving all repository behavior and public API.
- Keep changes surgical and limited to safe formatting and narrow SQL annotations where table interpolation is internally derived and query values are prepared.

### Description
- Applied formatting-equivalent cleanup to `includes/Data/Repositories/QrCodeRepository.php` (control-structure spacing, brace/parenthesis spacing, array spacing/alignment, missing trailing commas, minor cast/assignment alignment and consistency). Only formatting-style changes were made to existing lines.
- Normalized a few integer casts and update parameter types for consistency (`['id' => (int) $row->id]`) without changing semantics.
- Audited each SQL finding and added narrow `// phpcs:ignore ...` annotations only where justified by the repository pattern that the table name is derived from `$wpdb->prefix . 'kerbcycle_qr_codes'` and the dynamic values are prepared or not user-supplied: single-record SELECTs, COUNTs, list queries, and the bulk `IN (...)` select/delete paths.
- Left all query semantics unchanged: table suffix, selected columns, WHERE clauses, ORDER BY, LIMIT, lifecycle semantics, method names, return formats, and no other files modified.

SQL audit summary (per query group):
- Single-record SELECT queries (`find_by_qr_code`, `find_latest_by_status`): kept `prepare()` placeholders and added narrow interpolated-table suppression because table name is internally derived and values are prepared.
- COUNT query (`count_by_status`): kept `prepare()` placeholders and added narrow interpolated-table suppression.
- Available QR list (`list_available`) and QR list (`list_all`): added narrow interpolated-table suppression because these statements contain no user SQL fragments and table name is internal.
- Assigned-by-user query (`list_assigned_by_user`): kept `%d` `prepare()` usage and added narrow interpolated-table suppression.
- Bulk `IN (...)` availability select and delete (`bulk_delete_available`): confirmed placeholder string is generated from the value count and the final queries are executed via `$wpdb->prepare()` with the values; added narrow suppressions for `InterpolatedNotPrepared`, `PreparedSQLPlaceholders.UnfinishedPrepare`, and a `NotPrepared` suppression at the prepared-variable execution sites per guidance.

### Testing
- Commands run and results:
  - `git diff --name-only` returned:
    ```text
    includes/Data/Repositories/QrCodeRepository.php
    ```
  - `php -l includes/Data/Repositories/QrCodeRepository.php` returned:
    ```text
    No syntax errors detected in includes/Data/Repositories/QrCodeRepository.php
    ```
  - `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Data/Repositories/QrCodeRepository.php -s` could not be executed in this environment:
    ```text
    /bin/bash: line 1: vendor/bin/phpcs: No such file or directory
    ```
    This is an environment/tooling limitation; file-level PHPCS verification must be run in the project's CI or Codespace before merge.
- Automated checks performed in this environment succeeded for syntax and file-scope changes; PHPCS run is blocked by missing vendor tooling and must be validated in the project environment.

Files changed:
- `includes/Data/Repositories/QrCodeRepository.php`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feca23524c832da42bb71466ca33de)