### PR TITLE
Add PHPCS suppression for slash-style AI webhook hook name in AiSettingsService

### DIFF
--- a/includes/Services/AiSettingsService.php
+++ b/includes/Services/AiSettingsService.php
@@ -49,6 +49,7 @@ class AiSettingsService {
         /**
          * Filter the resolved pickup exception webhook URL.
          */
+		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- Existing plugin integration hook uses slash-separated namespace-style name; preserve backward compatibility.
 		return apply_filters( 'kerbcycle/ai/pickup_exception_webhook_url', $url, $options );
 	}
 


### PR DESCRIPTION
### Motivation
- Silence the `WordPress.NamingConventions.ValidHookName.UseUnderscores` PHPCS warning for an existing slash-separated AI webhook filter without renaming or changing runtime behavior.

### Description
- Edited only `includes/Services/AiSettingsService.php` and added the exact inline PHPCS suppression immediately above the existing `apply_filters()` call.
- Exact suppression added: `// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- Existing plugin integration hook uses slash-separated namespace-style name; preserve backward compatibility.`
- The hook name `kerbcycle/ai/pickup_exception_webhook_url` and the `apply_filters()` call were not changed, and no other files were modified.

### Testing
- `git diff --name-only` output confirmed only the target file changed: `includes/Services/AiSettingsService.php`.
- PHP syntax check passed with `php -l includes/Services/AiSettingsService.php` returning: `No syntax errors detected in includes/Services/AiSettingsService.php`.
- Project PHPCS could not be executed in this environment and returned: `/bin/bash: line 1: vendor/bin/phpcs: No such file or directory` when running `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Services/AiSettingsService.php -s --no-colors`.
- No other files were touched and there is no runtime behavior change, so merge is recommended pending CI/PHPCS verification in the normal build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0304ab9adc832d9e81304864819f25)