### PR TITLE
Fix PickupExceptionRetryService PHPCS non-auto-fixable issues (i18n + SQL suppression)

### DIFF
--- a/includes/Services/PickupExceptionRetryService.php
+++ b/includes/Services/PickupExceptionRetryService.php
@@ -24,19 +24,21 @@ class PickupExceptionRetryService
         if ($exception_id < 1) {
             return [
                 'state' => 'invalid_id',
-                'message' => __('Invalid pickup exception ID.', 'kerbcycle'),
+                'message' => __('Invalid pickup exception ID.', 'kerbcycle-qr-code-manager'),
                 'status_code' => 400,
             ];
         }
 
         global $wpdb;
         $table_name = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; dynamic values are prepared below.
         $record = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table_name} WHERE id = %d", $exception_id));
+        // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
         if (!$record) {
             return [
                 'state' => 'not_found',
-                'message' => __('Pickup exception record not found.', 'kerbcycle'),
+                'message' => __('Pickup exception record not found.', 'kerbcycle-qr-code-manager'),
                 'status_code' => 404,
             ];
         }
@@ -44,7 +46,7 @@ class PickupExceptionRetryService
         if ((int) $record->webhook_sent === 1) {
             return [
                 'state' => 'ineligible',
-                'message' => __('This pickup exception is not eligible for retry.', 'kerbcycle'),
+                'message' => __('This pickup exception is not eligible for retry.', 'kerbcycle-qr-code-manager'),
                 'status_code' => 400,
             ];
         }
@@ -52,7 +54,7 @@ class PickupExceptionRetryService
         if (!$this->acquire_retry_lock($exception_id)) {
             return [
                 'state' => 'lock_conflict',
-                'message' => __('Retry already in progress for this pickup exception.', 'kerbcycle'),
+                'message' => __('Retry already in progress for this pickup exception.', 'kerbcycle-qr-code-manager'),
                 'status_code' => 409,
             ];
         }
@@ -92,7 +94,7 @@ class PickupExceptionRetryService
 
                 return [
                     'state' => 'webhook_error',
-                    'message' => __('Retry failed. The record remains saved locally.', 'kerbcycle'),
+                    'message' => __('Retry failed. The record remains saved locally.', 'kerbcycle-qr-code-manager'),
                     'status_code' => 500,
                     'error_code' => $result->get_error_code(),
                 ];
@@ -120,7 +122,7 @@ class PickupExceptionRetryService
 
                 return [
                     'state' => 'success',
-                    'message' => __('Pickup exception resent successfully.', 'kerbcycle'),
+                    'message' => __('Pickup exception resent successfully.', 'kerbcycle-qr-code-manager'),
                     'status_code' => 200,
                     'webhook_status_code' => isset($result['status_code']) ? (int) $result['status_code'] : 0,
                 ];
@@ -141,7 +143,7 @@ class PickupExceptionRetryService
 
             return [
                 'state' => 'webhook_non_success',
-                'message' => __('Retry failed. The record remains saved locally.', 'kerbcycle'),
+                'message' => __('Retry failed. The record remains saved locally.', 'kerbcycle-qr-code-manager'),
                 'status_code' => 500,
                 'webhook_status_code' => isset($result['status_code']) ? (int) $result['status_code'] : 0,
             ];

--- a/includes/Services/PickupExceptionRetryService.php
+++ b/includes/Services/PickupExceptionRetryService.php
@@ -4,12 +4,12 @@ namespace Kerbcycle\QrCode\Services;
 
 use Kerbcycle\QrCode\Data\Repositories\PickupExceptionRepository;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-class PickupExceptionRetryService
-{
+class PickupExceptionRetryService {
+
     private const RETRY_LOCK_TTL = 120;
 
     /**
@@ -18,13 +18,12 @@ class PickupExceptionRetryService
      *
      * @return array{state:string,message:string,status_code?:int,error_code?:string}
      */
-    public function retry($exception_id, QrService $qr_service = null)
-    {
+    public function retry( $exception_id, QrService $qr_service = null ) {
         $exception_id = (int) $exception_id;
-        if ($exception_id < 1) {
+        if ( $exception_id < 1 ) {
             return [
-                'state' => 'invalid_id',
-                'message' => __('Invalid pickup exception ID.', 'kerbcycle-qr-code-manager'),
+                'state'       => 'invalid_id',
+                'message'     => __( 'Invalid pickup exception ID.', 'kerbcycle-qr-code-manager' ),
                 'status_code' => 400,
             ];
         }
@@ -32,144 +31,155 @@ class PickupExceptionRetryService
         global $wpdb;
         $table_name = $wpdb->prefix . 'kerbcycle_pickup_exceptions';
         // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived from the WordPress table prefix and fixed plugin table suffix; dynamic values are prepared below.
-        $record = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table_name} WHERE id = %d", $exception_id));
+        $record = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE id = %d", $exception_id ) );
         // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-        if (!$record) {
+        if ( ! $record ) {
             return [
-                'state' => 'not_found',
-                'message' => __('Pickup exception record not found.', 'kerbcycle-qr-code-manager'),
+                'state'       => 'not_found',
+                'message'     => __( 'Pickup exception record not found.', 'kerbcycle-qr-code-manager' ),
                 'status_code' => 404,
             ];
         }
 
-        if ((int) $record->webhook_sent === 1) {
+        if ( (int) $record->webhook_sent === 1 ) {
             return [
-                'state' => 'ineligible',
-                'message' => __('This pickup exception is not eligible for retry.', 'kerbcycle-qr-code-manager'),
+                'state'       => 'ineligible',
+                'message'     => __( 'This pickup exception is not eligible for retry.', 'kerbcycle-qr-code-manager' ),
                 'status_code' => 400,
             ];
         }
 
-        if (!$this->acquire_retry_lock($exception_id)) {
+        if ( ! $this->acquire_retry_lock( $exception_id ) ) {
             return [
-                'state' => 'lock_conflict',
-                'message' => __('Retry already in progress for this pickup exception.', 'kerbcycle-qr-code-manager'),
+                'state'       => 'lock_conflict',
+                'message'     => __( 'Retry already in progress for this pickup exception.', 'kerbcycle-qr-code-manager' ),
                 'status_code' => 409,
             ];
         }
 
         try {
-            $retry_timestamp = current_time('mysql', true);
-            PickupExceptionRepository::update_result($exception_id, [
-                'retry_count' => ((int) $record->retry_count) + 1,
-                'last_retry_at' => $retry_timestamp,
-                'updated_at' => $retry_timestamp,
-            ]);
+            $retry_timestamp = current_time( 'mysql', true );
+            PickupExceptionRepository::update_result(
+                $exception_id,
+                [
+					'retry_count'   => ( (int) $record->retry_count ) + 1,
+					'last_retry_at' => $retry_timestamp,
+					'updated_at'    => $retry_timestamp,
+				]
+            );
 
-            if ($qr_service === null) {
+            if ( $qr_service === null ) {
                 $qr_service = new QrService();
             }
 
-            $result = $qr_service->send_pickup_exception_to_n8n([
-                'qr_code'     => (string) $record->qr_code,
-                'customer_id' => (int) $record->customer_id,
-                'issue'       => (string) $record->issue,
-                'notes'       => (string) $record->notes,
-                'timestamp'   => !empty($record->submitted_at) ? (string) $record->submitted_at : '',
-            ]);
+            $result = $qr_service->send_pickup_exception_to_n8n(
+                [
+					'qr_code'     => (string) $record->qr_code,
+					'customer_id' => (int) $record->customer_id,
+					'issue'       => (string) $record->issue,
+					'notes'       => (string) $record->notes,
+					'timestamp'   => ! empty( $record->submitted_at ) ? (string) $record->submitted_at : '',
+				]
+            );
 
-            if (is_wp_error($result)) {
-                PickupExceptionRepository::update_result($exception_id, [
-                    'webhook_sent'             => 0,
-                    'webhook_status_code'      => 0,
-                    'status'                   => 'failed',
-                    'webhook_response_body'    => $result->get_error_message(),
-                    'ai_severity'              => '',
-                    'ai_category'              => '',
-                    'ai_summary'               => '',
-                    'ai_recommended_action'    => '',
-                    'updated_at'               => current_time('mysql', true),
-                ]);
+            if ( is_wp_error( $result ) ) {
+                PickupExceptionRepository::update_result(
+                    $exception_id,
+                    [
+						'webhook_sent'          => 0,
+						'webhook_status_code'   => 0,
+						'status'                => 'failed',
+						'webhook_response_body' => $result->get_error_message(),
+						'ai_severity'           => '',
+						'ai_category'           => '',
+						'ai_summary'            => '',
+						'ai_recommended_action' => '',
+						'updated_at'            => current_time( 'mysql', true ),
+					]
+                );
 
                 return [
-                    'state' => 'webhook_error',
-                    'message' => __('Retry failed. The record remains saved locally.', 'kerbcycle-qr-code-manager'),
+                    'state'       => 'webhook_error',
+                    'message'     => __( 'Retry failed. The record remains saved locally.', 'kerbcycle-qr-code-manager' ),
                     'status_code' => 500,
-                    'error_code' => $result->get_error_code(),
+                    'error_code'  => $result->get_error_code(),
                 ];
             }
 
-            if (!empty($result['success'])) {
-                $body = isset($result['body']) ? $result['body'] : '';
-                $decoded_body = json_decode((string) $body, true);
-                $ai_summary = is_array($decoded_body) && isset($decoded_body['summary']) ? (string) $decoded_body['summary'] : '';
-                $ai_category = is_array($decoded_body) && isset($decoded_body['category']) ? (string) $decoded_body['category'] : '';
-                $ai_severity = is_array($decoded_body) && isset($decoded_body['severity']) ? (string) $decoded_body['severity'] : '';
-                $ai_recommended_action = is_array($decoded_body) && isset($decoded_body['recommended_action']) ? (string) $decoded_body['recommended_action'] : '';
+            if ( ! empty( $result['success'] ) ) {
+                $body                  = isset( $result['body'] ) ? $result['body'] : '';
+                $decoded_body          = json_decode( (string) $body, true );
+                $ai_summary            = is_array( $decoded_body ) && isset( $decoded_body['summary'] ) ? (string) $decoded_body['summary'] : '';
+                $ai_category           = is_array( $decoded_body ) && isset( $decoded_body['category'] ) ? (string) $decoded_body['category'] : '';
+                $ai_severity           = is_array( $decoded_body ) && isset( $decoded_body['severity'] ) ? (string) $decoded_body['severity'] : '';
+                $ai_recommended_action = is_array( $decoded_body ) && isset( $decoded_body['recommended_action'] ) ? (string) $decoded_body['recommended_action'] : '';
 
-                PickupExceptionRepository::update_result($exception_id, [
-                    'webhook_sent'             => 1,
-                    'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
-                    'status'                   => 'sent',
-                    'webhook_response_body'    => is_scalar($body) ? (string) $body : wp_json_encode($body),
-                    'ai_severity'              => $ai_severity,
-                    'ai_category'              => $ai_category,
-                    'ai_summary'               => $ai_summary,
-                    'ai_recommended_action'    => $ai_recommended_action,
-                    'updated_at'               => current_time('mysql', true),
-                ]);
+                PickupExceptionRepository::update_result(
+                    $exception_id,
+                    [
+						'webhook_sent'          => 1,
+						'webhook_status_code'   => isset( $result['status_code'] ) ? (int) $result['status_code'] : 0,
+						'status'                => 'sent',
+						'webhook_response_body' => is_scalar( $body ) ? (string) $body : wp_json_encode( $body ),
+						'ai_severity'           => $ai_severity,
+						'ai_category'           => $ai_category,
+						'ai_summary'            => $ai_summary,
+						'ai_recommended_action' => $ai_recommended_action,
+						'updated_at'            => current_time( 'mysql', true ),
+					]
+                );
 
                 return [
-                    'state' => 'success',
-                    'message' => __('Pickup exception resent successfully.', 'kerbcycle-qr-code-manager'),
-                    'status_code' => 200,
-                    'webhook_status_code' => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+                    'state'               => 'success',
+                    'message'             => __( 'Pickup exception resent successfully.', 'kerbcycle-qr-code-manager' ),
+                    'status_code'         => 200,
+                    'webhook_status_code' => isset( $result['status_code'] ) ? (int) $result['status_code'] : 0,
                 ];
             }
 
-            $result_body = isset($result['body']) ? $result['body'] : '';
-            PickupExceptionRepository::update_result($exception_id, [
-                'webhook_sent'             => 0,
-                'webhook_status_code'      => isset($result['status_code']) ? (int) $result['status_code'] : 0,
-                'status'                   => 'failed',
-                'webhook_response_body'    => is_scalar($result_body) ? (string) $result_body : wp_json_encode($result_body),
-                'ai_severity'              => '',
-                'ai_category'              => '',
-                'ai_summary'               => '',
-                'ai_recommended_action'    => '',
-                'updated_at'               => current_time('mysql', true),
-            ]);
+            $result_body = isset( $result['body'] ) ? $result['body'] : '';
+            PickupExceptionRepository::update_result(
+                $exception_id,
+                [
+					'webhook_sent'          => 0,
+					'webhook_status_code'   => isset( $result['status_code'] ) ? (int) $result['status_code'] : 0,
+					'status'                => 'failed',
+					'webhook_response_body' => is_scalar( $result_body ) ? (string) $result_body : wp_json_encode( $result_body ),
+					'ai_severity'           => '',
+					'ai_category'           => '',
+					'ai_summary'            => '',
+					'ai_recommended_action' => '',
+					'updated_at'            => current_time( 'mysql', true ),
+				]
+            );
 
             return [
-                'state' => 'webhook_non_success',
-                'message' => __('Retry failed. The record remains saved locally.', 'kerbcycle-qr-code-manager'),
-                'status_code' => 500,
-                'webhook_status_code' => isset($result['status_code']) ? (int) $result['status_code'] : 0,
+                'state'               => 'webhook_non_success',
+                'message'             => __( 'Retry failed. The record remains saved locally.', 'kerbcycle-qr-code-manager' ),
+                'status_code'         => 500,
+                'webhook_status_code' => isset( $result['status_code'] ) ? (int) $result['status_code'] : 0,
             ];
         } finally {
-            $this->release_retry_lock($exception_id);
+            $this->release_retry_lock( $exception_id );
         }
     }
 
-    private function retry_lock_key($exception_id)
-    {
+    private function retry_lock_key( $exception_id ) {
         return 'kerbcycle_pickup_retry_lock_' . (int) $exception_id;
     }
 
-    private function acquire_retry_lock($exception_id)
-    {
-        $key = $this->retry_lock_key($exception_id);
-        $now = time();
-        $expires_at = (int) get_option($key, 0);
-        if ($expires_at > 0 && $expires_at <= $now) {
-            delete_option($key);
+    private function acquire_retry_lock( $exception_id ) {
+        $key        = $this->retry_lock_key( $exception_id );
+        $now        = time();
+        $expires_at = (int) get_option( $key, 0 );
+        if ( $expires_at > 0 && $expires_at <= $now ) {
+            delete_option( $key );
         }
-        return add_option($key, (string) ($now + self::RETRY_LOCK_TTL), '', 'no');
+        return add_option( $key, (string) ( $now + self::RETRY_LOCK_TTL ), '', 'no' );
     }
 
-    private function release_retry_lock($exception_id)
-    {
-        delete_option($this->retry_lock_key($exception_id));
+    private function release_retry_lock( $exception_id ) {
+        delete_option( $this->retry_lock_key( $exception_id ) );
     }
 }


### PR DESCRIPTION
### Motivation
- Resolve non-auto-fixable PHPCS findings in `includes/Services/PickupExceptionRetryService.php`, specifically `WordPress.WP.I18n.TextDomainMismatch` and `WordPress.DB.PreparedSQL.InterpolatedNotPrepared` for a fixed plugin table name.

### Description
- Replaced the incorrect text domain `kerbcycle` with `kerbcycle-qr-code-manager` in WordPress i18n calls inside `PickupExceptionRetryService::retry()` (7 occurrences) without changing any translated strings.
- Added a narrow PHPCS suppression pair (`// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared` / `// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared`) only around the single prepared query that interpolates the fixed `$table_name` (`SELECT * FROM {$table_name} WHERE id = %d`), leaving the SQL and `%d` prepare usage unchanged.
- Modified only `includes/Services/PickupExceptionRetryService.php` and made no changes to retry/webhook logic, method names, class, namespace, or other files.

### Testing
- Confirmed changed file only via `git diff --name-only`, which reported `includes/Services/PickupExceptionRetryService.php`.
- Verified PHP syntax with `php -l includes/Services/PickupExceptionRetryService.php`; the file reports no syntax errors.
- PHPCS was not run because `vendor/bin/phpcs` is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e0e7c6c8832d9635ad3572b8b66b)