### PR TITLE
PHPCS cleanup for MessagesService non-auto-fixable findings (pass 1)

### DIFF
--- a/includes/Services/MessagesService.php
+++ b/includes/Services/MessagesService.php
@@ -77,11 +77,13 @@ class MessagesService
 		}
 
 		$messages = self::get_all();
-		$tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'edit';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only admin tab state; no server-side state is changed by this GET value.
+		$tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'edit';
 
 		/** =========================
 		 *  SAVE HANDLER (Templates)
 		 *  ========================= */
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- This only detects the save action before entering the handler; the handler is protected by Nonces::verify( 'kc_msgs_save_nonce', 'kc_msgs_nonce' ).
 		if (!empty($_POST['kc_msgs_save'])) {
 			Nonces::verify('kc_msgs_save_nonce', 'kc_msgs_nonce');
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Save handler is protected by Nonces::verify( 'kc_msgs_save_nonce', 'kc_msgs_nonce' ) above.
@@ -131,6 +133,7 @@ class MessagesService
 		$send_email_checked = false;
 		$do_send_sms = false;
 		$do_send_email = false;
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- This only detects the test action before entering the handler; the handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ).
 		if (!empty($_POST['kc_msgs_render']) || !empty($_POST['kc_msgs_send'])) {
 			Nonces::verify('kc_msgs_test_nonce', 'kc_msgs_test_nonce_f');
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.

--- a/includes/Services/MessagesService.php
+++ b/includes/Services/MessagesService.php
@@ -9,8 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class MessagesService
-{
+class MessagesService {
+
 	public const OPT = 'kerbcycle_messages'; // stores an array of message templates
 
 	public static function defaults() {
@@ -35,20 +35,19 @@ class MessagesService
 		];
 	}
 
-	public static function get_all()
-	{
-		$saved = get_option(self::OPT, []);
+	public static function get_all() {
+		$saved    = get_option( self::OPT, [] );
 		$defaults = self::defaults();
-		if (!is_array($saved)) {
+		if ( ! is_array( $saved ) ) {
 			$saved = [];
 		}
-		foreach ($defaults as $k => $pair) {
-			if (!isset($saved[$k]) || !is_array($saved[$k])) {
-				$saved[$k] = $pair;
+		foreach ( $defaults as $k => $pair ) {
+			if ( ! isset( $saved[ $k ] ) || ! is_array( $saved[ $k ] ) ) {
+				$saved[ $k ] = $pair;
 			} else {
-				foreach ($pair as $kk => $vv) {
-					if (!isset($saved[$k][$kk])) {
-						$saved[$k][$kk] = $vv;
+				foreach ( $pair as $kk => $vv ) {
+					if ( ! isset( $saved[ $k ][ $kk ] ) ) {
+						$saved[ $k ][ $kk ] = $vv;
 					}
 				}
 			}
@@ -58,21 +57,19 @@ class MessagesService
 
 	/* ---------------- Admin page ---------------- */
 
-	public static function admin_menu()
-	{
+	public static function admin_menu() {
 		add_submenu_page(
 			'kerbcycle-qr-manager',
 			'KerbCycle Messages',
 			'Messages',
 			'manage_options',
 			'kerbcycle-messages',
-			[__CLASS__, 'render_page']
+			[ __CLASS__, 'render_page' ]
 		);
 	}
 
-	public static function render_page()
-	{
-		if (!current_user_can('manage_options')) {
+	public static function render_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
 
@@ -84,29 +81,32 @@ class MessagesService
 		 *  SAVE HANDLER (Templates)
 		 *  ========================= */
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- This only detects the save action before entering the handler; the handler is protected by Nonces::verify( 'kc_msgs_save_nonce', 'kc_msgs_nonce' ).
-		if (!empty($_POST['kc_msgs_save'])) {
-			Nonces::verify('kc_msgs_save_nonce', 'kc_msgs_nonce');
+		if ( ! empty( $_POST['kc_msgs_save'] ) ) {
+			Nonces::verify( 'kc_msgs_save_nonce', 'kc_msgs_nonce' );
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Save handler is protected by Nonces::verify( 'kc_msgs_save_nonce', 'kc_msgs_nonce' ) above.
 			$sel = isset( $_POST['kc_msg_type'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_msg_type'] ) ) : 'assigned';
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Save handler nonce verified above; template text is sanitized with wp_strip_all_tags() before persistence below.
-			$sms   = isset( $_POST['kc_sms'] ) ? wp_unslash( $_POST['kc_sms'] ) : '';
+			$sms = isset( $_POST['kc_sms'] ) ? wp_unslash( $_POST['kc_sms'] ) : '';
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Save handler nonce verified above; template text is sanitized with wp_strip_all_tags() before persistence below.
 			$email = isset( $_POST['kc_email'] ) ? wp_unslash( $_POST['kc_email'] ) : '';
 
-			$sms   = is_string($sms) ? trim($sms) : '';
-			$email = is_string($email) ? trim($email) : '';
+			$sms   = is_string( $sms ) ? trim( $sms ) : '';
+			$email = is_string( $email ) ? trim( $email ) : '';
 
-			if (!isset($messages[$sel])) {
-				$messages[ $sel ] = [ 'sms' => '', 'email' => '' ];
+			if ( ! isset( $messages[ $sel ] ) ) {
+				$messages[ $sel ] = [
+					'sms'   => '',
+					'email' => '',
+				];
 			}
-			$messages[$sel]['sms']   = wp_strip_all_tags($sms, true);
-			$messages[$sel]['email'] = wp_strip_all_tags($email, true);
+			$messages[ $sel ]['sms']   = wp_strip_all_tags( $sms, true );
+			$messages[ $sel ]['email'] = wp_strip_all_tags( $email, true );
 
-			update_option(self::OPT, $messages, false);
+			update_option( self::OPT, $messages, false );
 			Notices::add(
 				'success',
-				'Messages saved for <strong>' . esc_html(self::label_for($sel)) . '</strong>.',
+				'Messages saved for <strong>' . esc_html( self::label_for( $sel ) ) . '</strong>.',
 				[
 					'dismissible' => true,
 					'log_type'    => 'messages_save',
@@ -123,26 +123,26 @@ class MessagesService
 		$test_preview_sms   = '';
 		$test_preview_email = '';
 		$test_type          = 'assigned';
-		$t_user = '';
-		$t_code = '';
-		$t_amount = '';
-		$t_wallet = '';
-		$t_to_sms = '';
-		$t_to_email = '';
-		$send_sms_checked = false;
+		$t_user             = '';
+		$t_code             = '';
+		$t_amount           = '';
+		$t_wallet           = '';
+		$t_to_sms           = '';
+		$t_to_email         = '';
+		$send_sms_checked   = false;
 		$send_email_checked = false;
-		$do_send_sms = false;
-		$do_send_email = false;
+		$do_send_sms        = false;
+		$do_send_email      = false;
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- This only detects the test action before entering the handler; the handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ).
-		if (!empty($_POST['kc_msgs_render']) || !empty($_POST['kc_msgs_send'])) {
-			Nonces::verify('kc_msgs_test_nonce', 'kc_msgs_test_nonce_f');
+		if ( ! empty( $_POST['kc_msgs_render'] ) || ! empty( $_POST['kc_msgs_send'] ) ) {
+			Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' );
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
-			$t_type   = isset( $_POST['kc_test_type'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_type'] ) ) : 'assigned';
+			$t_type    = isset( $_POST['kc_test_type'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_type'] ) ) : 'assigned';
 			$test_type = $t_type;
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
-			$t_user   = isset( $_POST['kc_test_user'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_user'] ) ) : '';
+			$t_user = isset( $_POST['kc_test_user'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_user'] ) ) : '';
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
-			$t_code   = isset( $_POST['kc_test_code'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_code'] ) ) : '';
+			$t_code = isset( $_POST['kc_test_code'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_code'] ) ) : '';
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
 			$t_amount = isset( $_POST['kc_test_amount'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_amount'] ) ) : '';
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
@@ -152,34 +152,37 @@ class MessagesService
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
 			$t_to_email = isset( $_POST['kc_test_to_email'] ) ? sanitize_email( wp_unslash( $_POST['kc_test_to_email'] ) ) : '';
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
-			$send_sms_checked   = ! empty( $_POST['kc_test_send_sms'] );
+			$send_sms_checked = ! empty( $_POST['kc_test_send_sms'] );
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
 			$send_email_checked = ! empty( $_POST['kc_test_send_email'] );
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
-			$do_send_sms   = ! empty( $_POST['kc_msgs_send'] ) && $send_sms_checked;
+			$do_send_sms = ! empty( $_POST['kc_msgs_send'] ) && $send_sms_checked;
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
 			$do_send_email = ! empty( $_POST['kc_msgs_send'] ) && $send_email_checked;
 
-			$rendered = self::render($t_type, [
-				'user'   => $t_user,
-				'code'   => $t_code,
-				'amount' => $t_amount,
-				'wallet' => $t_wallet,
-			]);
+			$rendered = self::render(
+                $t_type,
+                [
+					'user'   => $t_user,
+					'code'   => $t_code,
+					'amount' => $t_amount,
+					'wallet' => $t_wallet,
+				]
+            );
 
 			$test_preview_sms   = $rendered['sms'];
 			$test_preview_email = $rendered['email'];
 
 			// SMS send (optional)
-			if ($do_send_sms && $t_to_sms) {
-				$r = \Kerbcycle\QrCode\Services\SmsService::send($t_to_sms, $test_preview_sms);
-				if (is_wp_error($r)) {
-					$d = $r->get_error_data();
-					$http = (is_array($d) && isset($d['http'])) ? ' HTTP=' . $d['http'] : '';
-					$body = (is_array($d) && isset($d['body'])) ? ' Body=' . substr(is_string($d['body']) ? $d['body'] : wp_json_encode($d['body']), 0, 300) : '';
+			if ( $do_send_sms && $t_to_sms ) {
+				$r = \Kerbcycle\QrCode\Services\SmsService::send( $t_to_sms, $test_preview_sms );
+				if ( is_wp_error( $r ) ) {
+					$d    = $r->get_error_data();
+					$http = ( is_array( $d ) && isset( $d['http'] ) ) ? ' HTTP=' . $d['http'] : '';
+					$body = ( is_array( $d ) && isset( $d['body'] ) ) ? ' Body=' . substr( is_string( $d['body'] ) ? $d['body'] : wp_json_encode( $d['body'] ), 0, 300 ) : '';
 					Notices::add(
 						'error',
-						'<strong>Test SMS failed:</strong> ' . esc_html($r->get_error_message() . $http . $body),
+						'<strong>Test SMS failed:</strong> ' . esc_html( $r->get_error_message() . $http . $body ),
 						[
 							'log_type' => 'test_sms',
 							'page'     => 'kerbcycle-messages',
@@ -189,7 +192,7 @@ class MessagesService
 				} else {
 					Notices::add(
 						'success',
-						'<strong>Test SMS sent.</strong> ' . esc_html(wp_json_encode($r)),
+						'<strong>Test SMS sent.</strong> ' . esc_html( wp_json_encode( $r ) ),
 						[
 							'dismissible' => true,
 							'log_type'    => 'test_sms',
@@ -201,12 +204,12 @@ class MessagesService
 			}
 
 			// Email send (optional)
-			if ($do_send_email && $t_to_email) {
-				$sent = wp_mail($t_to_email, 'KerbCycle Test: ' . self::label_for($t_type), $test_preview_email);
-				if ($sent) {
+			if ( $do_send_email && $t_to_email ) {
+				$sent = wp_mail( $t_to_email, 'KerbCycle Test: ' . self::label_for( $t_type ), $test_preview_email );
+				if ( $sent ) {
 					Notices::add(
 						'success',
-						'<strong>Test Email sent</strong> to ' . esc_html($t_to_email) . '.',
+						'<strong>Test Email sent</strong> to ' . esc_html( $t_to_email ) . '.',
 						[
 							'dismissible' => true,
 							'log_type'    => 'test_email',
@@ -232,7 +235,7 @@ class MessagesService
 		// Active type for editor (default assigned)
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Active editor state is display-only; save handling is protected by Nonces::verify() above.
 		$active = isset( $_POST['kc_msg_type'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_msg_type'] ) ) : 'assigned';
-		if (!isset($messages[$active])) {
+		if ( ! isset( $messages[ $active ] ) ) {
 			$active = 'assigned';
 		}
 
@@ -241,17 +244,17 @@ class MessagesService
 		<div class="wrap">
 			<h1>KerbCycle Messages</h1>
 			<h2 class="nav-tab-wrapper">
-				<a href="<?php echo esc_url(admin_url('admin.php?page=kerbcycle-messages&tab=edit')); ?>" class="nav-tab <?php echo $tab === 'edit' ? 'nav-tab-active' : ''; ?>">Edit Messages</a>
-				<a href="<?php echo esc_url(admin_url('admin.php?page=kerbcycle-messages&tab=test')); ?>" class="nav-tab <?php echo $tab === 'test' ? 'nav-tab-active' : ''; ?>">Test messages</a>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=kerbcycle-messages&tab=edit' ) ); ?>" class="nav-tab <?php echo $tab === 'edit' ? 'nav-tab-active' : ''; ?>">Edit Messages</a>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=kerbcycle-messages&tab=test' ) ); ?>" class="nav-tab <?php echo $tab === 'test' ? 'nav-tab-active' : ''; ?>">Test messages</a>
 			</h2>
 
-			<?php if ($tab === 'edit'): ?>
+			<?php if ( $tab === 'edit' ) : ?>
 			<p>Edit the SMS and Email templates for each message type. Use placeholders:
 				<code>{user}</code>, <code>{code}</code>, <code>{amount}</code>, <code>{wallet}</code>
 			</p>
 
-			<form method="post" action="<?php echo esc_url(admin_url('admin.php?page=kerbcycle-messages&tab=edit')); ?>">
-				<?php wp_nonce_field('kc_msgs_save_nonce', 'kc_msgs_nonce'); ?>
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=kerbcycle-messages&tab=edit' ) ); ?>">
+				<?php wp_nonce_field( 'kc_msgs_save_nonce', 'kc_msgs_nonce' ); ?>
 
 				<table class="form-table" role="presentation">
 					<tbody>
@@ -259,9 +262,9 @@ class MessagesService
 							<th scope="row"><label for="kc_msg_type">Message Type</label></th>
 							<td>
 								<select id="kc_msg_type" name="kc_msg_type">
-									<?php foreach ($types as $key => $label): ?>
-										<option value="<?php echo esc_attr($key); ?>" <?php selected($active, $key); ?>>
-											<?php echo esc_html($label); ?>
+									<?php foreach ( $types as $key => $label ) : ?>
+										<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $active, $key ); ?>>
+											<?php echo esc_html( $label ); ?>
 										</option>
 									<?php endforeach; ?>
 								</select>
@@ -272,7 +275,7 @@ class MessagesService
 						<tr class="kc-sms-row">
 							<th scope="row"><label for="kc_sms">SMS Text</label></th>
 							<td>
-								<textarea id="kc_sms" name="kc_sms" rows="4" style="width: 100%; max-width: 800px;"><?php echo esc_textarea($messages[$active]['sms'] ?? ''); ?></textarea>
+								<textarea id="kc_sms" name="kc_sms" rows="4" style="width: 100%; max-width: 800px;"><?php echo esc_textarea( $messages[ $active ]['sms'] ?? '' ); ?></textarea>
 								<p class="description">Keep SMS concise (ideally &lt; 160 chars). Placeholders allowed.</p>
 							</td>
 						</tr>
@@ -280,7 +283,7 @@ class MessagesService
 						<tr class="kc-email-row">
 							<th scope="row"><label for="kc_email">Email Text</label></th>
 							<td>
-								<textarea id="kc_email" name="kc_email" rows="8" style="width: 100%; max-width: 800px;"><?php echo esc_textarea($messages[$active]['email'] ?? ''); ?></textarea>
+								<textarea id="kc_email" name="kc_email" rows="8" style="width: 100%; max-width: 800px;"><?php echo esc_textarea( $messages[ $active ]['email'] ?? '' ); ?></textarea>
 								<p class="description">Plain text email. Placeholders allowed. Newlines are preserved.</p>
 							</td>
 						</tr>
@@ -291,11 +294,11 @@ class MessagesService
 					<button type="submit" class="button button-primary" name="kc_msgs_save" value="1">Save</button>
 				</p>
 			</form>
-			<?php else: ?>
+			<?php else : ?>
 			<p>Render a template with sample variables and optionally send a test SMS and/or Email.</p>
 
-			<form method="post" action="<?php echo esc_url(admin_url('admin.php?page=kerbcycle-messages&tab=test')); ?>">
-				<?php wp_nonce_field('kc_msgs_test_nonce', 'kc_msgs_test_nonce_f'); ?>
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=kerbcycle-messages&tab=test' ) ); ?>">
+				<?php wp_nonce_field( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ); ?>
 
 				<table class="form-table" role="presentation">
 					<tbody>
@@ -303,8 +306,8 @@ class MessagesService
 							<th scope="row"><label for="kc_test_type">Message Type</label></th>
 							<td>
 								<select id="kc_test_type" name="kc_test_type">
-									<?php foreach ($types as $key => $label): ?>
-										<option value="<?php echo esc_attr($key); ?>" <?php selected($test_type, $key); ?>><?php echo esc_html($label); ?></option>
+									<?php foreach ( $types as $key => $label ) : ?>
+										<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $test_type, $key ); ?>><?php echo esc_html( $label ); ?></option>
 									<?php endforeach; ?>
 								</select>
 							</td>
@@ -313,10 +316,10 @@ class MessagesService
 						<tr>
 							<th scope="row">Variables</th>
 							<td>
-								<input type="text" name="kc_test_user"   placeholder="user e.g. Sam"   style="width:200px" value="<?php echo esc_attr($t_user); ?>" />
-								<input type="text" name="kc_test_code"   placeholder="code e.g. QR123" style="width:200px" value="<?php echo esc_attr($t_code); ?>" />
-								<input type="text" name="kc_test_amount" placeholder="amount e.g. $10"  style="width:200px" value="<?php echo esc_attr($t_amount); ?>" />
-								<input type="text" name="kc_test_wallet" placeholder="wallet e.g. TeraWallet" style="width:220px" value="<?php echo esc_attr($t_wallet); ?>" />
+								<input type="text" name="kc_test_user"   placeholder="user e.g. Sam"   style="width:200px" value="<?php echo esc_attr( $t_user ); ?>" />
+								<input type="text" name="kc_test_code"   placeholder="code e.g. QR123" style="width:200px" value="<?php echo esc_attr( $t_code ); ?>" />
+								<input type="text" name="kc_test_amount" placeholder="amount e.g. $10"  style="width:200px" value="<?php echo esc_attr( $t_amount ); ?>" />
+								<input type="text" name="kc_test_wallet" placeholder="wallet e.g. TeraWallet" style="width:220px" value="<?php echo esc_attr( $t_wallet ); ?>" />
 								<p class="description">Only variables used in the selected template are needed.</p>
 							</td>
 						</tr>
@@ -324,26 +327,26 @@ class MessagesService
 						<tr>
 							<th scope="row">Send Options</th>
 							<td>
-								<label><input type="checkbox" name="kc_test_send_sms" value="1" <?php checked($send_sms_checked); ?> /> Send SMS to:</label>
-								<input type="text" name="kc_test_to_sms" placeholder="+15551234567" style="width:200px; margin-right:20px;" value="<?php echo esc_attr($t_to_sms); ?>" />
-								<label><input type="checkbox" name="kc_test_send_email" value="1" <?php checked($send_email_checked); ?> /> Send Email to:</label>
-								<input type="email" name="kc_test_to_email" placeholder="you@example.com" style="width:240px" value="<?php echo esc_attr($t_to_email); ?>" />
+								<label><input type="checkbox" name="kc_test_send_sms" value="1" <?php checked( $send_sms_checked ); ?> /> Send SMS to:</label>
+								<input type="text" name="kc_test_to_sms" placeholder="+15551234567" style="width:200px; margin-right:20px;" value="<?php echo esc_attr( $t_to_sms ); ?>" />
+								<label><input type="checkbox" name="kc_test_send_email" value="1" <?php checked( $send_email_checked ); ?> /> Send Email to:</label>
+								<input type="email" name="kc_test_to_email" placeholder="you@example.com" style="width:240px" value="<?php echo esc_attr( $t_to_email ); ?>" />
 								<p class="description">Leave unchecked to just preview below.</p>
 							</td>
 						</tr>
 
-						<?php if ($test_preview_sms !== '' || $test_preview_email !== ''): ?>
+						<?php if ( $test_preview_sms !== '' || $test_preview_email !== '' ) : ?>
 						<tr>
 							<th scope="row">Preview</th>
 							<td>
-								<?php if ($test_preview_sms !== ''): ?>
+								<?php if ( $test_preview_sms !== '' ) : ?>
 								<p><strong>SMS:</strong></p>
-								<pre style="background:#f6f7f7;padding:10px;max-width:800px;white-space:pre-wrap;"><?php echo esc_html($test_preview_sms); ?></pre>
+								<pre style="background:#f6f7f7;padding:10px;max-width:800px;white-space:pre-wrap;"><?php echo esc_html( $test_preview_sms ); ?></pre>
 								<?php endif; ?>
 
-								<?php if ($test_preview_email !== ''): ?>
+								<?php if ( $test_preview_email !== '' ) : ?>
 								<p><strong>Email:</strong></p>
-								<pre style="background:#f6f7f7;padding:10px;max-width:800px;white-space:pre-wrap;"><?php echo esc_html($test_preview_email); ?></pre>
+								<pre style="background:#f6f7f7;padding:10px;max-width:800px;white-space:pre-wrap;"><?php echo esc_html( $test_preview_email ); ?></pre>
 								<?php endif; ?>
 							</td>
 						</tr>
@@ -358,7 +361,7 @@ class MessagesService
 			</form>
 			<?php endif; ?>
 		</div>
-		<?php if ($tab === 'edit'): ?>
+		<?php if ( $tab === 'edit' ) : ?>
 		<script>
 		(function() {
 			const $type = document.getElementById('kc_msg_type');
@@ -366,8 +369,8 @@ class MessagesService
 			const $email= document.getElementById('kc_email');
 			const $desc = document.getElementById('kc_msg_desc');
 
-			const ALL   = <?php echo wp_json_encode($messages); ?>;
-			const DESCS = <?php echo wp_json_encode(self::descriptions_map()); ?>;
+			const ALL   = <?php echo wp_json_encode( $messages ); ?>;
+			const DESCS = <?php echo wp_json_encode( self::descriptions_map() ); ?>;
 
 			function updateFields() {
 				const key = $type.value;
@@ -391,8 +394,7 @@ class MessagesService
 		<?php
 	}
 
-	private static function types_map()
-	{
+	private static function types_map() {
 		return [
 			'assigned'   => 'QR code is assigned',
 			'released'   => 'QR code is released',
@@ -401,8 +403,7 @@ class MessagesService
 		];
 	}
 
-	private static function descriptions_map()
-	{
+	private static function descriptions_map() {
 		return [
 			'assigned'   => 'Sent when a QR code is assigned to a customer.',
 			'released'   => 'Sent when a QR code is released from a customer.',
@@ -411,10 +412,9 @@ class MessagesService
 		];
 	}
 
-	private static function label_for($key)
-	{
+	private static function label_for( $key ) {
 		$map = self::types_map();
-		return $map[$key] ?? $key;
+		return $map[ $key ] ?? $key;
 	}
 
 	/* -------- Helpers to fetch templates from elsewhere in your plugin -------- */
@@ -424,26 +424,27 @@ class MessagesService
 	 * @param string $type One of: assigned|released|funds_to|funds_from
 	 * @return array ['sms' => '...', 'email' => '...']
 	 */
-	public static function get_template($type)
-	{
+	public static function get_template( $type ) {
 		$all = self::get_all();
-		return isset( $all[ $type ] ) ? $all[ $type ] : [ 'sms' => '', 'email' => '' ];
+		return isset( $all[ $type ] ) ? $all[ $type ] : [
+			'sms'   => '',
+			'email' => '',
+		];
 	}
 
 	/**
 	 * Render a template with placeholders replaced.
 	 * Usage: KerbCycle_Messages::render('assigned', ['user'=>'Sam','code'=>'QR123'])
 	 */
-	public static function render($type, array $vars)
-	{
-		$tpl = self::get_template($type);
+	public static function render( $type, array $vars ) {
+		$tpl     = self::get_template( $type );
 		$replace = [];
-		foreach ($vars as $k => $v) {
+		foreach ( $vars as $k => $v ) {
 			$replace[ '{' . trim( $k ) . '}' ] = (string) $v;
 		}
 		return [
-			'sms'   => strtr($tpl['sms'] ?? '', $replace),
-			'email' => strtr($tpl['email'] ?? '', $replace),
+			'sms'   => strtr( $tpl['sms'] ?? '', $replace ),
+			'email' => strtr( $tpl['email'] ?? '', $replace ),
 		];
 	}
 }

--- a/includes/Services/MessagesService.php
+++ b/includes/Services/MessagesService.php
@@ -14,7 +14,7 @@ class MessagesService
 	public const OPT = 'kerbcycle_messages'; // stores an array of message templates
 
 	public static function defaults() {
-		// Each type has: ['sms' => '', 'email' => '']
+		// Each message type stores separate SMS and email template strings.
 		return [
 			'assigned'   => [
 				'sms'   => 'KerbCycle: QR {code} has been assigned to your account.',
@@ -84,10 +84,13 @@ class MessagesService
 		 *  ========================= */
 		if (!empty($_POST['kc_msgs_save'])) {
 			Nonces::verify('kc_msgs_save_nonce', 'kc_msgs_nonce');
-			$sel = sanitize_text_field($_POST['kc_msg_type'] ?? 'assigned');
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Save handler is protected by Nonces::verify( 'kc_msgs_save_nonce', 'kc_msgs_nonce' ) above.
+			$sel = isset( $_POST['kc_msg_type'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_msg_type'] ) ) : 'assigned';
 
-			$sms   = isset($_POST['kc_sms']) ? wp_unslash($_POST['kc_sms']) : '';
-			$email = isset($_POST['kc_email']) ? wp_unslash($_POST['kc_email']) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Save handler nonce verified above; template text is sanitized with wp_strip_all_tags() before persistence below.
+			$sms   = isset( $_POST['kc_sms'] ) ? wp_unslash( $_POST['kc_sms'] ) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Save handler nonce verified above; template text is sanitized with wp_strip_all_tags() before persistence below.
+			$email = isset( $_POST['kc_email'] ) ? wp_unslash( $_POST['kc_email'] ) : '';
 
 			$sms   = is_string($sms) ? trim($sms) : '';
 			$email = is_string($email) ? trim($email) : '';
@@ -118,24 +121,41 @@ class MessagesService
 		$test_preview_sms   = '';
 		$test_preview_email = '';
 		$test_type          = 'assigned';
-		$t_user = $t_code = $t_amount = $t_wallet = '';
-		$t_to_sms = $t_to_email = '';
-		$send_sms_checked = $send_email_checked = false;
-		$do_send_sms = $do_send_email = false;
+		$t_user = '';
+		$t_code = '';
+		$t_amount = '';
+		$t_wallet = '';
+		$t_to_sms = '';
+		$t_to_email = '';
+		$send_sms_checked = false;
+		$send_email_checked = false;
+		$do_send_sms = false;
+		$do_send_email = false;
 		if (!empty($_POST['kc_msgs_render']) || !empty($_POST['kc_msgs_send'])) {
 			Nonces::verify('kc_msgs_test_nonce', 'kc_msgs_test_nonce_f');
-			$t_type   = sanitize_text_field($_POST['kc_test_type'] ?? 'assigned');
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
+			$t_type   = isset( $_POST['kc_test_type'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_type'] ) ) : 'assigned';
 			$test_type = $t_type;
-			$t_user   = sanitize_text_field($_POST['kc_test_user'] ?? '');
-			$t_code   = sanitize_text_field($_POST['kc_test_code'] ?? '');
-			$t_amount = sanitize_text_field($_POST['kc_test_amount'] ?? '');
-			$t_wallet = sanitize_text_field($_POST['kc_test_wallet'] ?? '');
-			$t_to_sms = sanitize_text_field($_POST['kc_test_to_sms'] ?? '');
-			$t_to_email = sanitize_email($_POST['kc_test_to_email'] ?? '');
-			$send_sms_checked   = !empty($_POST['kc_test_send_sms']);
-			$send_email_checked = !empty($_POST['kc_test_send_email']);
-			$do_send_sms   = !empty($_POST['kc_msgs_send']) && $send_sms_checked;
-			$do_send_email = !empty($_POST['kc_msgs_send']) && $send_email_checked;
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
+			$t_user   = isset( $_POST['kc_test_user'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_user'] ) ) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
+			$t_code   = isset( $_POST['kc_test_code'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_code'] ) ) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
+			$t_amount = isset( $_POST['kc_test_amount'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_amount'] ) ) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
+			$t_wallet = isset( $_POST['kc_test_wallet'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_wallet'] ) ) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
+			$t_to_sms = isset( $_POST['kc_test_to_sms'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_test_to_sms'] ) ) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
+			$t_to_email = isset( $_POST['kc_test_to_email'] ) ? sanitize_email( wp_unslash( $_POST['kc_test_to_email'] ) ) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
+			$send_sms_checked   = ! empty( $_POST['kc_test_send_sms'] );
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
+			$send_email_checked = ! empty( $_POST['kc_test_send_email'] );
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
+			$do_send_sms   = ! empty( $_POST['kc_msgs_send'] ) && $send_sms_checked;
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test handler is protected by Nonces::verify( 'kc_msgs_test_nonce', 'kc_msgs_test_nonce_f' ) above.
+			$do_send_email = ! empty( $_POST['kc_msgs_send'] ) && $send_email_checked;
 
 			$rendered = self::render($t_type, [
 				'user'   => $t_user,
@@ -153,7 +173,7 @@ class MessagesService
 				if (is_wp_error($r)) {
 					$d = $r->get_error_data();
 					$http = (is_array($d) && isset($d['http'])) ? ' HTTP=' . $d['http'] : '';
-					$body = (is_array($d) && isset($d['body'])) ? ' Body=' . substr(is_string($d['body']) ? $d['body'] : json_encode($d['body']), 0, 300) : '';
+					$body = (is_array($d) && isset($d['body'])) ? ' Body=' . substr(is_string($d['body']) ? $d['body'] : wp_json_encode($d['body']), 0, 300) : '';
 					Notices::add(
 						'error',
 						'<strong>Test SMS failed:</strong> ' . esc_html($r->get_error_message() . $http . $body),
@@ -166,7 +186,7 @@ class MessagesService
 				} else {
 					Notices::add(
 						'success',
-						'<strong>Test SMS sent.</strong> ' . esc_html(json_encode($r)),
+						'<strong>Test SMS sent.</strong> ' . esc_html(wp_json_encode($r)),
 						[
 							'dismissible' => true,
 							'log_type'    => 'test_sms',
@@ -207,7 +227,8 @@ class MessagesService
 		}
 
 		// Active type for editor (default assigned)
-		$active = isset($_POST['kc_msg_type']) ? sanitize_text_field($_POST['kc_msg_type']) : 'assigned';
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Active editor state is display-only; save handling is protected by Nonces::verify() above.
+		$active = isset( $_POST['kc_msg_type'] ) ? sanitize_text_field( wp_unslash( $_POST['kc_msg_type'] ) ) : 'assigned';
 		if (!isset($messages[$active])) {
 			$active = 'assigned';
 		}


### PR DESCRIPTION
### Motivation
- Reduce non-auto-fixable PHPCS findings in `MessagesService` without changing runtime behavior by making nonce checks and input handling explicit for PHPCS.
- Preserve existing security and persistence semantics (`Nonces::verify()`, `wp_strip_all_tags()`, option key, message keys) while removing warnings that require human judgement.

### Description
- Files changed: `includes/Services/MessagesService.php` only.
- Rewrote the defaults comment to prose to avoid `Squiz.PHP.CommentedOutCode.Found` while leaving default templates unchanged.
- Added narrow PHPCS suppressions immediately after existing `Nonces::verify(...)` calls for the save and test handlers and for the display-only active-tab read so PHPCS does not demand the builtin nonce pattern.
- Added `wp_unslash()` to all targeted `$_POST` reads before sanitization, and made `kc_sms`/`kc_email` handling explicit (unslash → trim → `wp_strip_all_tags(..., true)`) with focused suppressions where PHPCS would still complain about deferred sanitization.
- Split chained/multiple-assignment statements into single assignments without changing default values.
- Replaced diagnostic `json_encode()` usages with `wp_json_encode()` for WP-compatible JSON encoding.
- No API, option key, nonce action/field name, message key, persistence, send, or rendering behavior was changed.

### Testing
- Confirmed only the target file changed with `git diff --name-only`:
  ```text
  includes/Services/MessagesService.php
  ```
- Verified PHP syntax with `php -l includes/Services/MessagesService.php` which returned:
  ```text
  No syntax errors detected in includes/Services/MessagesService.php
  ```
- Attempted to run PHPCS but it is unavailable in this environment, so automated PHPCS checks were not run here; observed result:
  ```text
  PHPCS was not run because vendor/bin/phpcs is unavailable in this environment.
  ```
- All changes limited to the allowed list (defaults comment, narrow nonce suppressions, `wp_unslash()` additions, `kc_sms`/`kc_email` handling, split assignments, `wp_json_encode()` replacements) and manual inspection confirms no behavior drift.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02aed65500832d9d83326ffc35d414)