### PR TITLE
Refine Dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 
 updates:
-  # Keep pinned GitHub Actions moving forward.
-  # Dependabot will open PRs when workflow action references can be updated.
+  # GitHub Actions:
+  # Group minor/patch action updates, but let major action updates open separately.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -16,12 +16,15 @@ updates:
       - "github-actions"
       - "security"
     groups:
-      github-actions:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"
 
-  # Keep Composer-based PHP tooling updated:
-  # PHPUnit, PHPCS/WPCS, PHPStan, Psalm, and other Composer dependencies.
+  # Composer:
+  # Group safe routine updates, but keep major updates separate.
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
@@ -35,12 +38,15 @@ updates:
       - "composer"
       - "php"
     groups:
-      composer-dependencies:
+      composer-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"
 
-  # Keep npm-based tooling updated:
-  # ESLint, Playwright, JS tooling, and packages in package-lock.json.
+  # npm:
+  # Group routine JS/tooling updates, but keep major updates separate.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -54,6 +60,9 @@ updates:
       - "npm"
       - "javascript"
     groups:
-      npm-dependencies:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

Refines the Dependabot configuration so routine dependency updates are easier to review.

## Changes

* Updates `.github/dependabot.yml`
* Keeps weekly checks for:

  * GitHub Actions
  * Composer/PHP dependencies
  * npm/JavaScript dependencies
* Changes Dependabot grouping so only `minor` and `patch` updates are grouped together
* Allows `major` updates to open separately instead of being bundled with lower-risk updates

## Why

The initial Dependabot setup grouped all updates together. That created large PRs combining routine patch updates with major upgrades, such as Composer tooling and GitHub Actions major-version changes.

Separating major updates should make Dependabot PRs easier to review, reduce CI confusion, and make it clearer which dependency update caused any failing checks.

## Review notes

After this change is merged, the current grouped Dependabot PRs can be closed and Dependabot can be rerun so it opens smaller, cleaner update PRs.

Automerge remains intentionally disabled. Dependabot PRs should still be reviewed manually before merging.

## Testing

* Configuration-only change
* No application code changed
* CI should validate repository workflows after PR creation
