### PR TITLE
Add ClamAV malware scan workflow

### DIFF
--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -1,0 +1,63 @@
+name: ClamAV Malware Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '17 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: clamav-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clamav:
+    name: ClamAV repository scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Prepare scan output
+        run: mkdir -p clamav-output
+
+      - name: Pull ClamAV image
+        run: docker pull clamav/clamav:stable
+
+      - name: Run ClamAV scan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker run --rm \
+            --mount type=bind,source="${GITHUB_WORKSPACE}",target=/scan,readonly \
+            --mount type=bind,source="${GITHUB_WORKSPACE}/clamav-output",target=/output \
+            clamav/clamav:stable \
+            clamscan \
+              --recursive \
+              --infected \
+              --log=/output/clamav-scan.log \
+              --exclude-dir='^/scan/\.git' \
+              --exclude-dir='^/scan/clamav-output' \
+              --max-filesize=100M \
+              --max-scansize=400M \
+              /scan
+
+      - name: Upload ClamAV scan log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: clamav-scan-log
+          path: clamav-output/clamav-scan.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -32,7 +32,7 @@ jobs:
         run: mkdir -p clamav-output
 
       - name: Pull ClamAV image
-        run: docker pull clamav/clamav:stable
+        run: docker pull clamav/clamav:stable@sha256:8df57e58b9127333f9ab5748a03a0f80f99d3c4830727c1c9ba9bffaa45a1b9c
 
       - name: Run ClamAV scan
         shell: bash
@@ -42,7 +42,7 @@ jobs:
           docker run --rm \
             --mount type=bind,source="${GITHUB_WORKSPACE}",target=/scan,readonly \
             --mount type=bind,source="${GITHUB_WORKSPACE}/clamav-output",target=/output \
-            clamav/clamav:stable \
+            clamav/clamav:stable@sha256:8df57e58b9127333f9ab5748a03a0f80f99d3c4830727c1c9ba9bffaa45a1b9c \
             clamscan \
               --recursive \
               --infected \

--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -53,6 +53,10 @@ jobs:
               --max-scansize=400M \
               /scan
 
+      - name: Fix ClamAV scan log permissions
+        if: always()
+        run: sudo chown -R "$USER":"$USER" clamav-output
+
       - name: Upload ClamAV scan log
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

Adds a ClamAV malware scanning workflow for the KerbCycle repository.

This workflow runs ClamAV in GitHub Actions to scan the repo for known malware signatures and suspicious infected files. It is intended as an additional defense-in-depth check alongside existing tools such as Wordfence CLI, CodeQL, Semgrep, OSV-Scanner, and Dependency Review.

## Changes

- Added `.github/workflows/clamav.yml`
- Runs on:
  - Pull requests
  - Pushes to `main`
  - Weekly scheduled scan
  - Manual `workflow_dispatch`
- Uses the official `clamav/clamav:stable` Docker image
- Recursively scans the repository
- Excludes `.git` and the scan output directory
- Uploads the ClamAV scan log as a GitHub Actions artifact
- Fails the workflow if ClamAV detects infected files or encounters a scan error

## Notes

This does not replace Wordfence CLI or other security scanners. ClamAV is primarily a known-malware/signature-based scanner and is useful as an additional check for malicious files, packed payloads, suspicious archives, or supply-chain residue.

The Docker image is currently referenced as `clamav/clamav:stable` for initial setup. After the workflow passes, we can optionally pin the image by digest in a follow-up PR for stronger supply-chain control.

## Testing

- Added workflow file only
- CI should validate the ClamAV scan behavior on this PR