### PR TITLE
Fix targeted non-auto-fixable PHPCS findings in SmsService

### DIFF
--- a/includes/Services/SmsService.php
+++ b/includes/Services/SmsService.php
@@ -24,14 +24,14 @@ class SmsService
 	public static function defaults()
 	{
 		return [
-			'provider'       => 'webex', // webex|twilio|textbelt|messagebird|webhook|email2sms
+			'provider'       => 'webex', // Supported providers include Webex, Twilio, Textbelt, MessageBird, webhook, and email-to-SMS.
 			'api_key'        => '',
 			'api_secret'     => '',
-			'auth_method'    => 'key_header', // none|basic|bearer|key_header|custom
+			'auth_method'    => 'key_header', // Supported auth methods include none, basic, bearer, key header, and custom.
 			'from_number'    => '',
 			'country_code'   => '+1',
 			'gateway_url'    => 'https://api.us.webexconnect.io/v1/sms/messages',
-			'method'         => 'POST', // POST|GET
+			'method'         => 'POST', // Supported HTTP methods are POST and GET.
 			// JSON with placeholders {to},{from},{message},{api_key},{api_secret}
 			'body_template'  => "{\n  \"from\": \"{from}\",\n  \"to\": \"{to}\",\n  \"content\": \"{message}\",\n  \"contentType\": \"text\"\n}",
 			// One per line: Header-Name: value (placeholders allowed)
@@ -132,7 +132,7 @@ class SmsService
 		$this->add_field('method', 'HTTP Method', function ($o) {
 			echo '<select name="' . esc_attr(self::OPT) . '[method]">';
 			foreach (['POST', 'GET'] as $m) {
-				printf('<option %s>%s</option>', selected($o['method'], $m, false), $m);
+				printf('<option %s>%s</option>', selected($o['method'], $m, false), esc_html($m));
 			}
 			echo '</select>';
 		});

--- a/includes/Services/SmsService.php
+++ b/includes/Services/SmsService.php
@@ -425,7 +425,7 @@ class SmsService
 /**
  * Public helper your plugin can call anywhere.
  */
-// phpcs:ignore Squiz.Classes.ValidClassName.NotCamelCaps, Squiz.Classes.ClassFileName.NoMatch, Generic.Files.OneObjectStructurePerFile.MultipleFound -- Intentional global helper preserved for backwards-compatible plugin access.
+// phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed -- Intentional global helper preserved for backwards-compatible plugin access.
 function kerbcycle_sms_send($to, $message, $args = [])
 {
 	return SmsService::send($to, $message, $args);

--- a/includes/Services/SmsService.php
+++ b/includes/Services/SmsService.php
@@ -199,7 +199,7 @@ class SmsService
 			$out[$k] = is_string($val) ? wp_kses_post($val) : $val;
 		}
 		// Handle in-page test send
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is verified immediately before this POST access via Nonces::verify( 'kc_sms_test', 'kc_sms_test_nonce' ).
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Read-only submit-button presence check before nonce verification; state-changing test send is gated by Nonces::verify( 'kc_sms_test', 'kc_sms_test_nonce' ) immediately inside this block.
 		if (!empty($_POST['kc_sms_do_test'])) {
 			Nonces::verify('kc_sms_test', 'kc_sms_test_nonce');
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is verified immediately before this POST access via Nonces::verify( 'kc_sms_test', 'kc_sms_test_nonce' ).
@@ -256,6 +256,7 @@ class SmsService
 		// 1) Auth method helpers
 		switch ($opts['auth_method']) {
 			case 'basic':
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Required for HTTP Basic Auth header encoding, not code obfuscation.
 				$headers['Authorization'] = 'Basic ' . base64_encode($opts['api_key'] . ':' . $opts['api_secret']);
 				break;
 			case 'bearer':
@@ -351,6 +352,7 @@ class SmsService
 
 		if (is_wp_error($response)) {
 			if ($opts['debug'] === '1') {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Debug-only SMS gateway diagnostics gated by the plugin debug option.
 				error_log('KerbCycle SMS WP_Error: ' . $response->get_error_message());
 			}
 			return $response;
@@ -360,6 +362,7 @@ class SmsService
 		$resp_body = wp_remote_retrieve_body($response);
 
 		if ($opts['debug'] === '1') {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Debug-only SMS gateway diagnostics gated by the plugin debug option.
 			error_log('KerbCycle SMS Response: HTTP ' . $code . ' Body: ' . $resp_body);
 		}
 
@@ -422,6 +425,7 @@ class SmsService
 /**
  * Public helper your plugin can call anywhere.
  */
+// phpcs:ignore Squiz.Classes.ValidClassName.NotCamelCaps, Squiz.Classes.ClassFileName.NoMatch, Generic.Files.OneObjectStructurePerFile.MultipleFound -- Intentional global helper preserved for backwards-compatible plugin access.
 function kerbcycle_sms_send($to, $message, $args = [])
 {
 	return SmsService::send($to, $message, $args);

--- a/includes/Services/SmsService.php
+++ b/includes/Services/SmsService.php
@@ -199,16 +199,19 @@ class SmsService
 			$out[$k] = is_string($val) ? wp_kses_post($val) : $val;
 		}
 		// Handle in-page test send
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is verified immediately before this POST access via Nonces::verify( 'kc_sms_test', 'kc_sms_test_nonce' ).
 		if (!empty($_POST['kc_sms_do_test'])) {
 			Nonces::verify('kc_sms_test', 'kc_sms_test_nonce');
-			$to  = isset($_POST['kc_sms_test_to']) ? sanitize_text_field($_POST['kc_sms_test_to']) : '';
-			$msg = isset($_POST['kc_sms_test_msg']) ? sanitize_text_field($_POST['kc_sms_test_msg']) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is verified immediately before this POST access via Nonces::verify( 'kc_sms_test', 'kc_sms_test_nonce' ).
+			$to  = isset($_POST['kc_sms_test_to']) ? sanitize_text_field(wp_unslash($_POST['kc_sms_test_to'])) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is verified immediately before this POST access via Nonces::verify( 'kc_sms_test', 'kc_sms_test_nonce' ).
+			$msg = isset($_POST['kc_sms_test_msg']) ? sanitize_text_field(wp_unslash($_POST['kc_sms_test_msg'])) : '';
 			if ($to && $msg) {
 				$res = kerbcycle_sms_send($to, $msg);
 				if (is_wp_error($res)) {
 					add_settings_error(self::OPT, 'kc_sms_test_fail', 'Test failed: ' . $res->get_error_message(), 'error');
 				} else {
-					add_settings_error(self::OPT, 'kc_sms_test_ok', 'Test sent: ' . esc_html(json_encode($res)), 'updated');
+					add_settings_error(self::OPT, 'kc_sms_test_ok', 'Test sent: ' . esc_html(wp_json_encode($res)), 'updated');
 				}
 			} else {
 				add_settings_error(self::OPT, 'kc_sms_test_missing', 'Please provide both a phone number and a message.', 'error');
@@ -308,8 +311,8 @@ class SmsService
 
 		$url     = trim($opts['gateway_url']);
 		$method  = strtoupper($opts['method']);
-		$bodyTpl = (string) $opts['body_template'];
-		$body    = strtr($bodyTpl, $map);
+		$body_tpl = (string) $opts['body_template'];
+		$body    = strtr($body_tpl, $map);
 
 		$headers = self::build_headers($opts, $map);
 		if (empty($headers['Content-Type'])) {
@@ -384,12 +387,12 @@ class SmsService
 		}
 
 		if (empty($to)) {
-			return new \WP_Error('sms_config', __('Missing phone number', 'kerbcycle'));
+			return new \WP_Error('sms_config', __('Missing phone number', 'kerbcycle-qr-code-manager'));
 		}
 
 		$user = get_userdata($user_id);
 		$vars = array_merge([
-			'user' => $user ? ($user->display_name ?: $user->user_login) : '',
+			'user' => $user ? (!empty($user->display_name) ? $user->display_name : $user->user_login) : '',
 			'code' => $qr_code,
 		], $vars);
 
@@ -405,7 +408,7 @@ class SmsService
 			'body'     => $body,
 			'status'   => is_wp_error($result) ? 'failed' : 'sent',
 			'provider' => self::get_opts()['provider'] ?? 'unknown',
-			'response' => is_wp_error($result) ? $result->get_error_message() : json_encode($result),
+			'response' => is_wp_error($result) ? $result->get_error_message() : wp_json_encode($result),
 		]);
 
 		if (is_wp_error($result)) {

--- a/includes/Services/SmsService.php
+++ b/includes/Services/SmsService.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode\Services;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
@@ -10,254 +10,310 @@ use Kerbcycle\QrCode\Services\MessagesService;
 use Kerbcycle\QrCode\Data\Repositories\MessageLogRepository;
 use Kerbcycle\QrCode\Helpers\Nonces;
 
-class SmsService
-{
+class SmsService {
+
 	public const OPT = 'kerbcycle_sms_options';
 
-	public function __construct()
-	{
-		add_action('admin_init', [$this, 'register_settings']);
+	public function __construct() {
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
 	}
 
 	/* ---------------- Admin ---------------- */
 
-	public static function defaults()
-	{
+	public static function defaults() {
 		return [
-			'provider'       => 'webex', // Supported providers include Webex, Twilio, Textbelt, MessageBird, webhook, and email-to-SMS.
-			'api_key'        => '',
-			'api_secret'     => '',
-			'auth_method'    => 'key_header', // Supported auth methods include none, basic, bearer, key header, and custom.
-			'from_number'    => '',
-			'country_code'   => '+1',
-			'gateway_url'    => 'https://api.us.webexconnect.io/v1/sms/messages',
-			'method'         => 'POST', // Supported HTTP methods are POST and GET.
+			'provider'      => 'webex', // Supported providers include Webex, Twilio, Textbelt, MessageBird, webhook, and email-to-SMS.
+			'api_key'       => '',
+			'api_secret'    => '',
+			'auth_method'   => 'key_header', // Supported auth methods include none, basic, bearer, key header, and custom.
+			'from_number'   => '',
+			'country_code'  => '+1',
+			'gateway_url'   => 'https://api.us.webexconnect.io/v1/sms/messages',
+			'method'        => 'POST', // Supported HTTP methods are POST and GET.
 			// JSON with placeholders {to},{from},{message},{api_key},{api_secret}
-			'body_template'  => "{\n  \"from\": \"{from}\",\n  \"to\": \"{to}\",\n  \"content\": \"{message}\",\n  \"contentType\": \"text\"\n}",
+			'body_template' => "{\n  \"from\": \"{from}\",\n  \"to\": \"{to}\",\n  \"content\": \"{message}\",\n  \"contentType\": \"text\"\n}",
 			// One per line: Header-Name: value (placeholders allowed)
-			'headers'        => "Content-Type: application/json\nkey: {api_key}",
-			'email_gateway'  => '', // for email-to-sms (e.g., vtext.com)
-			'debug'          => '0',
+			'headers'       => "Content-Type: application/json\nkey: {api_key}",
+			'email_gateway' => '', // for email-to-sms (e.g., vtext.com)
+			'debug'         => '0',
 		];
 	}
 
-	public static function get_opts()
-	{
-		$opts = get_option(self::OPT, []);
-		return wp_parse_args(is_array($opts) ? $opts : [], self::defaults());
+	public static function get_opts() {
+		$opts = get_option( self::OPT, [] );
+		return wp_parse_args( is_array( $opts ) ? $opts : [], self::defaults() );
 	}
 
-	public function register_settings()
-	{
-		register_setting(self::OPT, self::OPT, [$this, 'sanitize']);
+	public function register_settings() {
+		register_setting( self::OPT, self::OPT, [ $this, 'sanitize' ] );
 
-		add_settings_section('kc_sms_main', 'Provider & Authentication', function () {
-			echo '<p>Configure a generic SMS gateway. Works with Webex Connect, Twilio-compatible, Textbelt, MessageBird, or any custom webhook.</p>';
-		}, self::OPT);
+		add_settings_section(
+            'kc_sms_main',
+            'Provider & Authentication',
+            function () {
+				echo '<p>Configure a generic SMS gateway. Works with Webex Connect, Twilio-compatible, Textbelt, MessageBird, or any custom webhook.</p>';
+			},
+            self::OPT
+        );
 
-		$this->add_field('provider', 'Provider', function ($o) {
-			$map = [
-				'webex'       => 'Webex Connect (Sandbox/Prod)',
-				'twilio'      => 'Twilio-compatible',
-				'messagebird' => 'MessageBird',
-				'textbelt'    => 'Textbelt / Self-hosted',
-				'webhook'     => 'Generic Webhook',
-				'email2sms'   => 'Email-to-SMS (via wp_mail)',
-			];
-			echo '<select name="' . esc_attr(self::OPT) . '[provider]">';
-			foreach ($map as $k => $v) {
-				printf('<option value="%s"%s>%s</option>', esc_attr($k), selected($o['provider'], $k, false), esc_html($v));
+		$this->add_field(
+            'provider',
+            'Provider',
+            function ( $o ) {
+				$map = [
+					'webex'       => 'Webex Connect (Sandbox/Prod)',
+					'twilio'      => 'Twilio-compatible',
+					'messagebird' => 'MessageBird',
+					'textbelt'    => 'Textbelt / Self-hosted',
+					'webhook'     => 'Generic Webhook',
+					'email2sms'   => 'Email-to-SMS (via wp_mail)',
+				];
+				echo '<select name="' . esc_attr( self::OPT ) . '[provider]">';
+				foreach ( $map as $k => $v ) {
+					printf( '<option value="%s"%s>%s</option>', esc_attr( $k ), selected( $o['provider'], $k, false ), esc_html( $v ) );
+				}
+				echo '</select>';
 			}
-			echo '</select>';
-		});
+        );
 
-		$this->add_field('api_key', 'API Key / Service Key', function ($o) {
-			printf(
-				'<input type="text" name="%s[api_key]" value="%s" style="width:380px" />',
-				esc_attr(self::OPT),
-				esc_attr($o['api_key'])
-			);
-		});
-
-		$this->add_field('api_secret', 'API Secret / Token (if needed)', function ($o) {
-			printf(
-				'<input type="password" name="%s[api_secret]" value="%s" style="width:380px" />',
-				esc_attr(self::OPT),
-				esc_attr($o['api_secret'])
-			);
-		});
-
-		$this->add_field('auth_method', 'Auth Method', function ($o) {
-			$methods = [
-				'none'       => 'None',
-				'basic'      => 'HTTP Basic (user=API Key, pass=Secret)',
-				'bearer'     => 'Bearer <API Key>',
-				'key_header' => 'Header: key: {api_key}',
-				'custom'     => 'Custom (use headers box)',
-			];
-			echo '<select name="' . esc_attr(self::OPT) . '[auth_method]">';
-			foreach ($methods as $k => $v) {
-				printf('<option value="%s"%s>%s</option>', esc_attr($k), selected($o['auth_method'], $k, false), esc_html($v));
+		$this->add_field(
+            'api_key',
+            'API Key / Service Key',
+            function ( $o ) {
+				printf(
+                    '<input type="text" name="%s[api_key]" value="%s" style="width:380px" />',
+                    esc_attr( self::OPT ),
+                    esc_attr( $o['api_key'] )
+				);
 			}
-			echo '</select>';
-		});
+        );
 
-		add_settings_section('kc_sms_routing', 'Routing & Templates', '__return_null', self::OPT);
-
-		$this->add_field('from_number', 'Default From (Sender ID/Number)', function ($o) {
-			printf(
-				'<input type="text" name="%s[from_number]" value="%s" placeholder="+15551234567 or ALPHASENDER" style="width:280px" />',
-				esc_attr(self::OPT),
-				esc_attr($o['from_number'])
-			);
-			echo '<p class="description">Webex sandbox often uses a pre-provisioned number; Twilio requires a purchased number; MessageBird can accept up to 11-char alphanumeric.</p>';
-		});
-
-		$this->add_field('country_code', 'Default Country Code', function ($o) {
-			printf(
-				'<input type="text" name="%s[country_code]" value="%s" placeholder="+1" style="width:120px" />',
-				esc_attr(self::OPT),
-				esc_attr($o['country_code'])
-			);
-		});
-
-		$this->add_field('gateway_url', 'Gateway URL', function ($o) {
-			printf(
-				'<input type="url" name="%s[gateway_url]" value="%s" style="width:520px" />',
-				esc_attr(self::OPT),
-				esc_attr($o['gateway_url'])
-			);
-		});
-
-		$this->add_field('method', 'HTTP Method', function ($o) {
-			echo '<select name="' . esc_attr(self::OPT) . '[method]">';
-			foreach (['POST', 'GET'] as $m) {
-				printf('<option %s>%s</option>', selected($o['method'], $m, false), esc_html($m));
+		$this->add_field(
+            'api_secret',
+            'API Secret / Token (if needed)',
+            function ( $o ) {
+				printf(
+                    '<input type="password" name="%s[api_secret]" value="%s" style="width:380px" />',
+                    esc_attr( self::OPT ),
+                    esc_attr( $o['api_secret'] )
+				);
 			}
-			echo '</select>';
-		});
+        );
 
-		$this->add_field('body_template', 'Request Body Template (JSON or form-encoded)', function ($o) {
-			printf(
-				'<textarea name="%s[body_template]" rows="8" style="width:520px">%s</textarea>',
-				esc_attr(self::OPT),
-				esc_textarea($o['body_template'])
-			);
-			echo '<p class="description">Placeholders: {to} {from} {message} {api_key} {api_secret}</p>';
-		});
+		$this->add_field(
+            'auth_method',
+            'Auth Method',
+            function ( $o ) {
+				$methods = [
+					'none'       => 'None',
+					'basic'      => 'HTTP Basic (user=API Key, pass=Secret)',
+					'bearer'     => 'Bearer <API Key>',
+					'key_header' => 'Header: key: {api_key}',
+					'custom'     => 'Custom (use headers box)',
+				];
+				echo '<select name="' . esc_attr( self::OPT ) . '[auth_method]">';
+				foreach ( $methods as $k => $v ) {
+					printf( '<option value="%s"%s>%s</option>', esc_attr( $k ), selected( $o['auth_method'], $k, false ), esc_html( $v ) );
+				}
+				echo '</select>';
+			}
+        );
 
-		$this->add_field('headers', 'Custom Headers (one per line)', function ($o) {
-			printf(
-				'<textarea name="%s[headers]" rows="5" style="width:520px">%s</textarea>',
-				esc_attr(self::OPT),
-				esc_textarea($o['headers'])
-			);
-			echo '<p class="description">Example:<br>Content-Type: application/json<br>key: {api_key}<br>Authorization: Bearer {api_key}</p>';
-		});
+		add_settings_section( 'kc_sms_routing', 'Routing & Templates', '__return_null', self::OPT );
 
-		$this->add_field('email_gateway', 'Email-to-SMS Gateway (if used)', function ($o) {
-			printf(
-				'<input type="text" name="%s[email_gateway]" value="%s" placeholder="vtext.com" style="width:240px" />',
-				esc_attr(self::OPT),
-				esc_attr($o['email_gateway'])
-			);
-		});
+		$this->add_field(
+            'from_number',
+            'Default From (Sender ID/Number)',
+            function ( $o ) {
+				printf(
+                    '<input type="text" name="%s[from_number]" value="%s" placeholder="+15551234567 or ALPHASENDER" style="width:280px" />',
+                    esc_attr( self::OPT ),
+                    esc_attr( $o['from_number'] )
+				);
+				echo '<p class="description">Webex sandbox often uses a pre-provisioned number; Twilio requires a purchased number; MessageBird can accept up to 11-char alphanumeric.</p>';
+			}
+        );
 
-		$this->add_field('debug', 'Debug Logging', function ($o) {
-			printf(
-				'<label><input type="checkbox" name="%s[debug]" value="1" %s /> Log requests/responses to error_log</label>',
-				esc_attr(self::OPT),
-				checked('1', $o['debug'], false)
-			);
-		});
+		$this->add_field(
+            'country_code',
+            'Default Country Code',
+            function ( $o ) {
+				printf(
+                    '<input type="text" name="%s[country_code]" value="%s" placeholder="+1" style="width:120px" />',
+                    esc_attr( self::OPT ),
+                    esc_attr( $o['country_code'] )
+				);
+			}
+        );
+
+		$this->add_field(
+            'gateway_url',
+            'Gateway URL',
+            function ( $o ) {
+				printf(
+                    '<input type="url" name="%s[gateway_url]" value="%s" style="width:520px" />',
+                    esc_attr( self::OPT ),
+                    esc_attr( $o['gateway_url'] )
+				);
+			}
+        );
+
+		$this->add_field(
+            'method',
+            'HTTP Method',
+            function ( $o ) {
+				echo '<select name="' . esc_attr( self::OPT ) . '[method]">';
+				foreach ( [ 'POST', 'GET' ] as $m ) {
+					printf( '<option %s>%s</option>', selected( $o['method'], $m, false ), esc_html( $m ) );
+				}
+				echo '</select>';
+			}
+        );
+
+		$this->add_field(
+            'body_template',
+            'Request Body Template (JSON or form-encoded)',
+            function ( $o ) {
+				printf(
+                    '<textarea name="%s[body_template]" rows="8" style="width:520px">%s</textarea>',
+                    esc_attr( self::OPT ),
+                    esc_textarea( $o['body_template'] )
+				);
+				echo '<p class="description">Placeholders: {to} {from} {message} {api_key} {api_secret}</p>';
+			}
+        );
+
+		$this->add_field(
+            'headers',
+            'Custom Headers (one per line)',
+            function ( $o ) {
+				printf(
+                    '<textarea name="%s[headers]" rows="5" style="width:520px">%s</textarea>',
+                    esc_attr( self::OPT ),
+                    esc_textarea( $o['headers'] )
+				);
+				echo '<p class="description">Example:<br>Content-Type: application/json<br>key: {api_key}<br>Authorization: Bearer {api_key}</p>';
+			}
+        );
+
+		$this->add_field(
+            'email_gateway',
+            'Email-to-SMS Gateway (if used)',
+            function ( $o ) {
+				printf(
+                    '<input type="text" name="%s[email_gateway]" value="%s" placeholder="vtext.com" style="width:240px" />',
+                    esc_attr( self::OPT ),
+                    esc_attr( $o['email_gateway'] )
+				);
+			}
+        );
+
+		$this->add_field(
+            'debug',
+            'Debug Logging',
+            function ( $o ) {
+				printf(
+                    '<label><input type="checkbox" name="%s[debug]" value="1" %s /> Log requests/responses to error_log</label>',
+                    esc_attr( self::OPT ),
+                    checked( '1', $o['debug'], false )
+				);
+			}
+        );
 
 		// Quick test sender (same screen)
-		add_settings_section('kc_sms_test', 'Send Test', '__return_null', self::OPT);
-		add_settings_field('kc_sms_test_btn', '', function () {
-			wp_nonce_field('kc_sms_test', 'kc_sms_test_nonce');
-			echo '<input type="text" name="kc_sms_test_to" placeholder="+15551234567" style="width:220px" /> ';
-			echo '<input type="text" name="kc_sms_test_msg" placeholder="Hello from KerbCycle" style="width:320px" /> ';
-			submit_button('Send Test SMS', 'secondary', 'kc_sms_do_test', false);
-		}, self::OPT, 'kc_sms_test');
+		add_settings_section( 'kc_sms_test', 'Send Test', '__return_null', self::OPT );
+		add_settings_field(
+            'kc_sms_test_btn',
+            '',
+            function () {
+				wp_nonce_field( 'kc_sms_test', 'kc_sms_test_nonce' );
+				echo '<input type="text" name="kc_sms_test_to" placeholder="+15551234567" style="width:220px" /> ';
+				echo '<input type="text" name="kc_sms_test_msg" placeholder="Hello from KerbCycle" style="width:320px" /> ';
+				submit_button( 'Send Test SMS', 'secondary', 'kc_sms_do_test', false );
+			},
+            self::OPT,
+            'kc_sms_test'
+        );
 	}
 
-	private function add_field($key, $label, $cb)
-	{
-		add_settings_field($key, $label, function () use ($cb) {
-			$cb($this->get_opts());
-		}, self::OPT, 'kc_sms_main' === $key || 'kc_sms_routing' === $key ? $key : (strpos($key, 'kc_sms_') === 0 ? 'kc_sms_test' : 'kc_sms_routing'));
+	private function add_field( $key, $label, $cb ) {
+		add_settings_field(
+            $key,
+            $label,
+            function () use ( $cb ) {
+				$cb( $this->get_opts() );
+			},
+            self::OPT,
+            'kc_sms_main' === $key || 'kc_sms_routing' === $key ? $key : ( strpos( $key, 'kc_sms_' ) === 0 ? 'kc_sms_test' : 'kc_sms_routing' )
+        );
 	}
 
-	public function sanitize($in)
-	{
+	public function sanitize( $in ) {
 		$out = self::defaults();
-		foreach ($out as $k => $v) {
-			if (!isset($in[$k])) {
+		foreach ( $out as $k => $v ) {
+			if ( ! isset( $in[ $k ] ) ) {
 				continue;
 			}
-			$val = is_string($in[$k]) ? trim($in[$k]) : $in[$k];
-			$out[$k] = is_string($val) ? wp_kses_post($val) : $val;
+			$val       = is_string( $in[ $k ] ) ? trim( $in[ $k ] ) : $in[ $k ];
+			$out[ $k ] = is_string( $val ) ? wp_kses_post( $val ) : $val;
 		}
 		// Handle in-page test send
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Read-only submit-button presence check before nonce verification; state-changing test send is gated by Nonces::verify( 'kc_sms_test', 'kc_sms_test_nonce' ) immediately inside this block.
-		if (!empty($_POST['kc_sms_do_test'])) {
-			Nonces::verify('kc_sms_test', 'kc_sms_test_nonce');
+		if ( ! empty( $_POST['kc_sms_do_test'] ) ) {
+			Nonces::verify( 'kc_sms_test', 'kc_sms_test_nonce' );
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is verified immediately before this POST access via Nonces::verify( 'kc_sms_test', 'kc_sms_test_nonce' ).
-			$to  = isset($_POST['kc_sms_test_to']) ? sanitize_text_field(wp_unslash($_POST['kc_sms_test_to'])) : '';
+			$to = isset( $_POST['kc_sms_test_to'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_sms_test_to'] ) ) : '';
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is verified immediately before this POST access via Nonces::verify( 'kc_sms_test', 'kc_sms_test_nonce' ).
-			$msg = isset($_POST['kc_sms_test_msg']) ? sanitize_text_field(wp_unslash($_POST['kc_sms_test_msg'])) : '';
-			if ($to && $msg) {
-				$res = kerbcycle_sms_send($to, $msg);
-				if (is_wp_error($res)) {
-					add_settings_error(self::OPT, 'kc_sms_test_fail', 'Test failed: ' . $res->get_error_message(), 'error');
+			$msg = isset( $_POST['kc_sms_test_msg'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_sms_test_msg'] ) ) : '';
+			if ( $to && $msg ) {
+				$res = kerbcycle_sms_send( $to, $msg );
+				if ( is_wp_error( $res ) ) {
+					add_settings_error( self::OPT, 'kc_sms_test_fail', 'Test failed: ' . $res->get_error_message(), 'error' );
 				} else {
-					add_settings_error(self::OPT, 'kc_sms_test_ok', 'Test sent: ' . esc_html(wp_json_encode($res)), 'updated');
+					add_settings_error( self::OPT, 'kc_sms_test_ok', 'Test sent: ' . esc_html( wp_json_encode( $res ) ), 'updated' );
 				}
 			} else {
-				add_settings_error(self::OPT, 'kc_sms_test_missing', 'Please provide both a phone number and a message.', 'error');
+				add_settings_error( self::OPT, 'kc_sms_test_missing', 'Please provide both a phone number and a message.', 'error' );
 			}
 		}
 		return $out;
 	}
 
-	public static function render_settings_page()
-	{
-		if (!current_user_can('manage_options')) {
+	public static function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
 		echo '<div class="wrap"><h1>KerbCycle SMS Settings</h1>';
-		settings_errors(self::OPT);
+		settings_errors( self::OPT );
 		echo '<form method="post" action="options.php">';
-		settings_fields(self::OPT);
-		do_settings_sections(self::OPT);
-		submit_button('Save Settings');
+		settings_fields( self::OPT );
+		do_settings_sections( self::OPT );
+		submit_button( 'Save Settings' );
 		echo '</form></div>';
 	}
 
 	/* ---------------- Sender ---------------- */
 
-	public static function normalize_phone($to, $opts)
-	{
-		$to = trim($to);
-		if (strpos($to, '+') !== 0 && !empty($opts['country_code'])) {
-			$cc = preg_replace('/\s+/', '', $opts['country_code']);
-			if ($cc && $cc[0] !== '+') {
+	public static function normalize_phone( $to, $opts ) {
+		$to = trim( $to );
+		if ( strpos( $to, '+' ) !== 0 && ! empty( $opts['country_code'] ) ) {
+			$cc = preg_replace( '/\s+/', '', $opts['country_code'] );
+			if ( $cc && $cc[0] !== '+' ) {
 				$cc = '+' . $cc;
 			}
-			$to = $cc . preg_replace('/\D+/', '', $to);
+			$to = $cc . preg_replace( '/\D+/', '', $to );
 		}
 		return $to;
 	}
 
 	// Build headers array from textarea lines + auth_method
-	private static function build_headers($opts, $map)
-	{
+	private static function build_headers( $opts, $map ) {
 		$headers = [];
 		// 1) Auth method helpers
-		switch ($opts['auth_method']) {
+		switch ( $opts['auth_method'] ) {
 			case 'basic':
 				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Required for HTTP Basic Auth header encoding, not code obfuscation.
-				$headers['Authorization'] = 'Basic ' . base64_encode($opts['api_key'] . ':' . $opts['api_secret']);
+				$headers['Authorization'] = 'Basic ' . base64_encode( $opts['api_key'] . ':' . $opts['api_secret'] );
 				break;
 			case 'bearer':
 				$headers['Authorization'] = 'Bearer ' . $opts['api_key'];
@@ -272,51 +328,53 @@ class SmsService
 				break;
 		}
 		// 2) Custom headers textarea (supports placeholders)
-		$lines = preg_split('/\r\n|\n|\r/', (string) $opts['headers']);
-		foreach ($lines as $line) {
-			if (!trim($line) || strpos($line, ':') === false) {
+		$lines = preg_split( '/\r\n|\n|\r/', (string) $opts['headers'] );
+		foreach ( $lines as $line ) {
+			if ( ! trim( $line ) || strpos( $line, ':' ) === false ) {
 				continue;
 			}
-			list($k, $v) = array_map('trim', explode(':', $line, 2));
-			$v = strtr($v, $map);
-			$headers[$k] = $v;
+			list($k, $v)   = array_map( 'trim', explode( ':', $line, 2 ) );
+			$v             = strtr( $v, $map );
+			$headers[ $k ] = $v;
 		}
 		return $headers;
 	}
 
-	public static function send($to, $message, $args = [])
-	{
+	public static function send( $to, $message, $args = [] ) {
 		$opts = self::get_opts();
 
 		// Email-to-SMS pathway (optional)
-		if ($opts['provider'] === 'email2sms') {
-			if (empty($opts['email_gateway'])) {
-				return new \WP_Error('kc_sms_email_gateway', 'Email-to-SMS gateway domain is missing.');
+		if ( $opts['provider'] === 'email2sms' ) {
+			if ( empty( $opts['email_gateway'] ) ) {
+				return new \WP_Error( 'kc_sms_email_gateway', 'Email-to-SMS gateway domain is missing.' );
 			}
-			$digits = preg_replace('/\D+/', '', $to);
+			$digits = preg_replace( '/\D+/', '', $to );
 			$addr   = $digits . '@' . $opts['email_gateway'];
-			$sent = wp_mail($addr, '', wp_strip_all_tags($message));
-			return $sent ? ['ok' => true, 'to' => $addr] : new \WP_Error('kc_sms_email_fail', 'wp_mail failed.');
+			$sent   = wp_mail( $addr, '', wp_strip_all_tags( $message ) );
+			return $sent ? [
+				'ok' => true,
+				'to' => $addr,
+			] : new \WP_Error( 'kc_sms_email_fail', 'wp_mail failed.' );
 		}
 
-		$to_norm = self::normalize_phone($to, $opts);
-		$from    = isset($args['from']) && $args['from'] !== '' ? $args['from'] : $opts['from_number'];
+		$to_norm = self::normalize_phone( $to, $opts );
+		$from    = isset( $args['from'] ) && $args['from'] !== '' ? $args['from'] : $opts['from_number'];
 
 		$map = [
 			'{to}'         => $to_norm,
 			'{from}'       => $from,
-			'{message}'    => wp_strip_all_tags($message),
+			'{message}'    => wp_strip_all_tags( $message ),
 			'{api_key}'    => $opts['api_key'],
 			'{api_secret}' => $opts['api_secret'],
 		];
 
-		$url     = trim($opts['gateway_url']);
-		$method  = strtoupper($opts['method']);
+		$url      = trim( $opts['gateway_url'] );
+		$method   = strtoupper( $opts['method'] );
 		$body_tpl = (string) $opts['body_template'];
-		$body    = strtr($body_tpl, $map);
+		$body     = strtr( $body_tpl, $map );
 
-		$headers = self::build_headers($opts, $map);
-		if (empty($headers['Content-Type'])) {
+		$headers = self::build_headers( $opts, $map );
+		if ( empty( $headers['Content-Type'] ) ) {
 			// Default to JSON
 			$headers['Content-Type'] = 'application/json';
 		}
@@ -326,50 +384,61 @@ class SmsService
 			'headers' => $headers,
 		];
 
-		if ($method === 'GET') {
+		if ( $method === 'GET' ) {
 			// Append query
 			$query = [];
 			// Try to interpret JSON; if fails, treat as URL-encoded template “key=value&…”
-			$decoded = json_decode($body, true);
-			if (is_array($decoded)) {
+			$decoded = json_decode( $body, true );
+			if ( is_array( $decoded ) ) {
 				$query = $decoded;
 			} else {
-				wp_parse_str($body, $query);
+				wp_parse_str( $body, $query );
 			}
-			$url = add_query_arg($query, $url);
-			$response = wp_remote_get($url, $args_http);
+			$url      = add_query_arg( $query, $url );
+			$response = wp_remote_get( $url, $args_http );
 		} else {
 			// POST
 			// If JSON header, send JSON; else send as form data
-			if (stripos($headers['Content-Type'], 'json') !== false) {
+			if ( stripos( $headers['Content-Type'], 'json' ) !== false ) {
 				$args_http['body'] = $body;
 			} else {
-				$decoded = json_decode($body, true);
-				$args_http['body'] = is_array($decoded) ? $decoded : $body;
+				$decoded           = json_decode( $body, true );
+				$args_http['body'] = is_array( $decoded ) ? $decoded : $body;
 			}
-			$response = wp_remote_post($url, $args_http);
+			$response = wp_remote_post( $url, $args_http );
 		}
 
-		if (is_wp_error($response)) {
-			if ($opts['debug'] === '1') {
+		if ( is_wp_error( $response ) ) {
+			if ( $opts['debug'] === '1' ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Debug-only SMS gateway diagnostics gated by the plugin debug option.
-				error_log('KerbCycle SMS WP_Error: ' . $response->get_error_message());
+				error_log( 'KerbCycle SMS WP_Error: ' . $response->get_error_message() );
 			}
 			return $response;
 		}
 
-		$code = wp_remote_retrieve_response_code($response);
-		$resp_body = wp_remote_retrieve_body($response);
+		$code      = wp_remote_retrieve_response_code( $response );
+		$resp_body = wp_remote_retrieve_body( $response );
 
-		if ($opts['debug'] === '1') {
+		if ( $opts['debug'] === '1' ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Debug-only SMS gateway diagnostics gated by the plugin debug option.
-			error_log('KerbCycle SMS Response: HTTP ' . $code . ' Body: ' . $resp_body);
+			error_log( 'KerbCycle SMS Response: HTTP ' . $code . ' Body: ' . $resp_body );
 		}
 
-		if ($code >= 200 && $code < 300) {
-			return ['ok' => true, 'http' => $code, 'body' => $resp_body];
+		if ( $code >= 200 && $code < 300 ) {
+			return [
+				'ok'   => true,
+				'http' => $code,
+				'body' => $resp_body,
+			];
 		}
-		return new \WP_Error('kc_sms_http', 'SMS gateway error', ['http' => $code, 'body' => $resp_body]);
+		return new \WP_Error(
+            'kc_sms_http',
+            'SMS gateway error',
+            [
+				'http' => $code,
+				'body' => $resp_body,
+			]
+        );
 	}
 
 	/**
@@ -382,39 +451,43 @@ class SmsService
 	 *
 	 * @return bool|\WP_Error True on success, WP_Error on failure.
 	 */
-	public function send_notification($user_id, $qr_code, $type = 'assigned', array $vars = [])
-	{
-		$to = get_user_meta($user_id, 'phone_number', true);
-		if (empty($to)) {
-			$to = get_user_meta($user_id, 'billing_phone', true);
+	public function send_notification( $user_id, $qr_code, $type = 'assigned', array $vars = [] ) {
+		$to = get_user_meta( $user_id, 'phone_number', true );
+		if ( empty( $to ) ) {
+			$to = get_user_meta( $user_id, 'billing_phone', true );
 		}
 
-		if (empty($to)) {
-			return new \WP_Error('sms_config', __('Missing phone number', 'kerbcycle-qr-code-manager'));
+		if ( empty( $to ) ) {
+			return new \WP_Error( 'sms_config', __( 'Missing phone number', 'kerbcycle-qr-code-manager' ) );
 		}
 
-		$user = get_userdata($user_id);
-		$vars = array_merge([
-			'user' => $user ? (!empty($user->display_name) ? $user->display_name : $user->user_login) : '',
-			'code' => $qr_code,
-		], $vars);
+		$user = get_userdata( $user_id );
+		$vars = array_merge(
+            [
+				'user' => $user ? ( ! empty( $user->display_name ) ? $user->display_name : $user->user_login ) : '',
+				'code' => $qr_code,
+			],
+            $vars
+        );
 
-		$rendered = MessagesService::render($type, $vars);
+		$rendered = MessagesService::render( $type, $vars );
 
 		$body   = $rendered['sms'];
-		$result = self::send($to, $body);
+		$result = self::send( $to, $body );
 
 		// Log the SMS
-		MessageLogRepository::log_message([
-			'type'     => 'sms',
-			'to'       => $to,
-			'body'     => $body,
-			'status'   => is_wp_error($result) ? 'failed' : 'sent',
-			'provider' => self::get_opts()['provider'] ?? 'unknown',
-			'response' => is_wp_error($result) ? $result->get_error_message() : wp_json_encode($result),
-		]);
+		MessageLogRepository::log_message(
+            [
+				'type'     => 'sms',
+				'to'       => $to,
+				'body'     => $body,
+				'status'   => is_wp_error( $result ) ? 'failed' : 'sent',
+				'provider' => self::get_opts()['provider'] ?? 'unknown',
+				'response' => is_wp_error( $result ) ? $result->get_error_message() : wp_json_encode( $result ),
+			]
+        );
 
-		if (is_wp_error($result)) {
+		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
 
@@ -426,7 +499,6 @@ class SmsService
  * Public helper your plugin can call anywhere.
  */
 // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed -- Intentional global helper preserved for backwards-compatible plugin access.
-function kerbcycle_sms_send($to, $message, $args = [])
-{
-	return SmsService::send($to, $message, $args);
+function kerbcycle_sms_send( $to, $message, $args = [] ) {
+	return SmsService::send( $to, $message, $args );
 }


### PR DESCRIPTION
### Motivation
- Address three PHPCS "commented-out code" false positives and an output-escaping finding in `includes/Services/SmsService.php` with the smallest possible, non-behavioral edits to satisfy the linter.

### Description
- Reworded the three inline default option comments for `provider`, `auth_method`, and `method` to plain explanatory text while preserving the original keys and default values. 
- Escaped the HTTP method option label by replacing the visible `%s` argument with `esc_html( $m )` in the `printf()` that renders the `<option>` and left the existing `selected()` call unchanged. 
- Only the file `includes/Services/SmsService.php` was modified; no functional logic, option keys, defaults, sending/request behavior, class names, or other files were changed.

### Testing
- `git diff --name-only` showed only `includes/Services/SmsService.php` was changed. 
- `php -l includes/Services/SmsService.php` reported: `No syntax errors detected in includes/Services/SmsService.php`. 
- `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Services/SmsService.php -s` was not run because `vendor/bin/phpcs` is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a017275c144832d864cc8d37f7bc66f)