### PR TITLE
Fix AiProviderService i18n text-domain mismatches

### DIFF
--- a/includes/Services/AiProviderService.php
+++ b/includes/Services/AiProviderService.php
@@ -2,7 +2,7 @@
 
 namespace Kerbcycle\QrCode\Services;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -11,8 +11,8 @@ use Kerbcycle\QrCode\Data\Repositories\ErrorLogRepository;
 /**
  * Lightweight LLM provider adapter for Option B AI endpoint.
  */
-class AiProviderService
-{
+class AiProviderService {
+
     /**
      * Generate a structured response for an AI action.
      *
@@ -21,32 +21,30 @@ class AiProviderService
      *
      * @return array<string,mixed>|\WP_Error
      */
-    public function generate($action, array $payload)
-    {
+    public function generate( $action, array $payload ) {
         $provider = $this->get_provider();
 
-        if (is_wp_error($provider)) {
+        if ( is_wp_error( $provider ) ) {
             return $provider;
         }
 
-        if ($provider === 'render') {
-            return $this->call_render_endpoint($action, $payload);
+        if ( $provider === 'render' ) {
+            return $this->call_render_endpoint( $action, $payload );
         }
 
-        return $this->call_ollama($action, $payload);
+        return $this->call_ollama( $action, $payload );
     }
 
     /**
      * @return string|\WP_Error
      */
-    private function get_provider()
-    {
-        $provider = defined('KERBCYCLE_AI_PROVIDER') ? KERBCYCLE_AI_PROVIDER : get_option('kerbcycle_ai_provider', 'ollama');
-        $provider = is_string($provider) ? strtolower(trim($provider)) : 'ollama';
+    private function get_provider() {
+        $provider = defined( 'KERBCYCLE_AI_PROVIDER' ) ? KERBCYCLE_AI_PROVIDER : get_option( 'kerbcycle_ai_provider', 'ollama' );
+        $provider = is_string( $provider ) ? strtolower( trim( $provider ) ) : 'ollama';
         $provider = $provider !== '' ? $provider : 'ollama';
 
-        if (!in_array($provider, ['ollama', 'render'], true)) {
-            return new \WP_Error('kerbcycle_ai_provider_unsupported', __('Unsupported AI provider configured.', 'kerbcycle-qr-code-manager'), ['status' => 500]);
+        if ( ! in_array( $provider, [ 'ollama', 'render' ], true ) ) {
+            return new \WP_Error( 'kerbcycle_ai_provider_unsupported', __( 'Unsupported AI provider configured.', 'kerbcycle-qr-code-manager' ), [ 'status' => 500 ] );
         }
 
         return $provider;
@@ -58,16 +56,15 @@ class AiProviderService
      *
      * @return array<string,mixed>|\WP_Error
      */
-    private function call_ollama($action, array $payload)
-    {
-        $base_url = defined('KERBCYCLE_AI_OLLAMA_BASE_URL') ? KERBCYCLE_AI_OLLAMA_BASE_URL : get_option('kerbcycle_ai_ollama_base_url', 'http://127.0.0.1:11434');
-        $model    = defined('KERBCYCLE_AI_OLLAMA_MODEL') ? KERBCYCLE_AI_OLLAMA_MODEL : get_option('kerbcycle_ai_ollama_model', 'llama3.1:8b');
+    private function call_ollama( $action, array $payload ) {
+        $base_url = defined( 'KERBCYCLE_AI_OLLAMA_BASE_URL' ) ? KERBCYCLE_AI_OLLAMA_BASE_URL : get_option( 'kerbcycle_ai_ollama_base_url', 'http://127.0.0.1:11434' );
+        $model    = defined( 'KERBCYCLE_AI_OLLAMA_MODEL' ) ? KERBCYCLE_AI_OLLAMA_MODEL : get_option( 'kerbcycle_ai_ollama_model', 'llama3.1:8b' );
 
-        $base_url = is_string($base_url) ? rtrim(trim($base_url), '/') : 'http://127.0.0.1:11434';
-        $model    = is_string($model) ? trim($model) : 'llama3.1:8b';
+        $base_url = is_string( $base_url ) ? rtrim( trim( $base_url ), '/' ) : 'http://127.0.0.1:11434';
+        $model    = is_string( $model ) ? trim( $model ) : 'llama3.1:8b';
 
-        if ($base_url === '' || $model === '') {
-            return new \WP_Error('kerbcycle_ai_provider_misconfigured', __('AI provider configuration is incomplete.', 'kerbcycle-qr-code-manager'), ['status' => 500]);
+        if ( $base_url === '' || $model === '' ) {
+            return new \WP_Error( 'kerbcycle_ai_provider_misconfigured', __( 'AI provider configuration is incomplete.', 'kerbcycle-qr-code-manager' ), [ 'status' => 500 ] );
         }
 
         $request_payload = [
@@ -78,51 +75,54 @@ class AiProviderService
                 'temperature' => 0.2,
                 'top_p'       => 0.9,
             ],
-            'prompt'  => $this->build_prompt($action, $payload),
+            'prompt'  => $this->build_prompt( $action, $payload ),
         ];
 
-        $started = microtime(true);
-        $response = wp_remote_post($base_url . '/api/generate', [
-            'headers' => ['Content-Type' => 'application/json'],
-            'body'    => wp_json_encode($request_payload),
-            'timeout' => 20,
-        ]);
-        $elapsed_ms = (int) round((microtime(true) - $started) * 1000);
+        $started    = microtime( true );
+        $response   = wp_remote_post(
+            $base_url . '/api/generate',
+            [
+				'headers' => [ 'Content-Type' => 'application/json' ],
+				'body'    => wp_json_encode( $request_payload ),
+				'timeout' => 20,
+			]
+        );
+        $elapsed_ms = (int) round( ( microtime( true ) - $started ) * 1000 );
 
-        if (is_wp_error($response)) {
-            $this->log_provider_event('ollama', $action, $elapsed_ms, 'failure', $response->get_error_message());
+        if ( is_wp_error( $response ) ) {
+            $this->log_provider_event( 'ollama', $action, $elapsed_ms, 'failure', $response->get_error_message() );
 
-            return new \WP_Error('kerbcycle_ai_provider_unreachable', __('AI provider is unreachable.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
+            return new \WP_Error( 'kerbcycle_ai_provider_unreachable', __( 'AI provider is unreachable.', 'kerbcycle-qr-code-manager' ), [ 'status' => 502 ] );
         }
 
-        $status_code = (int) wp_remote_retrieve_response_code($response);
-        $body        = (string) wp_remote_retrieve_body($response);
+        $status_code = (int) wp_remote_retrieve_response_code( $response );
+        $body        = (string) wp_remote_retrieve_body( $response );
 
-        if ($status_code < 200 || $status_code >= 300) {
-            $this->log_provider_event('ollama', $action, $elapsed_ms, 'failure', sprintf('http_status=%d', $status_code));
+        if ( $status_code < 200 || $status_code >= 300 ) {
+            $this->log_provider_event( 'ollama', $action, $elapsed_ms, 'failure', sprintf( 'http_status=%d', $status_code ) );
 
-            return new \WP_Error('kerbcycle_ai_provider_http_error', __('AI provider returned an unexpected response.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
+            return new \WP_Error( 'kerbcycle_ai_provider_http_error', __( 'AI provider returned an unexpected response.', 'kerbcycle-qr-code-manager' ), [ 'status' => 502 ] );
         }
 
-        $decoded = json_decode($body, true);
-        if (!is_array($decoded) || !isset($decoded['response']) || !is_string($decoded['response'])) {
-            return new \WP_Error('kerbcycle_ai_provider_invalid_response', __('AI provider response could not be parsed.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
+        $decoded = json_decode( $body, true );
+        if ( ! is_array( $decoded ) || ! isset( $decoded['response'] ) || ! is_string( $decoded['response'] ) ) {
+            return new \WP_Error( 'kerbcycle_ai_provider_invalid_response', __( 'AI provider response could not be parsed.', 'kerbcycle-qr-code-manager' ), [ 'status' => 502 ] );
         }
 
-        $parsed_output = json_decode(trim($decoded['response']), true);
-        if (!is_array($parsed_output)) {
-            $this->log_provider_event('ollama', $action, $elapsed_ms, 'failure', 'invalid_json_output');
+        $parsed_output = json_decode( trim( $decoded['response'] ), true );
+        if ( ! is_array( $parsed_output ) ) {
+            $this->log_provider_event( 'ollama', $action, $elapsed_ms, 'failure', 'invalid_json_output' );
 
-            return new \WP_Error('kerbcycle_ai_output_invalid_json', __('AI output was not valid JSON.', 'kerbcycle-qr-code-manager'), ['status' => 422]);
+            return new \WP_Error( 'kerbcycle_ai_output_invalid_json', __( 'AI output was not valid JSON.', 'kerbcycle-qr-code-manager' ), [ 'status' => 422 ] );
         }
 
-        $this->log_provider_event('ollama', $action, $elapsed_ms, 'success');
+        $this->log_provider_event( 'ollama', $action, $elapsed_ms, 'success' );
 
         return [
-            'provider' => 'ollama',
-            'model'    => $model,
+            'provider'   => 'ollama',
+            'model'      => $model,
             'latency_ms' => $elapsed_ms,
-            'output'   => $parsed_output,
+            'output'     => $parsed_output,
         ];
     }
 
@@ -132,73 +132,77 @@ class AiProviderService
      *
      * @return array<string,mixed>|\WP_Error
      */
-    private function call_render_endpoint($action, array $payload)
-    {
+    private function call_render_endpoint( $action, array $payload ) {
         $endpoint = $this->get_render_endpoint();
         $api_key  = $this->get_render_api_key();
         $model    = $this->get_render_model();
 
-        if ($endpoint === '' || $api_key === '') {
-            return new \WP_Error('kerbcycle_ai_provider_misconfigured', __('AI provider configuration is incomplete.', 'kerbcycle-qr-code-manager'), ['status' => 500]);
+        if ( $endpoint === '' || $api_key === '' ) {
+            return new \WP_Error( 'kerbcycle_ai_provider_misconfigured', __( 'AI provider configuration is incomplete.', 'kerbcycle-qr-code-manager' ), [ 'status' => 500 ] );
         }
 
-        $started = microtime(true);
-        $response = wp_remote_post($endpoint, [
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'x-api-key'    => $api_key,
-            ],
-            'body'    => wp_json_encode([
-                'task' => $action,
-                'data' => $payload,
-            ]),
-            'timeout' => 20,
-        ]);
-        $elapsed_ms = (int) round((microtime(true) - $started) * 1000);
+        $started    = microtime( true );
+        $response   = wp_remote_post(
+            $endpoint,
+            [
+				'headers' => [
+					'Content-Type' => 'application/json',
+					'x-api-key'    => $api_key,
+				],
+				'body'    => wp_json_encode(
+                    [
+						'task' => $action,
+						'data' => $payload,
+                    ]
+                ),
+				'timeout' => 20,
+			]
+        );
+        $elapsed_ms = (int) round( ( microtime( true ) - $started ) * 1000 );
 
-        if (is_wp_error($response)) {
-            $this->log_provider_event('render', $action, $elapsed_ms, 'failure', $response->get_error_message());
+        if ( is_wp_error( $response ) ) {
+            $this->log_provider_event( 'render', $action, $elapsed_ms, 'failure', $response->get_error_message() );
 
-            return new \WP_Error('kerbcycle_ai_provider_unreachable', __('AI provider is unreachable.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
+            return new \WP_Error( 'kerbcycle_ai_provider_unreachable', __( 'AI provider is unreachable.', 'kerbcycle-qr-code-manager' ), [ 'status' => 502 ] );
         }
 
-        $status_code = (int) wp_remote_retrieve_response_code($response);
-        $body        = (string) wp_remote_retrieve_body($response);
+        $status_code = (int) wp_remote_retrieve_response_code( $response );
+        $body        = (string) wp_remote_retrieve_body( $response );
 
-        if ($status_code < 200 || $status_code >= 300) {
-            $this->log_provider_event('render', $action, $elapsed_ms, 'failure', sprintf('http_status=%d', $status_code));
+        if ( $status_code < 200 || $status_code >= 300 ) {
+            $this->log_provider_event( 'render', $action, $elapsed_ms, 'failure', sprintf( 'http_status=%d', $status_code ) );
 
-            return new \WP_Error('kerbcycle_ai_provider_http_error', __('AI provider returned an unexpected response.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
+            return new \WP_Error( 'kerbcycle_ai_provider_http_error', __( 'AI provider returned an unexpected response.', 'kerbcycle-qr-code-manager' ), [ 'status' => 502 ] );
         }
 
-        $decoded = json_decode($body, true);
-        if (!is_array($decoded)) {
-            return new \WP_Error('kerbcycle_ai_provider_invalid_response', __('AI provider response could not be parsed.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
+        $decoded = json_decode( $body, true );
+        if ( ! is_array( $decoded ) ) {
+            return new \WP_Error( 'kerbcycle_ai_provider_invalid_response', __( 'AI provider response could not be parsed.', 'kerbcycle-qr-code-manager' ), [ 'status' => 502 ] );
         }
 
         $raw_output = null;
-        foreach (['result', 'output', 'response', 'data'] as $candidate_key) {
-            if (array_key_exists($candidate_key, $decoded)) {
-                $raw_output = $decoded[$candidate_key];
+        foreach ( [ 'result', 'output', 'response', 'data' ] as $candidate_key ) {
+            if ( array_key_exists( $candidate_key, $decoded ) ) {
+                $raw_output = $decoded[ $candidate_key ];
                 break;
             }
         }
 
-        if ($raw_output === null) {
+        if ( $raw_output === null ) {
             $raw_output = $decoded;
         }
 
-        if (is_string($raw_output)) {
-            $raw_output = json_decode(trim($raw_output), true);
+        if ( is_string( $raw_output ) ) {
+            $raw_output = json_decode( trim( $raw_output ), true );
         }
 
-        if (!is_array($raw_output)) {
-            $this->log_provider_event('render', $action, $elapsed_ms, 'failure', 'invalid_json_output');
+        if ( ! is_array( $raw_output ) ) {
+            $this->log_provider_event( 'render', $action, $elapsed_ms, 'failure', 'invalid_json_output' );
 
-            return new \WP_Error('kerbcycle_ai_output_invalid_json', __('AI output was not valid JSON.', 'kerbcycle-qr-code-manager'), ['status' => 422]);
+            return new \WP_Error( 'kerbcycle_ai_output_invalid_json', __( 'AI output was not valid JSON.', 'kerbcycle-qr-code-manager' ), [ 'status' => 422 ] );
         }
 
-        $this->log_provider_event('render', $action, $elapsed_ms, 'success');
+        $this->log_provider_event( 'render', $action, $elapsed_ms, 'success' );
 
         return [
             'provider'   => 'render',
@@ -211,15 +215,14 @@ class AiProviderService
     /**
      * @return string|null
      */
-    private function get_render_model()
-    {
-        $model = defined('KERBCYCLE_AI_RENDER_MODEL') ? KERBCYCLE_AI_RENDER_MODEL : get_option('kerbcycle_ai_render_model', '');
+    private function get_render_model() {
+        $model = defined( 'KERBCYCLE_AI_RENDER_MODEL' ) ? KERBCYCLE_AI_RENDER_MODEL : get_option( 'kerbcycle_ai_render_model', '' );
 
-        if (!is_string($model)) {
+        if ( ! is_string( $model ) ) {
             return null;
         }
 
-        $model = trim($model);
+        $model = trim( $model );
 
         return $model !== '' ? $model : null;
     }
@@ -227,21 +230,19 @@ class AiProviderService
     /**
      * @return string
      */
-    private function get_render_endpoint()
-    {
-        $endpoint = defined('KERBCYCLE_AI_RENDER_URL') ? KERBCYCLE_AI_RENDER_URL : get_option('kerbcycle_ai_render_endpoint', '');
+    private function get_render_endpoint() {
+        $endpoint = defined( 'KERBCYCLE_AI_RENDER_URL' ) ? KERBCYCLE_AI_RENDER_URL : get_option( 'kerbcycle_ai_render_endpoint', '' );
 
-        return is_string($endpoint) ? trim($endpoint) : '';
+        return is_string( $endpoint ) ? trim( $endpoint ) : '';
     }
 
     /**
      * @return string
      */
-    private function get_render_api_key()
-    {
-        $api_key = defined('KERBCYCLE_AI_RENDER_API_KEY') ? KERBCYCLE_AI_RENDER_API_KEY : get_option('kerbcycle_ai_render_api_key', '');
+    private function get_render_api_key() {
+        $api_key = defined( 'KERBCYCLE_AI_RENDER_API_KEY' ) ? KERBCYCLE_AI_RENDER_API_KEY : get_option( 'kerbcycle_ai_render_api_key', '' );
 
-        return is_string($api_key) ? trim($api_key) : '';
+        return is_string( $api_key ) ? trim( $api_key ) : '';
     }
 
     /**
@@ -253,8 +254,7 @@ class AiProviderService
      *
      * @return void
      */
-    private function log_provider_event($provider, $action, $latency_ms, $status, $detail = '')
-    {
+    private function log_provider_event( $provider, $action, $latency_ms, $status, $detail = '' ) {
         $message = sprintf(
             'AI provider request provider=%s action=%s latency_ms=%d status=%s',
             $provider,
@@ -263,16 +263,18 @@ class AiProviderService
             $status
         );
 
-        if ($detail !== '') {
-            $message .= sprintf(' detail=%s', $detail);
+        if ( $detail !== '' ) {
+            $message .= sprintf( ' detail=%s', $detail );
         }
 
-        ErrorLogRepository::log([
-            'type'    => 'ai_provider',
-            'message' => $message,
-            'page'    => 'api-ai',
-            'status'  => $status,
-        ]);
+        ErrorLogRepository::log(
+            [
+				'type'    => 'ai_provider',
+				'message' => $message,
+				'page'    => 'api-ai',
+				'status'  => $status,
+			]
+        );
     }
 
     /**
@@ -281,32 +283,37 @@ class AiProviderService
      *
      * @return string
      */
-    private function build_prompt($action, array $payload)
-    {
+    private function build_prompt( $action, array $payload ) {
         $schemas = [
             'pickup_summary' => [
-                'summary' => 'string',
-                'highlights' => ['string'],
+                'summary'    => 'string',
+                'highlights' => [ 'string' ],
                 'risk_level' => 'low|medium|high',
             ],
-            'qr_exceptions' => [
-                'overview' => 'string',
-                'priority_exceptions' => [['type' => 'string', 'count' => 'number', 'reason' => 'string']],
-                'recommended_actions' => ['string'],
+            'qr_exceptions'  => [
+                'overview'            => 'string',
+                'priority_exceptions' => [
+					[
+						'type'   => 'string',
+						'count'  => 'number',
+						'reason' => 'string',
+					],
+				],
+                'recommended_actions' => [ 'string' ],
             ],
             'draft_template' => [
-                'title' => 'string',
-                'message' => 'string',
+                'title'    => 'string',
+                'message'  => 'string',
                 'audience' => 'string',
             ],
         ];
 
-        $schema = isset($schemas[$action]) ? $schemas[$action] : ['result' => 'string'];
+        $schema = isset( $schemas[ $action ] ) ? $schemas[ $action ] : [ 'result' => 'string' ];
 
         return "You are a municipal operations assistant.\n"
             . "Return ONLY valid JSON with no markdown, no prose outside JSON, and no trailing text.\n"
             . "Action: {$action}\n"
-            . 'Required JSON schema: ' . wp_json_encode($schema) . "\n"
-            . 'Input payload: ' . wp_json_encode($payload) . "\n";
+            . 'Required JSON schema: ' . wp_json_encode( $schema ) . "\n"
+            . 'Input payload: ' . wp_json_encode( $payload ) . "\n";
     }
 }

--- a/includes/Services/AiProviderService.php
+++ b/includes/Services/AiProviderService.php
@@ -46,7 +46,7 @@ class AiProviderService
         $provider = $provider !== '' ? $provider : 'ollama';
 
         if (!in_array($provider, ['ollama', 'render'], true)) {
-            return new \WP_Error('kerbcycle_ai_provider_unsupported', __('Unsupported AI provider configured.', 'kerbcycle'), ['status' => 500]);
+            return new \WP_Error('kerbcycle_ai_provider_unsupported', __('Unsupported AI provider configured.', 'kerbcycle-qr-code-manager'), ['status' => 500]);
         }
 
         return $provider;
@@ -67,7 +67,7 @@ class AiProviderService
         $model    = is_string($model) ? trim($model) : 'llama3.1:8b';
 
         if ($base_url === '' || $model === '') {
-            return new \WP_Error('kerbcycle_ai_provider_misconfigured', __('AI provider configuration is incomplete.', 'kerbcycle'), ['status' => 500]);
+            return new \WP_Error('kerbcycle_ai_provider_misconfigured', __('AI provider configuration is incomplete.', 'kerbcycle-qr-code-manager'), ['status' => 500]);
         }
 
         $request_payload = [
@@ -92,7 +92,7 @@ class AiProviderService
         if (is_wp_error($response)) {
             $this->log_provider_event('ollama', $action, $elapsed_ms, 'failure', $response->get_error_message());
 
-            return new \WP_Error('kerbcycle_ai_provider_unreachable', __('AI provider is unreachable.', 'kerbcycle'), ['status' => 502]);
+            return new \WP_Error('kerbcycle_ai_provider_unreachable', __('AI provider is unreachable.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
         }
 
         $status_code = (int) wp_remote_retrieve_response_code($response);
@@ -101,19 +101,19 @@ class AiProviderService
         if ($status_code < 200 || $status_code >= 300) {
             $this->log_provider_event('ollama', $action, $elapsed_ms, 'failure', sprintf('http_status=%d', $status_code));
 
-            return new \WP_Error('kerbcycle_ai_provider_http_error', __('AI provider returned an unexpected response.', 'kerbcycle'), ['status' => 502]);
+            return new \WP_Error('kerbcycle_ai_provider_http_error', __('AI provider returned an unexpected response.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
         }
 
         $decoded = json_decode($body, true);
         if (!is_array($decoded) || !isset($decoded['response']) || !is_string($decoded['response'])) {
-            return new \WP_Error('kerbcycle_ai_provider_invalid_response', __('AI provider response could not be parsed.', 'kerbcycle'), ['status' => 502]);
+            return new \WP_Error('kerbcycle_ai_provider_invalid_response', __('AI provider response could not be parsed.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
         }
 
         $parsed_output = json_decode(trim($decoded['response']), true);
         if (!is_array($parsed_output)) {
             $this->log_provider_event('ollama', $action, $elapsed_ms, 'failure', 'invalid_json_output');
 
-            return new \WP_Error('kerbcycle_ai_output_invalid_json', __('AI output was not valid JSON.', 'kerbcycle'), ['status' => 422]);
+            return new \WP_Error('kerbcycle_ai_output_invalid_json', __('AI output was not valid JSON.', 'kerbcycle-qr-code-manager'), ['status' => 422]);
         }
 
         $this->log_provider_event('ollama', $action, $elapsed_ms, 'success');
@@ -139,7 +139,7 @@ class AiProviderService
         $model    = $this->get_render_model();
 
         if ($endpoint === '' || $api_key === '') {
-            return new \WP_Error('kerbcycle_ai_provider_misconfigured', __('AI provider configuration is incomplete.', 'kerbcycle'), ['status' => 500]);
+            return new \WP_Error('kerbcycle_ai_provider_misconfigured', __('AI provider configuration is incomplete.', 'kerbcycle-qr-code-manager'), ['status' => 500]);
         }
 
         $started = microtime(true);
@@ -159,7 +159,7 @@ class AiProviderService
         if (is_wp_error($response)) {
             $this->log_provider_event('render', $action, $elapsed_ms, 'failure', $response->get_error_message());
 
-            return new \WP_Error('kerbcycle_ai_provider_unreachable', __('AI provider is unreachable.', 'kerbcycle'), ['status' => 502]);
+            return new \WP_Error('kerbcycle_ai_provider_unreachable', __('AI provider is unreachable.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
         }
 
         $status_code = (int) wp_remote_retrieve_response_code($response);
@@ -168,12 +168,12 @@ class AiProviderService
         if ($status_code < 200 || $status_code >= 300) {
             $this->log_provider_event('render', $action, $elapsed_ms, 'failure', sprintf('http_status=%d', $status_code));
 
-            return new \WP_Error('kerbcycle_ai_provider_http_error', __('AI provider returned an unexpected response.', 'kerbcycle'), ['status' => 502]);
+            return new \WP_Error('kerbcycle_ai_provider_http_error', __('AI provider returned an unexpected response.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
         }
 
         $decoded = json_decode($body, true);
         if (!is_array($decoded)) {
-            return new \WP_Error('kerbcycle_ai_provider_invalid_response', __('AI provider response could not be parsed.', 'kerbcycle'), ['status' => 502]);
+            return new \WP_Error('kerbcycle_ai_provider_invalid_response', __('AI provider response could not be parsed.', 'kerbcycle-qr-code-manager'), ['status' => 502]);
         }
 
         $raw_output = null;
@@ -195,7 +195,7 @@ class AiProviderService
         if (!is_array($raw_output)) {
             $this->log_provider_event('render', $action, $elapsed_ms, 'failure', 'invalid_json_output');
 
-            return new \WP_Error('kerbcycle_ai_output_invalid_json', __('AI output was not valid JSON.', 'kerbcycle'), ['status' => 422]);
+            return new \WP_Error('kerbcycle_ai_output_invalid_json', __('AI output was not valid JSON.', 'kerbcycle-qr-code-manager'), ['status' => 422]);
         }
 
         $this->log_provider_event('render', $action, $elapsed_ms, 'success');


### PR DESCRIPTION
### Motivation
- Resolve PHPCS i18n text-domain mismatches in `AiProviderService` by aligning translation calls with the plugin text domain.

### Description
- Updated only `includes/Services/AiProviderService.php` to replace the text-domain argument in WordPress i18n calls from `'kerbcycle'` to `'kerbcycle-qr-code-manager'` at 11 locations, without changing translated strings or any logic.

### Testing
- Confirmed only `includes/Services/AiProviderService.php` changed via `git diff --name-only`, confirmed PHP syntax via `php -l includes/Services/AiProviderService.php`, and attempted PHPCS but `vendor/bin/phpcs` was unavailable in this environment; all performed checks passed or were reported as unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01937689cc832d8dd5c3169bf5033c)