### PR TITLE
Create zap-baseline.yml

### DIFF
--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -1,0 +1,34 @@
+name: OWASP ZAP Baseline
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  zap-baseline:
+    name: ZAP Baseline Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Run OWASP ZAP baseline scan
+        uses: zaproxy/action-baseline@v0.15.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target: ${{ secrets.ZAP_TARGET_URL }}
+          docker_name: ghcr.io/zaproxy/zaproxy:stable
+          rules_file_name: .zap/rules.tsv
+          artifact_name: zap_baseline_report
+          allow_issue_writing: false
+          fail_action: false
+          cmd_options: "-I -m 2"

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -23,6 +23,10 @@ jobs:
 
       - name: Run OWASP ZAP baseline scan
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25
+        env:
+          ZAP_AUTH_HEADER: Authorization
+          ZAP_AUTH_HEADER_VALUE: Basic ${{ secrets.ZAP_BASIC_AUTH_TOKEN }}
+          ZAP_AUTH_HEADER_SITE: ${{ secrets.ZAP_TARGET_URL }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target: ${{ secrets.ZAP_TARGET_URL }}

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run OWASP ZAP baseline scan
-        uses: zaproxy/action-baseline@v0.15.0
+        uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target: ${{ secrets.ZAP_TARGET_URL }}

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,13 @@
+# ZAP baseline rules
+# Format:
+# Rule ID<TAB>Action<TAB>Description
+#
+# Actions: IGNORE, WARN, FAIL
+
+10010	WARN	(Cookie No HttpOnly Flag)
+10011	WARN	(Cookie Without Secure Flag)
+10015	WARN	(Incomplete or No Cache-control and Pragma HTTP Header Set)
+10020	WARN	(X-Frame-Options Header Not Set)
+10021	WARN	(X-Content-Type-Options Header Missing)
+10038	WARN	(Content Security Policy Header Not Set)
+10063	WARN	(Permissions Policy Header Not Set)


### PR DESCRIPTION
## Summary
Adds an OWASP ZAP Baseline GitHub Actions workflow for passive DAST scanning against the staging site.

## Details
- Adds `.github/workflows/zap-baseline.yml`
- Adds `.zap/rules.tsv` for explicit ZAP baseline rule handling
- Uses the stable ZAP Docker image
- Runs on PRs, manual dispatch, and weekly schedule
- Keeps the scan report-only initially with `fail_action: false`

## Notes
This is intentionally configured as a non-blocking baseline scan for initial tuning. Once the findings are reviewed and expected alerts are addressed or documented, the workflow can be tightened to fail on selected rules.