### PR TITLE
Pin Semgrep container image

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,7 +18,7 @@ jobs:
     name: semgrep/ci-report-only
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.162.0-nonroot@sha256:c9205060e5cefc26fe140f8d5ee477295c6d0724f9d15931a0a70f8272157064
+      image: semgrep/semgrep:1.162.0-nonroot@sha256:67eb06814eb0c38d8d77f074c18cb5d476df68a14e2caed9dd3241b71223891b
     if: (github.actor != 'dependabot[bot]')
 
     steps:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,7 +18,7 @@ jobs:
     name: semgrep/ci-report-only
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep:1.162.0-nonroot@sha256:c9205060e5cefc26fe140f8d5ee477295c6d0724f9d15931a0a70f8272157064
     if: (github.actor != 'dependabot[bot]')
 
     steps:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,7 +18,7 @@ jobs:
     name: semgrep/ci-report-only
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.162.0-nonroot@sha256:f682953ce85e3725f4a4dd94bd7ad13e570bb6b2c7a8cf7c6e38a9eac89239b2
+      image: semgrep/semgrep:1.162.0@sha256:f682953ce85e3725f4a4dd94bd7ad13e570bb6b2c7a8cf7c6e38a9eac89239b2
     if: (github.actor != 'dependabot[bot]')
 
     steps:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,7 +18,7 @@ jobs:
     name: semgrep/ci-report-only
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.162.0-nonroot@sha256:67eb06814eb0c38d8d77f074c18cb5d476df68a14e2caed9dd3241b71223891b
+      image: semgrep/semgrep:1.162.0-nonroot@sha256:f682953ce85e3725f4a4dd94bd7ad13e570bb6b2c7a8cf7c6e38a9eac89239b2
     if: (github.actor != 'dependabot[bot]')
 
     steps:


### PR DESCRIPTION
## Summary

Pins the Semgrep container image by version and digest.

## Details

- Replaces the floating `semgrep/semgrep` image reference with a versioned, digest-pinned Semgrep image.
- Addresses the final active zizmor `unpinned-images` finding.
- Uses the nonroot Semgrep image variant.
- Keeps the PR limited to `.github/workflows/semgrep.yml`.

## Verification

- zizmor should no longer report `unpinned-images` for `semgrep.yml`.