### PR TITLE
Create codecov.yml

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,42 @@
+name: Codecov
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  php-coverage:
+    name: PHP coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mysqli, mbstring, json
+          coverage: xdebug
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run PHPUnit with coverage
+        run: XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          flags: php
+          name: kerbcycle-php
+          fail_ci_if_error: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -67,7 +67,7 @@ jobs:
         run: vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f #v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,23 +14,57 @@ jobs:
     name: PHP coverage
     runs-on: ubuntu-latest
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: wordpress_test
+          MYSQL_USER: wordpress
+          MYSQL_PASSWORD: wordpress
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      WP_TESTS_DIR: /tmp/wordpress-tests-lib
+      WP_CORE_DIR: /tmp/wordpress
+      DB_HOST: 127.0.0.1
+      DB_NAME: wordpress_test
+      DB_USER: wordpress
+      DB_PASS: wordpress
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
-          php-version: '8.2'
-          extensions: mysqli, mbstring, json
+          php-version: '8.3'
           coverage: xdebug
           tools: composer:v2
 
-      - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: Show PHP version
+        run: php -v
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Install WordPress test suite
+        run: |
+          curl -fsSL -o /tmp/install-wp-tests.sh https://raw.githubusercontent.com/wp-cli/scaffold-command/master/templates/install-wp-tests.sh
+          chmod +x /tmp/install-wp-tests.sh
+          echo "y" | /tmp/install-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" latest
 
       - name: Run PHPUnit with coverage
-        run: XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover coverage.xml
+        env:
+          XDEBUG_MODE: coverage
+        run: vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+coverage:
+  precision: 2
+  round: down
+  range: "40...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        if_not_found: success
+    patch:
+      default:
+        target: 0%
+        threshold: 100%
+        if_not_found: success
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "vendor/**"
+  - "node_modules/**"
+  - "tests/**"
+  - ".github/**"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,4 +9,11 @@
             <directory suffix="Test.php">tests/phpunit/Smoke</directory>
         </testsuite>
     </testsuites>
+<coverage>
+    <include>
+        <directory suffix=".php">includes</directory>
+        <directory suffix=".php">admin</directory>
+        <directory suffix=".php">public</directory>
+    </include>
+</coverage>
 </phpunit>


### PR DESCRIPTION
## Summary

Adds initial Codecov coverage reporting for the KerbCycle PHPUnit test suite.

## Changes

- Adds a dedicated GitHub Actions workflow for PHP coverage.
- Generates PHPUnit Clover coverage as `coverage.xml`.
- Uploads coverage to Codecov using the official Codecov GitHub Action.
- Adds a conservative `codecov.yml` so Codecov is informational at first and does not aggressively block early PRs.

## Notes

This initial setup is intentionally limited to PHP coverage. JavaScript coverage can be added later after JS tests are introduced or stabilized.

## Validation

- Composer dependencies install successfully.
- PHPUnit runs with coverage enabled.
- Codecov receives the `coverage.xml` report.