### PR TITLE
Rename autoloader parameter $class → $class_name to satisfy PHPCS

### DIFF
--- a/includes/Autoloader.php
+++ b/includes/Autoloader.php
@@ -33,7 +33,7 @@ class Autoloader {
      *
      * @param string $class The class name.
      */
-    public static function autoload( $class ) {
+    public static function autoload( $class_name ) {
         // Project-specific namespace prefix
         $prefix = 'Kerbcycle\\QrCode\\';
 
@@ -42,13 +42,13 @@ class Autoloader {
 
         // Does the class use the namespace prefix?
         $len = strlen( $prefix );
-        if ( strncmp( $prefix, $class, $len ) !== 0 ) {
+        if ( strncmp( $prefix, $class_name, $len ) !== 0 ) {
             // No, move to the next registered autoloader
             return;
         }
 
         // Get the relative class name
-        $relative_class = substr( $class, $len );
+        $relative_class = substr( $class_name, $len );
 
         // Replace the namespace prefix with the base directory, replace namespace
         // separators with directory separators in the relative class name, append


### PR DESCRIPTION
### Motivation
- Fix the PHPCS warning `Universal.NamingConventions.NoReservedKeywordParameterNames.classFound` by renaming the reserved-style parameter name and keep autoload behavior unchanged.

### Description
- In `includes/Autoloader.php` changed the method signature from `public static function autoload( $class )` to `public static function autoload( $class_name )` and updated the in-method references (`strncmp` and `substr`) to use `$class_name`; no other files or logic were modified.

### Testing
- Files changed: `includes/Autoloader.php` only, no drift.
- `git diff --name-only` output:
```
includes/Autoloader.php
```
- `php -l includes/Autoloader.php` output:
```
No syntax errors detected in includes/Autoloader.php
```
- `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Autoloader.php -s --no-colors` output in this environment:
```
/bin/bash: line 1: vendor/bin/phpcs: No such file or directory
```
- Summary of test results: `git` check and `php -l` passed; `phpcs` could not be executed here due to missing vendor binary and should be re-run in CI or a full dev environment before final merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02fb92bf20832d936897a0d5545b1c)