### PR TITLE
Add targeted PHPCS suppression for FrontAssets Public namespace

### DIFF
--- a/includes/Public/FrontAssets.php
+++ b/includes/Public/FrontAssets.php
@@ -1,5 +1,6 @@
 <?php
 
+// phpcs:ignore PHPCompatibility.Keywords.ForbiddenNames.publicFound -- Existing plugin namespace segment; supported PHP target allows this usage.
 namespace Kerbcycle\QrCode\Public;
 
 use Kerbcycle\QrCode\Services\OsrmService;


### PR DESCRIPTION
### Motivation
- Suppress a PHPCS PHPCompatibility forbidden-name warning caused by the existing `Public` namespace segment without renaming the namespace or changing behavior, keeping the change minimal and file-scoped.

### Description
- Files changed: `includes/Public/FrontAssets.php`.
- Exact fix: added the single-line PHPCS suppression immediately above the existing namespace declaration: `// phpcs:ignore PHPCompatibility.Keywords.ForbiddenNames.publicFound -- Existing plugin namespace segment; supported PHP target allows this usage.`; the namespace `namespace Kerbcycle\QrCode\Public;` and all code were left unchanged.

### Testing
- Validation steps and exact outputs:

`git diff --name-only`

```
includes/Public/FrontAssets.php
```

`php -l includes/Public/FrontAssets.php`

```
No syntax errors detected in includes/Public/FrontAssets.php
```

`vendor/bin/phpcs --standard=phpcs.xml.dist includes/Public/FrontAssets.php -s --no-colors`

```
/bin/bash: line 1: vendor/bin/phpcs: No such file or directory
```

- No-drift confirmation: no namespace rename, no class rename, no method/function changes, no autoloading or call-site changes, no behavior changes, and no files outside `includes/Public/FrontAssets.php` were modified.
- Merge recommendation: Needs manual review (change is surgical and safe, but PHPCS binary was unavailable in this environment so final lint verification cannot be confirmed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f05f927c832d95bb67ba33843e1f)