### PR TITLE
Update Codecov action pin

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -69,7 +69,7 @@ jobs:
         run: vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f #v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml


### PR DESCRIPTION
## Summary

Fixes the remaining zizmor Codecov version-comment mismatch.

## Details

- Update the existing Codecov action SHA.
- Does not change workflow behavior.

## Follow-up

The remaining zizmor finding after this should be the unpinned Semgrep container image in `semgrep.yml`.