### PR TITLE
Configure Dependabot for actions, Composer, and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+version: 2
+
+updates:
+  # Keep pinned GitHub Actions moving forward.
+  # Dependabot will open PRs when workflow action references can be updated.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "security"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Keep Composer-based PHP tooling updated:
+  # PHPUnit, PHPCS/WPCS, PHPStan, Psalm, and other Composer dependencies.
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "composer"
+      - "php"
+    groups:
+      composer-dependencies:
+        patterns:
+          - "*"
+
+  # Keep npm-based tooling updated:
+  # ESLint, Playwright, JS tooling, and packages in package-lock.json.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "npm"
+      - "javascript"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Configures Dependabot version updates for the KerbCycle repo.

This adds scheduled weekly dependency update checks for:

* GitHub Actions used in CI workflows
* Composer/PHP tooling and dependencies
* npm/JavaScript tooling and dependencies

## Changes

* Adds/updates `.github/dependabot.yml`
* Enables weekly Dependabot checks for:

  * `github-actions`
  * `composer`
  * `npm`
* Groups routine updates by ecosystem to reduce PR noise
* Limits open Dependabot PRs per ecosystem to keep review manageable
* Adds labels for dependency/security-related update PRs

## Why

KerbCycle CI now uses multiple security, quality, and testing tools. Dependabot will help keep pinned GitHub Actions, Composer tooling, and npm tooling current while preserving manual review before updates are merged.

This is especially important for pinned GitHub Actions because SHA pinning improves supply-chain safety, but those pinned references still need a controlled update process.

## Review notes

Automerge is intentionally not enabled. Dependabot PRs should be reviewed manually, with CI results checked before merging.

## Testing

* Configuration-only change
* No application code changed
* CI should validate repository workflows after PR creation
