### PR TITLE
PHPCS cleanup in GeneratorPage (formatting, text-domain, escaping, loop/count)

### DIFF
--- a/includes/Admin/Pages/GeneratorPage.php
+++ b/includes/Admin/Pages/GeneratorPage.php
@@ -11,24 +11,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Admin page for generating QR codes.
  */
-class GeneratorPage
-{
+class GeneratorPage {
     /** @var self */
     private static $instance;
 
     /**
      * Singleton instance.
      */
-    public static function instance(): self
-    {
+    public static function instance(): self {
         if ( ! self::$instance ) {
             self::$instance = new self();
         }
         return self::$instance;
     }
 
-    private function __construct()
-    {
+    private function __construct() {
         add_action( 'admin_enqueue_scripts', array( $this, 'assets' ) );
         add_action( 'wp_ajax_kerbcycle_generate_qr', array( $this, 'ajax_generate_qr' ) );
         add_action( 'admin_post_kerbcycle_export_qr_csv', array( $this, 'handle_export_csv' ) );
@@ -37,16 +34,15 @@ class GeneratorPage
     /**
      * Register assets for the generator page.
      */
-    public function assets($hook)
-    {
-        if (strpos($hook, 'kerbcycle-qr-generator') === false) {
+    public function assets( $hook ) {
+        if ( strpos( $hook, 'kerbcycle-qr-generator' ) === false ) {
             return;
         }
 
         wp_enqueue_script(
             'kerbcycle-qrcode',
             KERBCYCLE_QR_URL . 'assets/js/qrcode.min.js',
-            [],
+            array(),
             '1.0.0',
             true
         );
@@ -54,20 +50,24 @@ class GeneratorPage
         wp_enqueue_script(
             'kerbcycle-qr-generator',
             KERBCYCLE_QR_URL . 'assets/js/qr-generator.js',
-            ['jquery', 'kerbcycle-qrcode'],
+            array( 'jquery', 'kerbcycle-qrcode' ),
             '1.0.0',
             true
         );
 
-        wp_localize_script('kerbcycle-qr-generator', 'KerbcycleQRGen', [
-            'ajaxUrl' => admin_url('admin-ajax.php'),
-            'nonce'   => wp_create_nonce('kerbcycle_generate_qr'),
-        ]);
+        wp_localize_script(
+            'kerbcycle-qr-generator',
+            'KerbcycleQRGen',
+            array(
+                'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+                'nonce'   => wp_create_nonce( 'kerbcycle_generate_qr' ),
+            )
+        );
 
         wp_enqueue_style(
             'kerbcycle-qr-generator',
             KERBCYCLE_QR_URL . 'assets/css/qr-generator.css',
-            [],
+            array(),
             '1.0.0'
         );
     }
@@ -75,80 +75,79 @@ class GeneratorPage
     /**
      * Render the admin page.
      */
-    public function render()
-    {
-        if (!current_user_can('manage_options')) {
+    public function render() {
+        if ( ! current_user_can( 'manage_options' ) ) {
             wp_die( esc_html__( 'Insufficient permissions.', 'kerbcycle-qr-code-manager' ) );
         }
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e('QR Code Generator', 'kerbcycle-qr-code-manager'); ?></h1>
+            <h1><?php esc_html_e( 'QR Code Generator', 'kerbcycle-qr-code-manager' ); ?></h1>
 
             <div class="kc-card">
-                <h2><?php esc_html_e('Generate Codes', 'kerbcycle-qr-code-manager'); ?></h2>
+                <h2><?php esc_html_e( 'Generate Codes', 'kerbcycle-qr-code-manager' ); ?></h2>
                 <form id="kc-generate-form" onsubmit="return false;">
                     <div class="kc-row">
-                        <label><?php esc_html_e('Generate Type', 'kerbcycle-qr-code-manager'); ?></label>
+                        <label><?php esc_html_e( 'Generate Type', 'kerbcycle-qr-code-manager' ); ?></label>
                         <select id="kc-gen-type">
-                            <option value="single"><?php esc_html_e('Single (enter exact code)', 'kerbcycle-qr-code-manager'); ?></option>
-                            <option value="batch"><?php esc_html_e('Batch (random codes)', 'kerbcycle-qr-code-manager'); ?></option>
+                            <option value="single"><?php esc_html_e( 'Single (enter exact code)', 'kerbcycle-qr-code-manager' ); ?></option>
+                            <option value="batch"><?php esc_html_e( 'Batch (random codes)', 'kerbcycle-qr-code-manager' ); ?></option>
                         </select>
                     </div>
 
                     <div class="kc-row kc-if-single">
-                        <label><?php esc_html_e('Code', 'kerbcycle-qr-code-manager'); ?></label>
+                        <label><?php esc_html_e( 'Code', 'kerbcycle-qr-code-manager' ); ?></label>
                         <input type="text" id="kc-code" placeholder="e.g. KC-2025-0001" />
                     </div>
 
                     <div class="kc-row kc-if-batch" style="display:none;">
-                        <label><?php esc_html_e('How many?', 'kerbcycle-qr-code-manager'); ?></label>
+                        <label><?php esc_html_e( 'How many?', 'kerbcycle-qr-code-manager' ); ?></label>
                         <input type="number" id="kc-count" min="1" max="5000" value="20" />
                     </div>
 
                     <div class="kc-row kc-if-batch" style="display:none;">
-                        <label><?php esc_html_e('Prefix (optional)', 'kerbcycle-qr-code-manager'); ?></label>
+                        <label><?php esc_html_e( 'Prefix (optional)', 'kerbcycle-qr-code-manager' ); ?></label>
                         <input type="text" id="kc-prefix" placeholder="e.g. KC-2025-" />
                     </div>
 
                     <div class="kc-row kc-if-batch" style="display:none;">
-                        <label><?php esc_html_e('Length (random part)', 'kerbcycle-qr-code-manager'); ?></label>
+                        <label><?php esc_html_e( 'Length (random part)', 'kerbcycle-qr-code-manager' ); ?></label>
                         <input type="number" id="kc-length" min="4" max="16" value="8" />
                     </div>
 
                     <div class="kc-row">
-                        <button class="button button-primary" id="kc-generate-btn"><?php esc_html_e('Generate & Save', 'kerbcycle-qr-code-manager'); ?></button>
+                        <button class="button button-primary" id="kc-generate-btn"><?php esc_html_e( 'Generate & Save', 'kerbcycle-qr-code-manager' ); ?></button>
                     </div>
 
-                    <p class="description"><?php esc_html_e('Codes are saved to the repository only if unique. Duplicates are skipped.', 'kerbcycle-qr-code-manager'); ?></p>
+                    <p class="description"><?php esc_html_e( 'Codes are saved to the repository only if unique. Duplicates are skipped.', 'kerbcycle-qr-code-manager' ); ?></p>
                 </form>
 
                 <div id="kc-generate-result" class="kc-grid"></div>
             </div>
 
             <div class="kc-card">
-                <h2><?php esc_html_e('Export Repository (Date Range)', 'kerbcycle-qr-code-manager'); ?></h2>
-                <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
-                    <?php wp_nonce_field('kerbcycle_export_qr_csv', 'kc_export_nonce'); ?>
+                <h2><?php esc_html_e( 'Export Repository (Date Range)', 'kerbcycle-qr-code-manager' ); ?></h2>
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                    <?php wp_nonce_field( 'kerbcycle_export_qr_csv', 'kc_export_nonce' ); ?>
                     <input type="hidden" name="action" value="kerbcycle_export_qr_csv" />
                     <div class="kc-row">
-                        <label><?php esc_html_e('From', 'kerbcycle-qr-code-manager'); ?></label>
+                        <label><?php esc_html_e( 'From', 'kerbcycle-qr-code-manager' ); ?></label>
                         <input type="date" name="from" required />
                     </div>
                     <div class="kc-row">
-                        <label><?php esc_html_e('To', 'kerbcycle-qr-code-manager'); ?></label>
+                        <label><?php esc_html_e( 'To', 'kerbcycle-qr-code-manager' ); ?></label>
                         <input type="date" name="to" required />
                     </div>
                     <div class="kc-row">
-                        <label><?php esc_html_e('Export Type', 'kerbcycle-qr-code-manager'); ?></label>
+                        <label><?php esc_html_e( 'Export Type', 'kerbcycle-qr-code-manager' ); ?></label>
                         <select name="format">
-                            <option value="print"><?php esc_html_e('Printable Sheet (browser print)', 'kerbcycle-qr-code-manager'); ?></option>
-                            <option value="csv"><?php esc_html_e('CSV file', 'kerbcycle-qr-code-manager'); ?></option>
+                            <option value="print"><?php esc_html_e( 'Printable Sheet (browser print)', 'kerbcycle-qr-code-manager' ); ?></option>
+                            <option value="csv"><?php esc_html_e( 'CSV file', 'kerbcycle-qr-code-manager' ); ?></option>
                         </select>
                     </div>
                     <div class="kc-row">
-                        <button class="button"><?php esc_html_e('Export', 'kerbcycle-qr-code-manager'); ?></button>
+                        <button class="button"><?php esc_html_e( 'Export', 'kerbcycle-qr-code-manager' ); ?></button>
                     </div>
-                    <p class="description"><?php esc_html_e('“Printable Sheet” opens a formatted page you can print to paper or PDF. “CSV” downloads code data.', 'kerbcycle-qr-code-manager'); ?></p>
+                    <p class="description"><?php esc_html_e( '“Printable Sheet” opens a formatted page you can print to paper or PDF. “CSV” downloads code data.', 'kerbcycle-qr-code-manager' ); ?></p>
                 </form>
             </div>
         </div>
@@ -158,87 +157,90 @@ class GeneratorPage
     /**
      * AJAX: generate and save unique codes.
      */
-    public function ajax_generate_qr()
-    {
-        check_ajax_referer('kerbcycle_generate_qr', 'nonce');
-        if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => __('No permission', 'kerbcycle-qr-code-manager')], 403);
+    public function ajax_generate_qr() {
+        check_ajax_referer( 'kerbcycle_generate_qr', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( array( 'message' => __( 'No permission', 'kerbcycle-qr-code-manager' ) ), 403 );
         }
 
         $repo = new QrRepoRepository();
-        $user = get_current_user_id();
-        $type = sanitize_text_field(wp_unslash($_POST['genType'] ?? 'single'));
-        $result = ['saved' => [], 'skipped' => []];
+        $user   = get_current_user_id();
+        $type   = sanitize_text_field( wp_unslash( $_POST['genType'] ?? 'single' ) );
+        $result = array( 'saved' => array(), 'skipped' => array() );
 
-        if ($type === 'single') {
-            $code = trim(sanitize_text_field(wp_unslash($_POST['code'] ?? '')));
-            if ($code === '') {
-                wp_send_json_error(['message' => __('Code required.', 'kerbcycle-qr-code-manager')], 400);
+        if ( 'single' === $type ) {
+            $code = trim( sanitize_text_field( wp_unslash( $_POST['code'] ?? '' ) ) );
+            if ( '' === $code ) {
+                wp_send_json_error( array( 'message' => __( 'Code required.', 'kerbcycle-qr-code-manager' ) ), 400 );
             }
 
-            if ($repo->exists($code)) {
+            if ( $repo->exists( $code ) ) {
                 $result['skipped'][] = $code;
             } else {
-                $repo->insert($code, $user);
+                $repo->insert( $code, $user );
                 $result['saved'][] = $code;
             }
-            wp_send_json_success($result);
+            wp_send_json_success( $result );
         }
 
         $count  = max(1, min(5000, intval(wp_unslash($_POST['count'] ?? 20))));
         $prefix = sanitize_text_field(wp_unslash($_POST['prefix'] ?? ''));
         $len    = max(4, min(16, intval(wp_unslash($_POST['length'] ?? 8))));
 
-        if ($prefix !== '' && !preg_match('/^[A-Za-z0-9-]+$/', $prefix)) {
-            wp_send_json_error(['message' => __('Invalid prefix.', 'kerbcycle-qr-code-manager')], 400);
+        if ( '' !== $prefix && ! preg_match( '/^[A-Za-z0-9-]+$/', $prefix ) ) {
+            wp_send_json_error( array( 'message' => __( 'Invalid prefix.', 'kerbcycle-qr-code-manager' ) ), 400 );
         }
 
         $attempts = 0;
         $saved_count = count( $result['saved'] );
         while ( $saved_count < $count ) {
-            $rand = wp_generate_password($len, false, false);
+            $rand = wp_generate_password( $len, false, false );
             $code = $prefix . strtoupper($rand);
-            if ($repo->exists($code)) {
+            if ( $repo->exists( $code ) ) {
                 $result['skipped'][] = $code;
             } else {
-                $repo->insert($code, $user);
+                $repo->insert( $code, $user );
                 $result['saved'][] = $code;
                 ++$saved_count;
             }
             ++$attempts;
-            if ($attempts > $count * 5) {
+            if ( $attempts > $count * 5 ) {
                 break; // prevent infinite loops on extreme collisions
             }
         }
 
-        wp_send_json_success($result);
+        wp_send_json_success( $result );
     }
 
     /**
      * Handle CSV or printable export.
      */
-    public function handle_export_csv()
-    {
-        if (!current_user_can('manage_options')) {
-            wp_die(__('No permission.', 'kerbcycle-qr-code-manager'));
+    public function handle_export_csv() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'No permission.', 'kerbcycle-qr-code-manager' ) );
         }
-        if (!isset($_POST['kc_export_nonce']) || !wp_verify_nonce($_POST['kc_export_nonce'], 'kerbcycle_export_qr_csv')) {
-            wp_die(__('Bad nonce.', 'kerbcycle-qr-code-manager'));
+
+        $export_nonce = isset( $_POST['kc_export_nonce'] )
+            ? sanitize_text_field( wp_unslash( $_POST['kc_export_nonce'] ) )
+            : '';
+
+        if ( '' === $export_nonce || ! wp_verify_nonce( $export_nonce, 'kerbcycle_export_qr_csv' ) ) {
+            wp_die( esc_html__( 'Bad nonce.', 'kerbcycle-qr-code-manager' ) );
         }
 
         $from   = sanitize_text_field(wp_unslash($_POST['from'] ?? ''));
         $to     = sanitize_text_field(wp_unslash($_POST['to'] ?? ''));
         $format = sanitize_text_field(wp_unslash($_POST['format'] ?? 'csv'));
 
-        if (!$from || !$to) {
-            wp_die(__('Date range required.', 'kerbcycle-qr-code-manager'));
+        if ( ! $from || ! $to ) {
+            wp_die( esc_html__( 'Date range required.', 'kerbcycle-qr-code-manager' ) );
         }
 
         $repo = new QrRepoRepository();
         $rows = $repo->list_between($from, $to);
 
-        if ($format === 'print') {
-            $this->render_printable($rows, $from, $to);
+        if ( 'print' === $format ) {
+            $this->render_printable( $rows, $from, $to );
             exit;
         }
 
@@ -246,17 +248,16 @@ class GeneratorPage
         header('Content-Type: text/csv; charset=UTF-8');
         header('Content-Disposition: attachment; filename=kerbcycle-qr-codes-' . $from . '_to_' . $to . '.csv');
 
-        $out = fopen('php://output', 'w');
-        fputcsv($out, ['ID', 'Code', 'Status', 'Created At']);
-        foreach ($rows as $r) {
-            fputcsv($out, [$r['id'], $r['code'], $r['status'], $r['created_at']]);
+        $out = fopen( 'php://output', 'w' );
+        fputcsv( $out, array( 'ID', 'Code', 'Status', 'Created At' ) );
+        foreach ( $rows as $r ) {
+            fputcsv( $out, array( $r['id'], $r['code'], $r['status'], $r['created_at'] ) );
         }
-        fclose($out);
+        fclose( $out );
         exit;
     }
 
-    private function render_printable(array $rows, string $from, string $to)
-    {
+    private function render_printable( array $rows, string $from, string $to ) {
         ?>
         <!DOCTYPE html>
         <html>

--- a/includes/Admin/Pages/GeneratorPage.php
+++ b/includes/Admin/Pages/GeneratorPage.php
@@ -183,19 +183,19 @@ class GeneratorPage {
             wp_send_json_success( $result );
         }
 
-        $count  = max(1, min(5000, intval(wp_unslash($_POST['count'] ?? 20))));
-        $prefix = sanitize_text_field(wp_unslash($_POST['prefix'] ?? ''));
-        $len    = max(4, min(16, intval(wp_unslash($_POST['length'] ?? 8))));
+        $count  = max( 1, min( 5000, intval( wp_unslash( $_POST['count'] ?? 20 ) ) ) );
+        $prefix = sanitize_text_field( wp_unslash( $_POST['prefix'] ?? '' ) );
+        $len    = max( 4, min( 16, intval( wp_unslash( $_POST['length'] ?? 8 ) ) ) );
 
         if ( '' !== $prefix && ! preg_match( '/^[A-Za-z0-9-]+$/', $prefix ) ) {
             wp_send_json_error( array( 'message' => __( 'Invalid prefix.', 'kerbcycle-qr-code-manager' ) ), 400 );
         }
 
-        $attempts = 0;
+        $attempts   = 0;
         $saved_count = count( $result['saved'] );
         while ( $saved_count < $count ) {
             $rand = wp_generate_password( $len, false, false );
-            $code = $prefix . strtoupper($rand);
+            $code = $prefix . strtoupper( $rand );
             if ( $repo->exists( $code ) ) {
                 $result['skipped'][] = $code;
             } else {
@@ -228,16 +228,16 @@ class GeneratorPage {
             wp_die( esc_html__( 'Bad nonce.', 'kerbcycle-qr-code-manager' ) );
         }
 
-        $from   = sanitize_text_field(wp_unslash($_POST['from'] ?? ''));
-        $to     = sanitize_text_field(wp_unslash($_POST['to'] ?? ''));
-        $format = sanitize_text_field(wp_unslash($_POST['format'] ?? 'csv'));
+        $from   = sanitize_text_field( wp_unslash( $_POST['from'] ?? '' ) );
+        $to     = sanitize_text_field( wp_unslash( $_POST['to'] ?? '' ) );
+        $format = sanitize_text_field( wp_unslash( $_POST['format'] ?? 'csv' ) );
 
         if ( ! $from || ! $to ) {
             wp_die( esc_html__( 'Date range required.', 'kerbcycle-qr-code-manager' ) );
         }
 
         $repo = new QrRepoRepository();
-        $rows = $repo->list_between($from, $to);
+        $rows = $repo->list_between( $from, $to );
 
         if ( 'print' === $format ) {
             $this->render_printable( $rows, $from, $to );
@@ -245,8 +245,8 @@ class GeneratorPage {
         }
 
         nocache_headers();
-        header('Content-Type: text/csv; charset=UTF-8');
-        header('Content-Disposition: attachment; filename=kerbcycle-qr-codes-' . $from . '_to_' . $to . '.csv');
+        header( 'Content-Type: text/csv; charset=UTF-8' );
+        header( 'Content-Disposition: attachment; filename=kerbcycle-qr-codes-' . $from . '_to_' . $to . '.csv' );
 
         $out = fopen( 'php://output', 'w' );
         fputcsv( $out, array( 'ID', 'Code', 'Status', 'Created At' ) );
@@ -263,7 +263,7 @@ class GeneratorPage {
         <html>
         <head>
             <meta charset="utf-8"/>
-            <title>KerbCycle QR Codes: <?php echo esc_html($from); ?> to <?php echo esc_html($to); ?></title>
+            <title>KerbCycle QR Codes: <?php echo esc_html( $from ); ?> to <?php echo esc_html( $to ); ?></title>
             <style>
                 body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
                 .header { display:flex; justify-content:space-between; align-items:center; margin:16px 0; }
@@ -271,28 +271,28 @@ class GeneratorPage {
                 .card { border:1px solid #ddd; padding:12px; border-radius:12px; text-align:center; }
                 .code-text { margin-top:8px; font-weight:600; font-size:14px; word-break:break-all; }
                 @media print {
-                  .no-print { display:none; }
-                  .grid { gap:8px; }
-                  .card { padding:8px; }
+                  .no-print { display: none; }
+                  .grid { gap: 8px; }
+                  .card { padding: 8px; }
                 }
             </style>
         </head>
         <body>
             <div class="header no-print">
-                <h1>QR Codes (<?php echo esc_html($from); ?> → <?php echo esc_html($to); ?>)</h1>
+                <h1>QR Codes (<?php echo esc_html( $from ); ?> → <?php echo esc_html( $to ); ?>)</h1>
                 <button onclick="window.print()">Print</button>
             </div>
             <div class="grid" id="print-grid">
-                <?php foreach ($rows as $r): ?>
+                <?php foreach ( $rows as $r ) : ?>
                     <div class="card">
-                        <div class="qrc" data-code="<?php echo esc_attr($r['code']); ?>"></div>
-                        <div class="code-text"><?php echo esc_html($r['code']); ?></div>
+                        <div class="qrc" data-code="<?php echo esc_attr( $r['code'] ); ?>"></div>
+                        <div class="code-text"><?php echo esc_html( $r['code'] ); ?></div>
                     </div>
                 <?php endforeach; ?>
             </div>
 
             <script>
-            <?php readfile(KERBCYCLE_QR_PATH . 'assets/js/qrcode.min.js'); ?>
+            <?php readfile( KERBCYCLE_QR_PATH . 'assets/js/qrcode.min.js' ); ?>
             document.querySelectorAll('.qrc').forEach(function(el){
                 const code = el.getAttribute('data-code');
                 new QRCode(el, { text: code, width: 128, height: 128, correctLevel: QRCode.CorrectLevel.M });

--- a/includes/Admin/Pages/GeneratorPage.php
+++ b/includes/Admin/Pages/GeneratorPage.php
@@ -166,9 +166,9 @@ class GeneratorPage {
         $repo   = new QrRepoRepository();
         $user   = get_current_user_id();
         $type   = sanitize_text_field( wp_unslash( $_POST['genType'] ?? 'single' ) );
-        $result = array( 
-            'saved' => array(), 
-            'skipped' => array() 
+        $result = array(
+            'saved'   => array(),
+            'skipped' => array(),
         );
 
         if ( 'single' === $type ) {

--- a/includes/Admin/Pages/GeneratorPage.php
+++ b/includes/Admin/Pages/GeneratorPage.php
@@ -4,7 +4,7 @@ namespace Kerbcycle\QrCode\Admin\Pages;
 
 use Kerbcycle\QrCode\Data\Repositories\QrRepoRepository;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -21,7 +21,7 @@ class GeneratorPage
      */
     public static function instance(): self
     {
-        if (!self::$instance) {
+        if ( ! self::$instance ) {
             self::$instance = new self();
         }
         return self::$instance;
@@ -29,9 +29,9 @@ class GeneratorPage
 
     private function __construct()
     {
-        add_action('admin_enqueue_scripts', [$this, 'assets']);
-        add_action('wp_ajax_kerbcycle_generate_qr', [$this, 'ajax_generate_qr']);
-        add_action('admin_post_kerbcycle_export_qr_csv', [$this, 'handle_export_csv']);
+        add_action( 'admin_enqueue_scripts', array( $this, 'assets' ) );
+        add_action( 'wp_ajax_kerbcycle_generate_qr', array( $this, 'ajax_generate_qr' ) );
+        add_action( 'admin_post_kerbcycle_export_qr_csv', array( $this, 'handle_export_csv' ) );
     }
 
     /**
@@ -78,77 +78,77 @@ class GeneratorPage
     public function render()
     {
         if (!current_user_can('manage_options')) {
-            wp_die(__('Insufficient permissions.', 'kerbcycle'));
+            wp_die( esc_html__( 'Insufficient permissions.', 'kerbcycle-qr-code-manager' ) );
         }
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e('QR Code Generator', 'kerbcycle'); ?></h1>
+            <h1><?php esc_html_e('QR Code Generator', 'kerbcycle-qr-code-manager'); ?></h1>
 
             <div class="kc-card">
-                <h2><?php esc_html_e('Generate Codes', 'kerbcycle'); ?></h2>
+                <h2><?php esc_html_e('Generate Codes', 'kerbcycle-qr-code-manager'); ?></h2>
                 <form id="kc-generate-form" onsubmit="return false;">
                     <div class="kc-row">
-                        <label><?php esc_html_e('Generate Type', 'kerbcycle'); ?></label>
+                        <label><?php esc_html_e('Generate Type', 'kerbcycle-qr-code-manager'); ?></label>
                         <select id="kc-gen-type">
-                            <option value="single"><?php esc_html_e('Single (enter exact code)', 'kerbcycle'); ?></option>
-                            <option value="batch"><?php esc_html_e('Batch (random codes)', 'kerbcycle'); ?></option>
+                            <option value="single"><?php esc_html_e('Single (enter exact code)', 'kerbcycle-qr-code-manager'); ?></option>
+                            <option value="batch"><?php esc_html_e('Batch (random codes)', 'kerbcycle-qr-code-manager'); ?></option>
                         </select>
                     </div>
 
                     <div class="kc-row kc-if-single">
-                        <label><?php esc_html_e('Code', 'kerbcycle'); ?></label>
+                        <label><?php esc_html_e('Code', 'kerbcycle-qr-code-manager'); ?></label>
                         <input type="text" id="kc-code" placeholder="e.g. KC-2025-0001" />
                     </div>
 
                     <div class="kc-row kc-if-batch" style="display:none;">
-                        <label><?php esc_html_e('How many?', 'kerbcycle'); ?></label>
+                        <label><?php esc_html_e('How many?', 'kerbcycle-qr-code-manager'); ?></label>
                         <input type="number" id="kc-count" min="1" max="5000" value="20" />
                     </div>
 
                     <div class="kc-row kc-if-batch" style="display:none;">
-                        <label><?php esc_html_e('Prefix (optional)', 'kerbcycle'); ?></label>
+                        <label><?php esc_html_e('Prefix (optional)', 'kerbcycle-qr-code-manager'); ?></label>
                         <input type="text" id="kc-prefix" placeholder="e.g. KC-2025-" />
                     </div>
 
                     <div class="kc-row kc-if-batch" style="display:none;">
-                        <label><?php esc_html_e('Length (random part)', 'kerbcycle'); ?></label>
+                        <label><?php esc_html_e('Length (random part)', 'kerbcycle-qr-code-manager'); ?></label>
                         <input type="number" id="kc-length" min="4" max="16" value="8" />
                     </div>
 
                     <div class="kc-row">
-                        <button class="button button-primary" id="kc-generate-btn"><?php esc_html_e('Generate & Save', 'kerbcycle'); ?></button>
+                        <button class="button button-primary" id="kc-generate-btn"><?php esc_html_e('Generate & Save', 'kerbcycle-qr-code-manager'); ?></button>
                     </div>
 
-                    <p class="description"><?php esc_html_e('Codes are saved to the repository only if unique. Duplicates are skipped.', 'kerbcycle'); ?></p>
+                    <p class="description"><?php esc_html_e('Codes are saved to the repository only if unique. Duplicates are skipped.', 'kerbcycle-qr-code-manager'); ?></p>
                 </form>
 
                 <div id="kc-generate-result" class="kc-grid"></div>
             </div>
 
             <div class="kc-card">
-                <h2><?php esc_html_e('Export Repository (Date Range)', 'kerbcycle'); ?></h2>
+                <h2><?php esc_html_e('Export Repository (Date Range)', 'kerbcycle-qr-code-manager'); ?></h2>
                 <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
                     <?php wp_nonce_field('kerbcycle_export_qr_csv', 'kc_export_nonce'); ?>
                     <input type="hidden" name="action" value="kerbcycle_export_qr_csv" />
                     <div class="kc-row">
-                        <label><?php esc_html_e('From', 'kerbcycle'); ?></label>
+                        <label><?php esc_html_e('From', 'kerbcycle-qr-code-manager'); ?></label>
                         <input type="date" name="from" required />
                     </div>
                     <div class="kc-row">
-                        <label><?php esc_html_e('To', 'kerbcycle'); ?></label>
+                        <label><?php esc_html_e('To', 'kerbcycle-qr-code-manager'); ?></label>
                         <input type="date" name="to" required />
                     </div>
                     <div class="kc-row">
-                        <label><?php esc_html_e('Export Type', 'kerbcycle'); ?></label>
+                        <label><?php esc_html_e('Export Type', 'kerbcycle-qr-code-manager'); ?></label>
                         <select name="format">
-                            <option value="print"><?php esc_html_e('Printable Sheet (browser print)', 'kerbcycle'); ?></option>
-                            <option value="csv"><?php esc_html_e('CSV file', 'kerbcycle'); ?></option>
+                            <option value="print"><?php esc_html_e('Printable Sheet (browser print)', 'kerbcycle-qr-code-manager'); ?></option>
+                            <option value="csv"><?php esc_html_e('CSV file', 'kerbcycle-qr-code-manager'); ?></option>
                         </select>
                     </div>
                     <div class="kc-row">
-                        <button class="button"><?php esc_html_e('Export', 'kerbcycle'); ?></button>
+                        <button class="button"><?php esc_html_e('Export', 'kerbcycle-qr-code-manager'); ?></button>
                     </div>
-                    <p class="description"><?php esc_html_e('“Printable Sheet” opens a formatted page you can print to paper or PDF. “CSV” downloads code data.', 'kerbcycle'); ?></p>
+                    <p class="description"><?php esc_html_e('“Printable Sheet” opens a formatted page you can print to paper or PDF. “CSV” downloads code data.', 'kerbcycle-qr-code-manager'); ?></p>
                 </form>
             </div>
         </div>
@@ -162,7 +162,7 @@ class GeneratorPage
     {
         check_ajax_referer('kerbcycle_generate_qr', 'nonce');
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => __('No permission', 'kerbcycle')], 403);
+            wp_send_json_error(['message' => __('No permission', 'kerbcycle-qr-code-manager')], 403);
         }
 
         $repo = new QrRepoRepository();
@@ -173,7 +173,7 @@ class GeneratorPage
         if ($type === 'single') {
             $code = trim(sanitize_text_field(wp_unslash($_POST['code'] ?? '')));
             if ($code === '') {
-                wp_send_json_error(['message' => __('Code required.', 'kerbcycle')], 400);
+                wp_send_json_error(['message' => __('Code required.', 'kerbcycle-qr-code-manager')], 400);
             }
 
             if ($repo->exists($code)) {
@@ -190,11 +190,12 @@ class GeneratorPage
         $len    = max(4, min(16, intval(wp_unslash($_POST['length'] ?? 8))));
 
         if ($prefix !== '' && !preg_match('/^[A-Za-z0-9-]+$/', $prefix)) {
-            wp_send_json_error(['message' => __('Invalid prefix.', 'kerbcycle')], 400);
+            wp_send_json_error(['message' => __('Invalid prefix.', 'kerbcycle-qr-code-manager')], 400);
         }
 
         $attempts = 0;
-        while (count($result['saved']) < $count) {
+        $saved_count = count( $result['saved'] );
+        while ( $saved_count < $count ) {
             $rand = wp_generate_password($len, false, false);
             $code = $prefix . strtoupper($rand);
             if ($repo->exists($code)) {
@@ -202,8 +203,9 @@ class GeneratorPage
             } else {
                 $repo->insert($code, $user);
                 $result['saved'][] = $code;
+                ++$saved_count;
             }
-            $attempts++;
+            ++$attempts;
             if ($attempts > $count * 5) {
                 break; // prevent infinite loops on extreme collisions
             }
@@ -218,10 +220,10 @@ class GeneratorPage
     public function handle_export_csv()
     {
         if (!current_user_can('manage_options')) {
-            wp_die(__('No permission.', 'kerbcycle'));
+            wp_die(__('No permission.', 'kerbcycle-qr-code-manager'));
         }
         if (!isset($_POST['kc_export_nonce']) || !wp_verify_nonce($_POST['kc_export_nonce'], 'kerbcycle_export_qr_csv')) {
-            wp_die(__('Bad nonce.', 'kerbcycle'));
+            wp_die(__('Bad nonce.', 'kerbcycle-qr-code-manager'));
         }
 
         $from   = sanitize_text_field(wp_unslash($_POST['from'] ?? ''));
@@ -229,7 +231,7 @@ class GeneratorPage
         $format = sanitize_text_field(wp_unslash($_POST['format'] ?? 'csv'));
 
         if (!$from || !$to) {
-            wp_die(__('Date range required.', 'kerbcycle'));
+            wp_die(__('Date range required.', 'kerbcycle-qr-code-manager'));
         }
 
         $repo = new QrRepoRepository();

--- a/includes/Admin/Pages/GeneratorPage.php
+++ b/includes/Admin/Pages/GeneratorPage.php
@@ -163,10 +163,13 @@ class GeneratorPage {
             wp_send_json_error( array( 'message' => __( 'No permission', 'kerbcycle-qr-code-manager' ) ), 403 );
         }
 
-        $repo = new QrRepoRepository();
+        $repo   = new QrRepoRepository();
         $user   = get_current_user_id();
         $type   = sanitize_text_field( wp_unslash( $_POST['genType'] ?? 'single' ) );
-        $result = array( 'saved' => array(), 'skipped' => array() );
+        $result = array( 
+            'saved' => array(), 
+            'skipped' => array() 
+        );
 
         if ( 'single' === $type ) {
             $code = trim( sanitize_text_field( wp_unslash( $_POST['code'] ?? '' ) ) );
@@ -191,7 +194,7 @@ class GeneratorPage {
             wp_send_json_error( array( 'message' => __( 'Invalid prefix.', 'kerbcycle-qr-code-manager' ) ), 400 );
         }
 
-        $attempts   = 0;
+        $attempts    = 0;
         $saved_count = count( $result['saved'] );
         while ( $saved_count < $count ) {
             $rand = wp_generate_password( $len, false, false );
@@ -271,9 +274,9 @@ class GeneratorPage {
                 .card { border:1px solid #ddd; padding:12px; border-radius:12px; text-align:center; }
                 .code-text { margin-top:8px; font-weight:600; font-size:14px; word-break:break-all; }
                 @media print {
-                  .no-print { display: none; }
-                  .grid { gap: 8px; }
-                  .card { padding: 8px; }
+                    .no-print { display: none; }
+                    .grid { gap: 8px; }
+                    .card { padding: 8px; }
                 }
             </style>
         </head>


### PR DESCRIPTION
### Motivation
- Fix file-scoped PHPCS findings in `includes/Admin/Pages/GeneratorPage.php` without changing runtime behavior or public APIs.
- Normalize spacing/brace/callback formatting, correct text-domain mismatches, and resolve unsafe translated output and minor loop/increment issues reported by PHPCS.

### Description
- Applied formatting-equivalent changes (ABSPATH guard spacing, brace/parenthesis/callback spacing and array callback style) only in `includes/Admin/Pages/GeneratorPage.php`.
- Replaced text-domain arguments from `'kerbcycle'` to `'kerbcycle-qr-code-manager'` throughout the file while preserving all visible string text exactly.
- Fixed the unsafe translated output at the permissions `wp_die()` path by using `esc_html__()` for proper escaping in that context.
- Removed `count()` from the batch-generation loop condition by caching `count( $result['saved'] )` into a local variable and incrementing that cached value only when a code is saved, preserving loop bounds and behavior.
- Replaced the reported stand-alone post-increment (`$attempts++`) with a pre-increment (`++$attempts`) where PHPCS flagged it.

### Testing
- Confirmed only the target file was modified using `git diff --name-only`, which reported: `includes/Admin/Pages/GeneratorPage.php`.
- Syntax check passed: `php -l includes/Admin/Pages/GeneratorPage.php` returned `No syntax errors detected in includes/Admin/Pages/GeneratorPage.php`.
- PHPCS could not be executed in this environment because `vendor/bin/phpcs` is not available; running `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Admin/Pages/GeneratorPage.php -s` failed with the tooling missing, so file-specific PHPCS must be run in CI or a provisioned environment before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fed56fd9ec832dad8889b19cb66658)