### PR TITLE
Update setup-php action pin

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.12
         with:
           php-version: '8.3'
           coverage: xdebug

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.12
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.3'
           coverage: xdebug

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.12
         with:
           php-version: '8.3'
           tools: composer

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.12
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.3'
           tools: composer

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc 2.37.12
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc 2.37.1
         with:
           php-version: '8.2'
           tools: composer

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc 2.37.12
         with:
           php-version: '8.2'
           tools: composer

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc 2.37.1
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.2'
           tools: composer

--- a/.github/workflows/phpunit-smoke.yml
+++ b/.github/workflows/phpunit-smoke.yml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.12
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: '8.3'
           tools: composer:v2

--- a/.github/workflows/phpunit-smoke.yml
+++ b/.github/workflows/phpunit-smoke.yml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.3'
           tools: composer:v2

--- a/.github/workflows/phpunit-smoke.yml
+++ b/.github/workflows/phpunit-smoke.yml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.12
         with:
           php-version: '8.3'
           tools: composer:v2


### PR DESCRIPTION
## Summary

Updates pinned `shivammathur/setup-php` GitHub Action references.

## Details

- Replaces the previously pinned setup-php SHA flagged by zizmor as vulnerable.
- Pins setup-php to the commit for version 2.37.1.
- Updates the version comment from `# v2` to `# 2.37.1`.
- Keeps this PR limited to setup-php action pins only.

## Follow-up

Remaining zizmor findings will be handled separately, including:
- Codecov version-comment mismatch cleanup.
- Container image pinning, if applicable.
- Any remaining unpinned or mismatch findings from the next zizmor run.