### PR TITLE
Harden retry webhook link href in pickup exceptions table

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -732,7 +732,7 @@ function initKerbcycleAdmin() {
           .map((row) => {
             const actionHtml =
               row.can_retry && row.retry_url
-                ? `<a href="${escapeHtml(row.retry_url)}" class="button button-small kerbcycle-retry-webhook" data-exception-id="${escapeHtml(row.id)}">Retry Webhook</a>`
+                ? `<a href="#" class="button button-small kerbcycle-retry-webhook" data-exception-id="${escapeHtml(row.id)}">Retry Webhook</a>`
                 : "";
 
             return `<tr data-exception-id="${escapeHtml(row.id)}">


### PR DESCRIPTION
### Motivation
- Semgrep flagged a manual HTML-escaping helper (`escapeHtml`) that uses chained `.replaceAll()` calls, and one call site placed an escaped value into an `href` attribute which can permit `javascript:`-style URL injection despite HTML entity escaping. 
- Make the smallest possible, WordPress-safe change to remove the protocol injection risk at the exact risky sink without refactoring the renderer or adding dependencies.

### Description
- Replaced the dynamic `href="${escapeHtml(row.retry_url)}"` with a static `href="#"` for the retry action link in `assets/js/admin.js` so the link no longer accepts a protocol-bearing URL from AJAX data. 
- Preserved the existing `data-exception-id` attribute and the click handling (`preventDefault` + AJAX retry), so retry semantics and UI behavior remain unchanged. 
- Only `assets/js/admin.js` was modified and no PHP, workflow, dependency, or Semgrep config files were changed.

### Testing
- Ran `git diff --name-only` which returned only `assets/js/admin.js`, confirming file-scope compliance. 
- Inspected the file and verified the sink and helper occurrences with `grep -n "replaceAll\|innerHTML\|outerHTML\|insertAdjacentHTML\|\.html(" assets/js/admin.js`, which listed the `escapeHtml` definition and its call sites including the pickup exceptions table. 
- Displayed the targeted region with `nl -ba assets/js/admin.js | sed -n '720,812p'` to confirm the exact replacement in the table renderer. 
- Committed the single-file change; local automated checks performed (diff/grep/commit) succeeded, but `semgrep` is not available in the environment (`semgrep --version` not found) so Semgrep verification must run in CI/PR. 
- No JS lint/test command was executed because no project JS test/lint command was configured in the environment. 
- Recommendation: merge after GitHub Actions/Semgrep run passes to confirm the Semgrep rule is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05626a9884832d8f152d0b32edf8dc)