### PR TITLE
Add narrow PHPCS suppressions for GeneratorPage file operations

### DIFF
--- a/includes/Admin/Pages/GeneratorPage.php
+++ b/includes/Admin/Pages/GeneratorPage.php
@@ -256,6 +256,7 @@ class GeneratorPage {
         foreach ( $rows as $r ) {
             fputcsv( $out, array( $r['id'], $r['code'], $r['status'], $r['created_at'] ) );
         }
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closing plugin-generated CSV export file handle.
         fclose( $out );
         exit;
     }
@@ -295,6 +296,7 @@ class GeneratorPage {
             </div>
 
             <script>
+            <?php // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile -- Streaming plugin-generated printable export script to the browser. ?>
             <?php readfile( KERBCYCLE_QR_PATH . 'assets/js/qrcode.min.js' ); ?>
             document.querySelectorAll('.qrc').forEach(function(el){
                 const code = el.getAttribute('data-code');


### PR DESCRIPTION
### Motivation
- Silence two PHPCS warnings for intentional direct file operations in the export/print flows of the admin generator page while making no behavioral changes to file generation, export, or permissions.

### Description
- Modified only `includes/Admin/Pages/GeneratorPage.php` and added two targeted PHPCS ignores immediately above the flagged calls: `// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closing plugin-generated CSV export file handle.` above `fclose( $out );` and `// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile -- Streaming plugin-generated printable export script to the browser.` above `readfile( KERBCYCLE_QR_PATH . 'assets/js/qrcode.min.js' );`.

### Testing
- Ran `git diff --name-only` which returned `includes/Admin/Pages/GeneratorPage.php`; ran `php -l includes/Admin/Pages/GeneratorPage.php` which returned `No syntax errors detected in includes/Admin/Pages/GeneratorPage.php`; attempted `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Admin/Pages/GeneratorPage.php -s --no-colors` which failed in this environment with `/bin/bash: line 1: vendor/bin/phpcs: No such file or directory`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03019ab37c832da14fb95b58969100)