### PR TITLE
Add OSV-Scanner PR dependency vulnerability scan

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,0 +1,16 @@
+name: OSV-Scanner PR Scan
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+
+permissions:
+  actions: read
+  security-events: write
+  contents: read
+
+jobs:
+  scan-pr:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.8

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   scan-pr:
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.8
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@3adb4b14a2b0623876d18d863a498b785fb3752d


### PR DESCRIPTION
## Summary
Adds OSV-Scanner PR scanning to detect known vulnerable dependencies introduced by pull requests.

## Notes
- Uses the official OSV-Scanner reusable PR workflow.
- Runs on pull requests and merge queue events targeting `main`.
- Keeps permissions minimal: `contents: read`, `actions: read`, and `security-events: write`.
- This is intended to complement existing security tooling, not replace Semgrep, CodeQL, ZAP, or secrets scanning.

## Validation
- Workflow added at `.github/workflows/osv-scanner-pr.yml`.
- First PR run will confirm whether OSV-Scanner works cleanly with the current repo.