### PR TITLE
Harden inline message template JSON encoding in admin page

### DIFF
--- a/includes/Services/MessagesService.php
+++ b/includes/Services/MessagesService.php
@@ -369,8 +369,8 @@ class MessagesService {
 			const $email= document.getElementById('kc_email');
 			const $desc = document.getElementById('kc_msg_desc');
 
-			const ALL   = <?php echo wp_json_encode( $messages ); ?>;
-			const DESCS = <?php echo wp_json_encode( self::descriptions_map() ); ?>;
+			const ALL   = <?php echo wp_json_encode( $messages, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ); ?>;
+			const DESCS = <?php echo wp_json_encode( self::descriptions_map(), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ); ?>;
 
 			function updateFields() {
 				const key = $type.value;


### PR DESCRIPTION
### Motivation
- Address a Semgrep taint/escaping concern for message templates rendered into an inline `<script>` by adding a minimal defense-in-depth measure for the script context.

### Description
- Added `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT` to the two `wp_json_encode()` calls used in the inline script in `includes/Services/MessagesService.php` so the JSON cannot contain raw characters that can interfere with HTML/script parsing.
- The change touches only `includes/Services/MessagesService.php` and does not modify template keys, defaults, save flow, nonce/capability checks, textarea output, or any JS assets.
- Existing sanitization and escaping remain intact: saved templates are sanitized with `wp_strip_all_tags(..., true)` and textareas are rendered with `esc_textarea()`.

### Testing
- Inspected `includes/Services/MessagesService.php` to confirm `wp_json_encode( $messages )` location, how `$messages` is built, save flow sanitization, textarea rendering, and inline script usage of the JSON payload.
- Ran PHP syntax check `php -l includes/Services/MessagesService.php` and received no syntax errors.
- Verified the change is limited to a single file (`includes/Services/MessagesService.php`) and that `esc_textarea()` is used at the textarea output points; static analysis tool `vendor/bin/phpcs` was not available in this environment and `semgrep` is not installed locally so those scans must be validated by CI.
- Acceptance conditions met: single-file change, only encoding flags added, no behavior or API changes, and message/template behavior preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05674e1c34832d936d86ddfea19ad7)