### PR TITLE
Fix MessagesHistoryPage href attribute whitespace

### DIFF
--- a/includes/Admin/Pages/MessagesHistoryPage.php
+++ b/includes/Admin/Pages/MessagesHistoryPage.php
@@ -340,11 +340,38 @@ class MessagesHistoryPage {
                     ?>
                 <?php endif; ?>
 
+                <?php
+                $sms_tab_url = add_query_arg(
+                    array(
+                        'tab'   => 'sms',
+                        'paged' => 1,
+                    ),
+                    $base_url
+                );
+
+                $email_tab_url = add_query_arg(
+                    array(
+                        'tab'   => 'email',
+                        'paged' => 1,
+                    ),
+                    $base_url
+                );
+
+                $reset_url = add_query_arg(
+                    array(
+                        's'     => null,
+                        'from'  => null,
+                        'to'    => null,
+                        'paged' => 1,
+                    ),
+                    $base_url
+                );
+                ?>
                 <h2 class="nav-tab-wrapper" style="margin-top:12px;">
-                    <a href="<?php echo esc_url( add_query_arg( array( 'tab' => 'sms', 'paged' => 1 ), $base_url ) ); ?>" class="nav-tab <?php echo $active_tab === 'sms' ? 'nav-tab-active' : ''; ?>">
+                    <a href="<?php echo esc_url( $sms_tab_url ); ?>" class="nav-tab <?php echo $active_tab === 'sms' ? 'nav-tab-active' : ''; ?>">
                         <?php esc_html_e( 'SMS', 'kerbcycle-qr-code-manager' ); ?>
                     </a>
-                    <a href="<?php echo esc_url( add_query_arg( array( 'tab' => 'email', 'paged' => 1 ), $base_url ) ); ?>" class="nav-tab <?php echo $active_tab === 'email' ? 'nav-tab-active' : ''; ?>">
+                    <a href="<?php echo esc_url( $email_tab_url ); ?>" class="nav-tab <?php echo $active_tab === 'email' ? 'nav-tab-active' : ''; ?>">
                         <?php esc_html_e( 'Email', 'kerbcycle-qr-code-manager' ); ?>
                     </a>
                 </h2>
@@ -356,7 +383,7 @@ class MessagesHistoryPage {
                     <input type="date" name="from" value="<?php echo esc_attr( $from ); ?>" />
                     <input type="date" name="to" value="<?php echo esc_attr( $to ); ?>" />
                     <button class="button"><?php esc_html_e( 'Filter', 'kerbcycle-qr-code-manager' ); ?></button>
-                    <a class="button" href="<?php echo esc_url( add_query_arg( array( 's' => null, 'from' => null, 'to' => null, 'paged' => 1 ), $base_url ) ); ?>">
+                    <a class="button" href="<?php echo esc_url( $reset_url ); ?>">
                         <?php esc_html_e( 'Reset', 'kerbcycle-qr-code-manager' ); ?>
                     </a>
                 </form>

--- a/includes/Admin/Pages/MessagesHistoryPage.php
+++ b/includes/Admin/Pages/MessagesHistoryPage.php
@@ -341,10 +341,10 @@ class MessagesHistoryPage {
                 <?php endif; ?>
 
                 <h2 class="nav-tab-wrapper" style="margin-top:12px;">
-                    <a href="<?php echo esc_url( add_query_arg( [ 'tab' => 'sms', 'paged' => 1 ], $base_url ) ); ?>" class="nav-tab <?php echo $active_tab === 'sms' ? 'nav-tab-active' : ''; ?>">
+                    <a href="<?php echo esc_url( add_query_arg( array( 'tab' => 'sms', 'paged' => 1 ), $base_url ) ); ?>" class="nav-tab <?php echo $active_tab === 'sms' ? 'nav-tab-active' : ''; ?>">
                         <?php esc_html_e( 'SMS', 'kerbcycle-qr-code-manager' ); ?>
                     </a>
-                    <a href="<?php echo esc_url( add_query_arg( [ 'tab' => 'email', 'paged' => 1 ], $base_url ) ); ?>" class="nav-tab <?php echo $active_tab === 'email' ? 'nav-tab-active' : ''; ?>">
+                    <a href="<?php echo esc_url( add_query_arg( array( 'tab' => 'email', 'paged' => 1 ), $base_url ) ); ?>" class="nav-tab <?php echo $active_tab === 'email' ? 'nav-tab-active' : ''; ?>">
                         <?php esc_html_e( 'Email', 'kerbcycle-qr-code-manager' ); ?>
                     </a>
                 </h2>
@@ -356,7 +356,7 @@ class MessagesHistoryPage {
                     <input type="date" name="from" value="<?php echo esc_attr( $from ); ?>" />
                     <input type="date" name="to" value="<?php echo esc_attr( $to ); ?>" />
                     <button class="button"><?php esc_html_e( 'Filter', 'kerbcycle-qr-code-manager' ); ?></button>
-                    <a class="button" href="<?php echo esc_url( add_query_arg( [ 's' => null, 'from' => null, 'to' => null, 'paged' => 1 ], $base_url ) ); ?>">
+                    <a class="button" href="<?php echo esc_url( add_query_arg( array( 's' => null, 'from' => null, 'to' => null, 'paged' => 1 ), $base_url ) ); ?>">
                         <?php esc_html_e( 'Reset', 'kerbcycle-qr-code-manager' ); ?>
                     </a>
                 </form>

--- a/includes/Admin/Pages/MessagesHistoryPage.php
+++ b/includes/Admin/Pages/MessagesHistoryPage.php
@@ -341,34 +341,10 @@ class MessagesHistoryPage {
                 <?php endif; ?>
 
                 <h2 class="nav-tab-wrapper" style="margin-top:12px;">
-                    <a href="
-                    <?php
-                    echo esc_url(
-                        add_query_arg(
-                            [
-								'tab'   => 'sms',
-								'paged' => 1,
-							],
-							$base_url
-                        )
-                    );
-					?>
-                                " class="nav-tab <?php echo $active_tab === 'sms' ? 'nav-tab-active' : ''; ?>">
+                    <a href="<?php echo esc_url( add_query_arg( [ 'tab' => 'sms', 'paged' => 1 ], $base_url ) ); ?>" class="nav-tab <?php echo $active_tab === 'sms' ? 'nav-tab-active' : ''; ?>">
                         <?php esc_html_e( 'SMS', 'kerbcycle-qr-code-manager' ); ?>
                     </a>
-                    <a href="
-                    <?php
-                    echo esc_url(
-                        add_query_arg(
-                            [
-								'tab'   => 'email',
-								'paged' => 1,
-							],
-							$base_url
-                        )
-                    );
-					?>
-                                " class="nav-tab <?php echo $active_tab === 'email' ? 'nav-tab-active' : ''; ?>">
+                    <a href="<?php echo esc_url( add_query_arg( [ 'tab' => 'email', 'paged' => 1 ], $base_url ) ); ?>" class="nav-tab <?php echo $active_tab === 'email' ? 'nav-tab-active' : ''; ?>">
                         <?php esc_html_e( 'Email', 'kerbcycle-qr-code-manager' ); ?>
                     </a>
                 </h2>
@@ -380,21 +356,7 @@ class MessagesHistoryPage {
                     <input type="date" name="from" value="<?php echo esc_attr( $from ); ?>" />
                     <input type="date" name="to" value="<?php echo esc_attr( $to ); ?>" />
                     <button class="button"><?php esc_html_e( 'Filter', 'kerbcycle-qr-code-manager' ); ?></button>
-                    <a class="button" href="
-                    <?php
-                    echo esc_url(
-                        add_query_arg(
-                            [
-								's'     => null,
-								'from'  => null,
-								'to'    => null,
-								'paged' => 1,
-							],
-							$base_url
-                        )
-                    );
-					?>
-                                            ">
+                    <a class="button" href="<?php echo esc_url( add_query_arg( [ 's' => null, 'from' => null, 'to' => null, 'paged' => 1 ], $base_url ) ); ?>">
                         <?php esc_html_e( 'Reset', 'kerbcycle-qr-code-manager' ); ?>
                     </a>
                 </form>


### PR DESCRIPTION
### Motivation
- Remove unintended newline/indentation whitespace that PHPCBF introduced inside quoted `href` attributes so rendered links do not contain extraneous spaces without changing behavior.

### Description
- Collapse multiline PHP output into inline `href` attributes in `includes/Admin/Pages/MessagesHistoryPage.php` for the SMS tab, Email tab, and Reset link while preserving `esc_url()` and `add_query_arg()` and all query arguments exactly.
- Only `includes/Admin/Pages/MessagesHistoryPage.php` was modified and no logic, query args, classes, visible text, nonces, SQL, pagination, or public APIs were changed.

### Testing
- Ran `git diff --name-only` and observed the only changed file:
  `includes/Admin/Pages/MessagesHistoryPage.php`
- Checked PHP syntax with `php -l includes/Admin/Pages/MessagesHistoryPage.php` which returned:
  `No syntax errors detected in includes/Admin/Pages/MessagesHistoryPage.php`
- Attempted PHPCS with `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Admin/Pages/MessagesHistoryPage.php -s` but the binary is not available in this environment, yielding:
  `/bin/bash: line 1: vendor/bin/phpcs: No such file or directory`
- Commit created with message: `Fix href whitespace in messages history page` and the change summary is a small removal of multiline PHP output around the three `href` attributes.
- Merge recommendation: Safe to keep.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a013720a8bc832d91bddc536acbef94)