### PR TITLE
Create actionlint.yml

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,34 @@
+# .github/workflows/actionlint.yml
+
+name: actionlint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install actionlint
+        run: |
+          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          echo "$PWD" >> "$GITHUB_PATH"
+
+      - name: Run actionlint
+        run: actionlint

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -68,11 +68,11 @@ jobs:
         run: |
           set -euo pipefail
 
-        if [ -s changed-php-files.txt ]; then
-          xargs -a changed-php-files.txt vendor/bin/phpcs --standard=phpcs.xml.dist
-        else
-          echo "No changed PHP files to lint."
-        fi
+          if [ -s changed-php-files.txt ]; then
+            xargs -a changed-php-files.txt vendor/bin/phpcs --standard=phpcs.xml.dist
+          else
+            echo "No changed PHP files to lint."
+          fi
 
       #- name: Annotate PHPCS results
         #if: always()

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -67,7 +67,12 @@ jobs:
         if: steps.changed_php.outputs.has_php_files == 'true'
         run: |
           set -euo pipefail
-          vendor/bin/phpcs --standard=phpcs.xml.dist $(cat changed-php-files.txt)
+
+        if [ -s changed-php-files.txt ]; then
+          xargs -a changed-php-files.txt vendor/bin/phpcs --standard=phpcs.xml.dist
+        else
+          echo "No changed PHP files to lint."
+        fi
 
       #- name: Annotate PHPCS results
         #if: always()


### PR DESCRIPTION
## Summary
Adds an `actionlint` GitHub Actions workflow to validate repository workflow files.

## Details
- Runs on pull requests and pushes that modify `.github/workflows/**`
- Uses read-only repository permissions
- Pins `actions/checkout`
- Runs `actionlint` against all GitHub Actions workflow files

## Why
This helps catch broken workflow syntax, invalid contexts, bad expressions, and other GitHub Actions configuration mistakes before merge.

## Testing
- Expected: workflow runs successfully when `.github/workflows/actionlint.yml` is added
- Expected: future workflow YAML mistakes are caught in PR checks