### PR TITLE
ESLint: fix no-unused-vars in JS (catch params and unused locals)

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -280,7 +280,7 @@ function initKerbcycleAdmin() {
             return parsed;
           }
         }
-      } catch (error) {
+      } catch {
         // ignore malformed URLs
       }
     }

--- a/assets/js/dashboard-scanner.js
+++ b/assets/js/dashboard-scanner.js
@@ -65,7 +65,7 @@ async function createQrScannerAdapter({
             onResult(String(text));
           }
         }
-      } catch (e) {
+      } catch {
         // ignore frame-level errors
       }
       rafId = requestAnimationFrame(loop);
@@ -87,13 +87,13 @@ async function createQrScannerAdapter({
 
     // Use decodeFromVideoDevice for continuous scanning.
     zxingReader = new ZXingBrowser.BrowserQRCodeReader();
-    await zxingReader.decodeFromVideoDevice(null, videoEl, (result, err) => {
+    await zxingReader.decodeFromVideoDevice(null, videoEl, (result, _err) => {
       if (paused) return;
       if (result && result.getText) {
         paused = true;
         onResult(String(result.getText()));
       }
-      // err is normal per frame; ignore
+      // _err is normal per frame; ignore
     });
 
     return true;
@@ -159,7 +159,7 @@ async function createQrScannerAdapter({
     stop() {
       try {
         if (zxingReader && zxingReader.reset) zxingReader.reset();
-      } catch (e) {
+      } catch {
         // ignore errors when resetting reader
       }
       zxingReader = null;

--- a/assets/js/kc-osrm.js
+++ b/assets/js/kc-osrm.js
@@ -49,7 +49,7 @@
     var start = parseLatLon(storedStart) ||
       parseLatLon(cfg.start) ||
       parseLatLon(KC_OSRM.defaultStart) || [40.73, -73.99];
-    var end = parseLatLon(cfg.end) || [40.78, -73.97];
+    var _end = parseLatLon(cfg.end) || [40.78, -73.97];
 
     var parent = el.parentNode;
     if (!parent) return;
@@ -161,7 +161,7 @@
     var addStopMode = false;
     var map;
     var routingControl;
-    var geocoderControl;
+    var _geocoderControl;
     var tripBase = getTripBase(KC_OSRM.base);
     var stepQueue = [];
     var stepIndex = 0;
@@ -249,7 +249,7 @@
           window.speechSynthesis.speak(utterance);
           return true;
         }
-      } catch (error) {
+      } catch {
         // ignore
       }
       return false;
@@ -264,7 +264,7 @@
           return !!window.Capacitor.isNativePlatform();
         }
         return !!window.Capacitor.isNativePlatform;
-      } catch (error) {
+      } catch {
         return false;
       }
     }
@@ -276,14 +276,14 @@
             return window.Capacitor.Plugins.TextToSpeech;
           }
         }
-      } catch (error) {
+      } catch {
         // ignore
       }
       try {
         if (window.TextToSpeech) {
           return window.TextToSpeech;
         }
-      } catch (error2) {
+      } catch {
         // ignore
       }
       return null;
@@ -318,7 +318,7 @@
             });
         }
         return Promise.resolve(true);
-      } catch (error) {
+      } catch {
         return Promise.resolve(false);
       }
     }
@@ -399,7 +399,7 @@
           if (cap.isPluginAvailable("Geolocation")) {
             return true;
           }
-        } catch (error) {
+        } catch {
           // ignore
         }
       }
@@ -424,7 +424,7 @@
         if (targetOrigin) {
           window.postMessage(msg, targetOrigin);
         }
-      } catch (error) {
+      } catch {
         // ignore
       }
     }
@@ -696,7 +696,7 @@
           var ok = false;
           try {
             ok = await geocodeAndAdd(addresses[i]);
-          } catch (error) {
+          } catch {
             ok = false;
           }
           if (ok) {
@@ -942,7 +942,7 @@
       var data;
       try {
         data = JSON.parse(String(text || ""));
-      } catch (error) {
+      } catch {
         setStatus("Invalid JSON.", "error");
         updateErrorReportButton();
         return;
@@ -1144,7 +1144,7 @@
         if (typeof window !== "undefined" && window.localStorage) {
           return window.localStorage.getItem("kc_default_start") || "";
         }
-      } catch (error) {
+      } catch {
         // localStorage can throw in private browsing; ignore.
       }
       return "";
@@ -1299,7 +1299,7 @@
         }
         try {
           sendNative({ type: "kc:tts", text: text });
-        } catch (error) {
+        } catch {
           // ignore
         }
         speakWeb(text);
@@ -1967,7 +1967,7 @@
         L.Control.Geocoder &&
         typeof L.Control.geocoder === "function"
       ) {
-        geocoderControl = L.Control.geocoder({
+        _geocoderControl = L.Control.geocoder({
           defaultMarkGeocode: false,
           geocoder: L.Control.Geocoder.nominatim({
             serviceUrl: "https://nominatim.openstreetmap.org/",
@@ -2096,7 +2096,7 @@
         setTimeout(function () {
           try {
             observer.disconnect();
-          } catch (error) {}
+          } catch {}
         }, 1000);
       })();
 

--- a/assets/js/qr-scanner.js
+++ b/assets/js/qr-scanner.js
@@ -66,7 +66,7 @@ async function createQrScannerAdapter({
             onResult(String(text));
           }
         }
-      } catch (e) {
+      } catch {
         // ignore frame-level errors
       }
       rafId = requestAnimationFrame(loop);
@@ -88,13 +88,13 @@ async function createQrScannerAdapter({
 
     // Use decodeFromVideoDevice for continuous scanning.
     zxingReader = new ZXingBrowser.BrowserQRCodeReader();
-    await zxingReader.decodeFromVideoDevice(null, videoEl, (result, err) => {
+    await zxingReader.decodeFromVideoDevice(null, videoEl, (result, _err) => {
       if (paused) return;
       if (result && result.getText) {
         paused = true;
         onResult(String(result.getText()));
       }
-      // err is normal per frame; ignore
+      // _err is normal per frame; ignore
     });
 
     return true;
@@ -160,7 +160,7 @@ async function createQrScannerAdapter({
     stop() {
       try {
         if (zxingReader && zxingReader.reset) zxingReader.reset();
-      } catch (e) {
+      } catch {
         // ignore errors when resetting reader
       }
       zxingReader = null;
@@ -643,7 +643,7 @@ function initKerbcycleScanner() {
         const rawState = scanner.getState();
         const normalized = getScannerStateLabel(rawState);
         return normalized || scannerStateHint;
-      } catch (stateError) {
+      } catch {
         // Fall back to our internal hint when the library cannot report the state.
         return scannerStateHint;
       }


### PR DESCRIPTION
### Motivation
- Reduce `no-unused-vars` warnings reported by the repo ESLint config while making the smallest safe edits. 
- Preserve runtime behavior for scanner, admin, and OSRM/map code and avoid any UX or API changes. 

### Description
- Files changed: `assets/js/admin.js`, `assets/js/dashboard-scanner.js`, `assets/js/kc-osrm.js`, `assets/js/qr-scanner.js`.
- Removed unused catch bindings by converting `catch (error)` / `catch (e)` / `catch (stateError)` / `catch (error2)` to plain `catch` in places where the error value was intentionally ignored. 
- Renamed intentionally ignored ZXing callback error parameter from `err` to `_err` in both scanner adapters to satisfy the args-ignore pattern without changing the callback signature. 
- Renamed unused OSRM locals `end` → `_end` and `geocoderControl` → `_geocoderControl` to preserve assignments and initialization while matching the ESLint underscore-ignore pattern; no routing/map logic was altered. 
- All edits were strictly limited to the allowed JS files and intended to be behavior-preserving (no alert/confirm replacements, no refactors, no public API changes). 

### Testing
- Ran `npm run lint:js` and `npm run lint:js -- --format stylish`; result: ESLint exited successfully with no `no-unused-vars` findings and only existing `no-alert` warnings remaining (primarily in `assets/js/admin.js` and `assets/js/qr-generator.js`).
- Verified changed files are limited to the four allowed JS files and that no scanner/OSRM/admin behavior or UX was modified during the edits.
- Confirmed remaining ESLint warnings are `no-alert` and were intentionally deferred; no other ESLint rules were modified or fixed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e952025ec832db78c3c5a10b9a88b)