### PR TITLE
Add Dependabot cooldown configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
@@ -32,6 +34,8 @@ updates:
       day: "monday"
       time: "09:30"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
@@ -54,6 +58,8 @@ updates:
       day: "monday"
       time: "10:00"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 3
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary

Adds a 7-day Dependabot cooldown to each configured update ecosystem:

* GitHub Actions
* Composer
* npm

This addresses the `zizmor` `dependabot-cooldown` finding by delaying routine version updates for a short period after release.

## Why

`zizmor` flagged the current Dependabot configuration for insufficient cooldown coverage. Adding a cooldown gives new dependency and action releases a short settling period before Dependabot opens routine version-update PRs.

This can reduce noisy or unstable update PRs while preserving Dependabot’s security-update behavior.

## Changes

* Added `cooldown.default-days: 7` to the GitHub Actions Dependabot block.
* Added `cooldown.default-days: 7` to the Composer Dependabot block.
* Added `cooldown.default-days: 7` to the npm Dependabot block.

## Validation

* Confirm CI passes.
* Confirm `zizmor` no longer reports `warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates`.

## Notes

This PR only changes Dependabot configuration. It does not update application code, workflow actions, Composer packages, or npm packages.
