### PR TITLE
Fix PSR2 property underscore warning in includes/Plugin.php

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -15,17 +15,17 @@ class Plugin {
     /**
      * The single instance of the class.
      */
-    private static $_instance = null;
+    private static $instance = null;
 
     /**
      * Main Plugin Instance.
      * Ensures only one instance of the plugin is loaded.
      */
     public static function instance() {
-        if ( is_null( self::$_instance ) ) {
-            self::$_instance = new self();
+        if ( is_null( self::$instance ) ) {
+            self::$instance = new self();
         }
-        return self::$_instance;
+        return self::$instance;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Resolve the `PSR2.Classes.PropertyDeclaration.Underscore` PHPCS warning for the Plugin singleton property while making the smallest possible change and preserving behavior.

### Description
- Renamed the private static singleton property `$_instance` to `$instance` and updated in-file references (`self::$_instance` → `self::$instance`) in `includes/Plugin.php` only, with no changes to class name, methods, visibility, or runtime behavior.

### Testing
- Executed `git diff --name-only` (output: `includes/Plugin.php`); `php -l includes/Plugin.php` (output: `No syntax errors detected in includes/Plugin.php`); attempted `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Plugin.php -s --no-colors` but `phpcs` was not available in this environment (`/bin/bash: line 1: vendor/bin/phpcs: No such file or directory`), so recommend running PHPCS in CI to verify zero errors/warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ff595f5c832d8bad29738b84a25c)