### PR TITLE
Harden postMessage origin handling in kc-osrm.js

### DIFF
--- a/assets/js/kc-osrm.js
+++ b/assets/js/kc-osrm.js
@@ -417,7 +417,13 @@
 
     function sendNative(msg) {
       try {
-        window.postMessage(msg, "*");
+        var targetOrigin =
+          window.location && typeof window.location.origin === "string"
+            ? window.location.origin
+            : undefined;
+        if (targetOrigin) {
+          window.postMessage(msg, targetOrigin);
+        }
       } catch (error) {
         // ignore
       }
@@ -1407,7 +1413,14 @@
     window.kcHandlePosition = onPosition;
     if (!window._kcPositionListenerBound) {
       window.addEventListener("message", function (e) {
-        if (e && e.data && e.data.type === "kc:position" && e.data.detail) {
+        var allowedOrigin =
+          window.location && typeof window.location.origin === "string"
+            ? window.location.origin
+            : "";
+        if (!e || e.origin !== allowedOrigin || e.source !== window) {
+          return;
+        }
+        if (e.data && e.data.type === "kc:position" && e.data.detail) {
           var c = e.data.detail;
           if (
             typeof window.kcHandlePosition === "function" &&

--- a/assets/js/kc-osrm.js
+++ b/assets/js/kc-osrm.js
@@ -417,7 +417,7 @@
 
     function sendNative(msg) {
       try {
-        var targetOrigin =
+        const targetOrigin =
           window.location && typeof window.location.origin === "string"
             ? window.location.origin
             : undefined;
@@ -1413,7 +1413,7 @@
     window.kcHandlePosition = onPosition;
     if (!window._kcPositionListenerBound) {
       window.addEventListener("message", function (e) {
-        var allowedOrigin =
+        const allowedOrigin =
           window.location && typeof window.location.origin === "string"
             ? window.location.origin
             : "";
@@ -1421,7 +1421,7 @@
           return;
         }
         if (e.data && e.data.type === "kc:position" && e.data.detail) {
-          var c = e.data.detail;
+          const c = e.data.detail;
           if (
             typeof window.kcHandlePosition === "function" &&
             typeof c.latitude === "number" &&


### PR DESCRIPTION
### Motivation
- Remediate Semgrep findings for unsafe `postMessage` usage and an unvalidated `message` listener while preserving existing kc:position behavior. 

### Description
- Replace `window.postMessage(msg, "*")` with a call that uses `window.location.origin` as the explicit `targetOrigin` and only sends when that origin string is available. 
- Harden the `window.addEventListener("message", ...)` handler to reject events unless `e.origin` equals the page origin and `e.source` equals `window`, while keeping the existing `kc:position` payload checks and numeric latitude/longitude validation. 

### Testing
- Verified only `assets/js/kc-osrm.js` changed via `git diff --name-only` and committed the patch. 
- Confirmed no remaining wildcard postMessage targets via `grep` and that the message listener still exists and now enforces origin/source checks. 
- Confirmed the `kc:position` handling and numeric coordinate checks remain present and unchanged in logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045fd95914832d941b308582cba988)