### PR TITLE
Add zizmor GitHub Actions security analysis

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,43 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "action.yml"
+      - "action.yaml"
+      - ".github/dependabot.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "action.yml"
+      - "action.yaml"
+      - ".github/dependabot.yml"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Analyze GitHub Actions security
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        continue-on-error: true
+        with:
+          advanced-security: false
+          inputs: .


### PR DESCRIPTION
## Summary

Adds zizmor GitHub Actions security analysis for KerbCycle workflow files.

## Details

- Runs zizmor on pull requests and pushes to `main` when GitHub Actions-related files change.
- Uses pinned action SHAs.
- Uses least-privilege workflow permissions.
- Disables credential persistence for checkout.
- Runs in non-GitHub-Advanced-Security mode.
- Keeps the first setup report-only with `continue-on-error: true` so existing findings can be reviewed before making the check blocking.

## Follow-up

After the first report is reviewed, we can either:
- fix any findings in a dedicated follow-up PR, and/or
- remove `continue-on-error: true` to make zizmor blocking.