### PR TITLE
Add narrow PHPCS suppression for reserved `Public` namespace segment

### DIFF
--- a/includes/Public/Shortcodes.php
+++ b/includes/Public/Shortcodes.php
@@ -1,5 +1,6 @@
 <?php
 
+// phpcs:ignore PHPCompatibility.Keywords.ForbiddenNames.publicFound -- Existing plugin namespace segment; supported PHP target allows this usage.
 namespace Kerbcycle\QrCode\Public;
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
### Motivation
- Suppress the `PHPCompatibility.Keywords.ForbiddenNames.publicFound` PHPCS finding triggered by the existing `Public` namespace segment in a single file without renaming the namespace or changing behavior.

### Description
- Added the exact, single-line PHPCS ignore comment immediately above the existing namespace declaration in `includes/Public/Shortcodes.php` and left the namespace `Kerbcycle\QrCode\Public`, class names, autoloading, and behavior unchanged; only `includes/Public/Shortcodes.php` was modified.

### Testing
- Commands run and their exact outputs:

`git diff --name-only`
```
includes/Public/Shortcodes.php
```

`php -l includes/Public/Shortcodes.php`
```
No syntax errors detected in includes/Public/Shortcodes.php
```

`vendor/bin/phpcs --standard=phpcs.xml.dist includes/Public/Shortcodes.php -s --no-colors`
```
/bin/bash: line 1: vendor/bin/phpcs: No such file or directory
```

- Result: PHP syntax check passed, `phpcs` could not be executed in this environment because the binary is not available; the change is a minimal, file-scoped suppression and requires no runtime changes, so it is safe to keep but needs manual review if project-level PHPCS execution is required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f8af05e4832da7bca24c5d5a6e9d)