### PR TITLE
kc-osrm.js: fix DeepSource/Sonar findings (remove unused _end, init geocoder, small let/const)

### DIFF
--- a/assets/js/kc-osrm.js
+++ b/assets/js/kc-osrm.js
@@ -335,7 +335,7 @@
         window.speechSynthesis.getVoices().length === 0
       ) {
         if (typeof window.speechSynthesis.addEventListener === "function") {
-          var handleVoicesReady = function handleVoicesReady() {
+          var handleVoicesReady = function () {
             window.speechSynthesis.removeEventListener(
               "voiceschanged",
               handleVoicesReady,
@@ -2092,7 +2092,7 @@
           clearItinerary();
         });
         observer.observe(container, { childList: true, subtree: true });
-        setTimeout(function () {
+        setTimeout(() => {
           try {
             observer.disconnect();
           } catch {

--- a/assets/js/kc-osrm.js
+++ b/assets/js/kc-osrm.js
@@ -45,11 +45,10 @@
       return;
     }
 
-    var storedStart = readStoredDefaultStart();
-    var start = parseLatLon(storedStart) ||
+    const storedStart = readStoredDefaultStart();
+    const start = parseLatLon(storedStart) ||
       parseLatLon(cfg.start) ||
       parseLatLon(KC_OSRM.defaultStart) || [40.73, -73.99];
-    var _end = parseLatLon(cfg.end) || [40.78, -73.97];
 
     var parent = el.parentNode;
     if (!parent) return;
@@ -158,11 +157,11 @@
     wrapper.appendChild(mapHolder);
     mapHolder.appendChild(el);
 
-    var addStopMode = false;
-    var map;
-    var routingControl;
-    var _geocoderControl;
-    var tripBase = getTripBase(KC_OSRM.base);
+    let addStopMode = false;
+    let map;
+    let routingControl;
+    let _geocoderControl = null;
+    const tripBase = getTripBase(KC_OSRM.base);
     var stepQueue = [];
     var stepIndex = 0;
     var following = true;
@@ -2096,7 +2095,9 @@
         setTimeout(function () {
           try {
             observer.disconnect();
-          } catch {}
+          } catch {
+            // Ignore disconnect errors while allowing cleanup to continue.
+          }
         }, 1000);
       })();
 


### PR DESCRIPTION
### Motivation
- Address deferred DeepSource / Sonar findings from the OSRM/map JavaScript surface without changing runtime routing or geocoding behavior by making the smallest safe edits in `assets/js/kc-osrm.js` only.

### Description
- Removed the unused `_end` parse (it was assigned from `cfg.end` and never read) to resolve the Sonar unused-variable finding without changing the `start` fallback chain.
- Converted targeted `var` declarations used in the OSRM initialization to `const`/`let` where scope and reassignment are clear (`storedStart`, `start`, `tripBase`, and control variables) and initialized `_geocoderControl` to `null` on declaration as requested by DeepSource.
- Added a short explanatory comment inside the previously empty `catch` around `observer.disconnect()` to document the intentional ignore and satisfy empty-block findings.
- Changes are intentionally narrow and behavior-preserving: Leaflet geocoder creation, `.on("markgeocode", ...)`, `.addTo(map)`, routingControl setup, waypoint handling, and UI behavior were left unchanged.

### Testing
- Ran `git diff --name-only` which showed only `assets/js/kc-osrm.js` was modified.
- Ran `npm run lint:js` and ESLint completed with exit 0; existing `no-alert` warnings remain in other files and were intentionally not changed (19 warnings, 0 errors).
- Ran `git diff --check` and found no whitespace/format issues.
- Verified via `grep`/inspection that `_end` no longer appears, `_geocoderControl` is initialized, and the empty `catch` was replaced with a short explanatory comment; DeepSource/Sonar verification should be performed by the PR scan.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ea57cd158832db19398d3f9abca80)