### PR TITLE
Harden checkout credential persistence

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install actionlint
         run: |

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -37,6 +37,8 @@ jobs:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v5

--- a/.github/workflows/eslint-js.yml
+++ b/.github/workflows/eslint-js.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240

--- a/.github/workflows/phpunit-smoke.yml
+++ b/.github/workflows/phpunit-smoke.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run Semgrep in report-only mode
         run: semgrep ci || true

--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -44,6 +44,8 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Snyk CLI to check for security issues
         # Snyk can be used to break the build when it detects security issues.
         # In this case we want to upload the SAST issues to GitHub Code Scanning

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run TruffleHog
         uses: trufflesecurity/trufflehog@26eae1f2969f4240acfd3fc363b504b1b43255d4 

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Prepare Basic Auth header
         env:


### PR DESCRIPTION
## Summary

Hardens GitHub Actions checkout steps by disabling persisted credentials.

## Details

- Adds `persist-credentials: false` to `actions/checkout` steps.
- Addresses zizmor `artipacked` findings related to checkout credential persistence.
- Keeps this PR narrow by avoiding unrelated action pinning or version updates.

## Follow-up

Remaining zizmor findings will be handled separately:
- Pin remaining action references to full commit SHAs.
- Update vulnerable `shivammathur/setup-php` pins.
- Fix version comment mismatches.