### PR TITLE
Create dependency-review.yml

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+# .github/workflows/dependency-review.yml
+
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime
+          comment-summary-in-pr: always


### PR DESCRIPTION
## Summary
Adds GitHub Dependency Review Action to review dependency changes in pull requests.

## Behavior
- Runs on pull requests targeting `main`
- Uses read-only repository permissions
- Fails on newly introduced high or critical runtime dependency vulnerabilities
- Adds a dependency summary comment to PRs when applicable

## Notes
This is intended as a conservative first-pass dependency gate. License enforcement and moderate-severity blocking can be considered after the workflow runs cleanly.