### PR TITLE
Change Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,13 +54,13 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "10:00"
+      interval: "daily"
+      #day: "monday"
+      time: "6:00"
       timezone: "America/New_York"
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 8
     labels:
       - "dependencies"
       - "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
+      interval: "daily"
+      #day: "monday"
+      time: "06:00"
       timezone: "America/New_York"
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 8
     labels:
       - "dependencies"
       - "github-actions"
@@ -30,13 +30,13 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:30"
+      interval: "daily"
+      #day: "monday"
+      time: "06:30"
       timezone: "America/New_York"
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "composer"
@@ -56,11 +56,11 @@ updates:
     schedule:
       interval: "daily"
       #day: "monday"
-      time: "6:00"
+      time: "07:00"
       timezone: "America/New_York"
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 8
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "npm"


### PR DESCRIPTION
## Summary

Updates Dependabot scheduling and PR limits to make dependency updates easier to keep current while still preserving review control.

## Changes

- Run Dependabot checks more frequently.
- Increase the open PR limit so updates are not blocked by a small backlog.
- Keep grouped minor/patch updates for routine maintenance.
- Keep major updates separate for closer review.

## Rationale

The previous weekly schedule with a low open PR limit was too restrictive while the repo is actively adding and maintaining CI/security tooling. A small backlog of open Dependabot PRs could prevent newer updates from being created in a timely way.

This configuration should help surface GitHub Actions and dependency updates sooner without making major upgrades harder to review.

## Review notes

- Major updates should still be reviewed individually.
- Some CI checks may fail on Dependabot PRs due to GitHub’s Dependabot secret isolation; those failures should be evaluated separately from actual workflow/runtime failures.
- After this merges, stale broad Dependabot PRs can be closed or allowed to regenerate under the updated configuration.