### PR TITLE
test: add SMS service coverage

### DIFF
--- a/tests/phpunit/Smoke/SmsServiceSmokeTest.php
+++ b/tests/phpunit/Smoke/SmsServiceSmokeTest.php
@@ -1,0 +1,399 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KerbCycle\Tests\PhpUnit\Smoke;
+
+require_once __DIR__ . '/../TestCase.php';
+
+use KerbCycle\Tests\PhpUnit\TestCase;
+use Kerbcycle\QrCode\Data\Repositories\MessageLogRepository;
+use Kerbcycle\QrCode\Services\MessagesService;
+use Kerbcycle\QrCode\Services\SmsService;
+
+final class SmsServiceSmokeTest extends TestCase
+{
+    private function message_log_table_name(): string
+    {
+        global $wpdb;
+
+        return $wpdb->prefix . 'kerbcycle_message_logs';
+    }
+
+    public function tear_down(): void
+    {
+        remove_all_filters('pre_http_request');
+        remove_all_filters('pre_wp_mail');
+
+        delete_option(SmsService::OPT);
+        delete_option(MessagesService::OPT);
+    }
+
+    public function test_sms_defaults_and_get_opts_merge_saved_values(): void
+    {
+        update_option(
+            SmsService::OPT,
+            [
+                'provider' => 'webhook',
+                'auth_method' => 'none',
+                'gateway_url' => 'http://kerbcycle-sms-dev:4001/v1/messages',
+                'method' => 'POST',
+            ],
+            false
+        );
+
+        $opts = SmsService::get_opts();
+
+        $this->assertSame('webhook', $opts['provider']);
+        $this->assertSame('none', $opts['auth_method']);
+        $this->assertSame('http://kerbcycle-sms-dev:4001/v1/messages', $opts['gateway_url']);
+        $this->assertSame('POST', $opts['method']);
+        $this->assertArrayHasKey('country_code', $opts);
+        $this->assertArrayHasKey('body_template', $opts);
+        $this->assertArrayHasKey('headers', $opts);
+    }
+
+    public function test_normalize_phone_adds_country_code_to_local_number(): void
+    {
+        $opts = [
+            'country_code' => '+1',
+        ];
+
+        $this->assertSame('+12015550123', SmsService::normalize_phone('(201) 555-0123', $opts));
+        $this->assertSame('+15551234567', SmsService::normalize_phone('+15551234567', $opts));
+    }
+
+    public function test_email_to_sms_requires_gateway_domain(): void
+    {
+        update_option(
+            SmsService::OPT,
+            [
+                'provider' => 'email2sms',
+                'email_gateway' => '',
+            ],
+            false
+        );
+
+        $result = SmsService::send('+15551234567', 'Test message');
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('kc_sms_email_gateway', $result->get_error_code());
+    }
+
+    public function test_email_to_sms_success_uses_wp_mail_gateway_address(): void
+    {
+        update_option(
+            SmsService::OPT,
+            [
+                'provider' => 'email2sms',
+                'email_gateway' => 'vtext.example',
+            ],
+            false
+        );
+
+        $captured = [];
+
+        add_filter(
+            'pre_wp_mail',
+            static function ($preempt, $atts) use (&$captured) {
+                $captured = $atts;
+
+                return true;
+            },
+            10,
+            2
+        );
+
+        $result = SmsService::send('(201) 555-0123', '<strong>Hello</strong> SMS');
+
+        $this->assertIsArray($result);
+        $this->assertTrue($result['ok']);
+        $this->assertSame('2015550123@vtext.example', $result['to']);
+        $this->assertSame('2015550123@vtext.example', $captured['to']);
+        $this->assertSame('Hello SMS', $captured['message']);
+    }
+
+    public function test_webhook_post_success_sends_json_body_and_headers(): void
+    {
+        update_option(
+            SmsService::OPT,
+            [
+                'provider' => 'webhook',
+                'api_key' => 'test-api-key',
+                'api_secret' => '',
+                'auth_method' => 'bearer',
+                'from_number' => '+15555559999',
+                'country_code' => '+1',
+                'gateway_url' => 'http://kerbcycle-sms-dev:4001/v1/messages',
+                'method' => 'POST',
+                'body_template' => '{"from":"{from}","to":"{to}","body":"{message}"}',
+                'headers' => "Content-Type: application/json\nX-Test-Key: {api_key}",
+                'debug' => '0',
+            ],
+            false
+        );
+
+        add_filter(
+            'pre_http_request',
+            static function ($preempt, $parsed_args, $url) {
+                if ($url !== 'http://kerbcycle-sms-dev:4001/v1/messages') {
+                    return $preempt;
+                }
+
+                $headers = $parsed_args['headers'];
+                $body = json_decode((string) $parsed_args['body'], true);
+
+                if (($headers['Authorization'] ?? '') !== 'Bearer test-api-key') {
+                    return new \WP_Error('unexpected_auth', 'Unexpected auth header.');
+                }
+
+                if (($headers['X-Test-Key'] ?? '') !== 'test-api-key') {
+                    return new \WP_Error('unexpected_custom_header', 'Unexpected custom header.');
+                }
+
+                if (($body['from'] ?? '') !== '+15555559999') {
+                    return new \WP_Error('unexpected_from', 'Unexpected from number.');
+                }
+
+                if (($body['to'] ?? '') !== '+12015550123') {
+                    return new \WP_Error('unexpected_to', 'Unexpected normalized recipient.');
+                }
+
+                if (($body['body'] ?? '') !== 'Pickup reminder') {
+                    return new \WP_Error('unexpected_body', 'Unexpected message body.');
+                }
+
+                return [
+                    'headers' => [],
+                    'body' => '{"queued":true}',
+                    'response' => [
+                        'code' => 202,
+                        'message' => 'Accepted',
+                    ],
+                    'cookies' => [],
+                    'filename' => null,
+                ];
+            },
+            10,
+            3
+        );
+
+        $result = SmsService::send('(201) 555-0123', '<em>Pickup reminder</em>');
+
+        $this->assertIsArray($result);
+        $this->assertTrue($result['ok']);
+        $this->assertSame(202, $result['http']);
+        $this->assertSame('{"queued":true}', $result['body']);
+    }
+
+    public function test_webhook_post_http_error_returns_wp_error_with_status_data(): void
+    {
+        update_option(
+            SmsService::OPT,
+            [
+                'provider' => 'webhook',
+                'auth_method' => 'none',
+                'gateway_url' => 'http://sms-error.test/v1/messages',
+                'method' => 'POST',
+                'body_template' => '{"to":"{to}","body":"{message}"}',
+                'headers' => 'Content-Type: application/json',
+                'debug' => '0',
+            ],
+            false
+        );
+
+        add_filter(
+            'pre_http_request',
+            static function ($preempt, $parsed_args, $url) {
+                if ($url !== 'http://sms-error.test/v1/messages') {
+                    return $preempt;
+                }
+
+                return [
+                    'headers' => [],
+                    'body' => 'Forbidden',
+                    'response' => [
+                        'code' => 403,
+                        'message' => 'Forbidden',
+                    ],
+                    'cookies' => [],
+                    'filename' => null,
+                ];
+            },
+            10,
+            3
+        );
+
+        $result = SmsService::send('+15551234567', 'Blocked message');
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('kc_sms_http', $result->get_error_code());
+        $this->assertSame(403, $result->get_error_data()['http'] ?? null);
+        $this->assertSame('Forbidden', $result->get_error_data()['body'] ?? null);
+    }
+
+    public function test_webhook_get_success_appends_template_as_query_args(): void
+    {
+        update_option(
+            SmsService::OPT,
+            [
+                'provider' => 'webhook',
+                'auth_method' => 'key_header',
+                'api_key' => 'query-api-key',
+                'gateway_url' => 'http://sms-get.test/send',
+                'method' => 'GET',
+                'country_code' => '+1',
+                'body_template' => '{"to":"{to}","message":"{message}"}',
+                'headers' => '',
+                'debug' => '0',
+            ],
+            false
+        );
+
+        add_filter(
+            'pre_http_request',
+            static function ($preempt, $parsed_args, $url) {
+                if (strpos($url, 'http://sms-get.test/send') !== 0) {
+                    return $preempt;
+                }
+
+                $query = [];
+                wp_parse_str((string) wp_parse_url($url, PHP_URL_QUERY), $query);
+
+                if (($parsed_args['headers']['key'] ?? '') !== 'query-api-key') {
+                    return new \WP_Error('unexpected_key_header', 'Unexpected key header.');
+                }
+
+                if (($query['to'] ?? '') !== '+12015550123') {
+                    return new \WP_Error('unexpected_query_to', 'Unexpected query recipient.');
+                }
+
+                if (($query['message'] ?? '') !== 'GET message') {
+                    return new \WP_Error('unexpected_query_message', 'Unexpected query message.');
+                }
+
+                return [
+                    'headers' => [],
+                    'body' => 'OK',
+                    'response' => [
+                        'code' => 200,
+                        'message' => 'OK',
+                    ],
+                    'cookies' => [],
+                    'filename' => null,
+                ];
+            },
+            10,
+            3
+        );
+
+        $result = SmsService::send('(201) 555-0123', 'GET message');
+
+        $this->assertIsArray($result);
+        $this->assertTrue($result['ok']);
+        $this->assertSame(200, $result['http']);
+        $this->assertSame('OK', $result['body']);
+    }
+
+    public function test_send_notification_returns_error_when_user_has_no_phone(): void
+    {
+        $userId = self::factory()->user->create([
+            'role' => 'subscriber',
+            'display_name' => 'No Phone User',
+        ]);
+
+        $service = new SmsService();
+        $result = $service->send_notification($userId, 'QR-NO-PHONE', 'assigned');
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('sms_config', $result->get_error_code());
+    }
+
+    public function test_send_notification_success_logs_message_result(): void
+    {
+        global $wpdb;
+
+        update_option(
+            SmsService::OPT,
+            [
+                'provider' => 'webhook',
+                'auth_method' => 'none',
+                'from_number' => '+15555559999',
+                'country_code' => '+1',
+                'gateway_url' => 'http://notify-sms.test/send',
+                'method' => 'POST',
+                'body_template' => '{"to":"{to}","message":"{message}"}',
+                'headers' => 'Content-Type: application/json',
+                'debug' => '0',
+            ],
+            false
+        );
+
+        update_option(
+            MessagesService::OPT,
+            [
+                'assigned' => [
+                    'sms' => 'Assigned {code} to {user}',
+                    'email' => '',
+                ],
+            ],
+            false
+        );
+
+        add_filter(
+            'pre_http_request',
+            static function ($preempt, $parsed_args, $url) {
+                if ($url !== 'http://notify-sms.test/send') {
+                    return $preempt;
+                }
+
+                $body = json_decode((string) $parsed_args['body'], true);
+
+                if (($body['to'] ?? '') !== '+12015550123') {
+                    return new \WP_Error('unexpected_notify_to', 'Unexpected notification recipient.');
+                }
+
+                if (($body['message'] ?? '') !== 'Assigned QR-NOTIFY-001 to Notify User') {
+                    return new \WP_Error('unexpected_notify_body', 'Unexpected notification body.');
+                }
+
+                return [
+                    'headers' => [],
+                    'body' => '{"sent":true}',
+                    'response' => [
+                        'code' => 200,
+                        'message' => 'OK',
+                    ],
+                    'cookies' => [],
+                    'filename' => null,
+                ];
+            },
+            10,
+            3
+        );
+
+        $userId = self::factory()->user->create([
+            'role' => 'subscriber',
+            'display_name' => 'Notify User',
+        ]);
+
+        update_user_meta($userId, 'billing_phone', '(201) 555-0123');
+
+        $service = new SmsService();
+        $result = $service->send_notification($userId, 'QR-NOTIFY-001', 'assigned');
+
+        $this->assertTrue($result);
+
+        $log = $wpdb->get_row(
+            'SELECT * FROM ' . $this->message_log_table_name() . ' ORDER BY id DESC LIMIT 1'
+        );
+
+        $this->assertNotNull($log);
+        $this->assertSame('sms', $log->type);
+        $this->assertSame('(201) 555-0123', $log->recipient);
+        $this->assertSame('Assigned QR-NOTIFY-001 to Notify User', $log->body);
+        $this->assertSame('sent', $log->status);
+        $this->assertSame('webhook', $log->provider);
+        $this->assertStringContainsString('"ok":true', $log->response);
+    }
+}

--- a/tests/phpunit/Smoke/SmsServiceSmokeTest.php
+++ b/tests/phpunit/Smoke/SmsServiceSmokeTest.php
@@ -7,17 +7,66 @@ namespace KerbCycle\Tests\PhpUnit\Smoke;
 require_once __DIR__ . '/../TestCase.php';
 
 use KerbCycle\Tests\PhpUnit\TestCase;
-use Kerbcycle\QrCode\Data\Repositories\MessageLogRepository;
 use Kerbcycle\QrCode\Services\MessagesService;
 use Kerbcycle\QrCode\Services\SmsService;
 
 final class SmsServiceSmokeTest extends TestCase
 {
-    private function message_log_table_name(): string
+    private const LOCAL_PHONE = '(201) 555-0123';
+    private const NORMALIZED_PHONE = '+12015550123';
+    private const NORMALIZED_PHONE_DIGITS = '12015550123';
+    private const E164_PHONE = '+15551234567';
+    private const FROM_NUMBER = '+15555559999';
+
+    private const PROVIDER_WEBHOOK = 'webhook';
+    private const HEADER_JSON_LINE = 'Content-Type: application/json';
+
+    private const SMS_ENDPOINT = 'https://kerbcycle-sms-dev.test/v1/messages';
+    private const SMS_ERROR_ENDPOINT = 'https://sms-error.test/v1/messages';
+    private const SMS_GET_ENDPOINT = 'https://sms-get.test/send';
+    private const NOTIFY_SMS_ENDPOINT = 'https://notify-sms.test/send';
+
+    private function messageLogTableName(): string
     {
         global $wpdb;
 
         return $wpdb->prefix . 'kerbcycle_message_logs';
+    }
+
+    private function updateSmsOptions(array $overrides): void
+    {
+        update_option(
+            SmsService::OPT,
+            array_merge(
+                [
+                    'debug' => '0',
+                ],
+                $overrides
+            ),
+            false
+        );
+    }
+
+    private function httpResponse(int $code, string $message, string $body): array
+    {
+        return [
+            'headers' => [],
+            'body' => $body,
+            'response' => [
+                'code' => $code,
+                'message' => $message,
+            ],
+            'cookies' => [],
+            'filename' => null,
+        ];
+    }
+
+    private function assertSuccessfulSmsResult($result, int $statusCode, string $body): void
+    {
+        $this->assertIsArray($result);
+        $this->assertTrue($result['ok']);
+        $this->assertSame($statusCode, $result['http']);
+        $this->assertSame($body, $result['body']);
     }
 
     public function tear_down(): void
@@ -31,22 +80,20 @@ final class SmsServiceSmokeTest extends TestCase
 
     public function test_sms_defaults_and_get_opts_merge_saved_values(): void
     {
-        update_option(
-            SmsService::OPT,
+        $this->updateSmsOptions(
             [
-                'provider' => 'webhook',
+                'provider' => self::PROVIDER_WEBHOOK,
                 'auth_method' => 'none',
-                'gateway_url' => 'http://kerbcycle-sms-dev:4001/v1/messages',
+                'gateway_url' => self::SMS_ENDPOINT,
                 'method' => 'POST',
-            ],
-            false
+            ]
         );
 
         $opts = SmsService::get_opts();
 
-        $this->assertSame('webhook', $opts['provider']);
+        $this->assertSame(self::PROVIDER_WEBHOOK, $opts['provider']);
         $this->assertSame('none', $opts['auth_method']);
-        $this->assertSame('http://kerbcycle-sms-dev:4001/v1/messages', $opts['gateway_url']);
+        $this->assertSame(self::SMS_ENDPOINT, $opts['gateway_url']);
         $this->assertSame('POST', $opts['method']);
         $this->assertArrayHasKey('country_code', $opts);
         $this->assertArrayHasKey('body_template', $opts);
@@ -59,22 +106,20 @@ final class SmsServiceSmokeTest extends TestCase
             'country_code' => '+1',
         ];
 
-        $this->assertSame('+12015550123', SmsService::normalize_phone('(201) 555-0123', $opts));
-        $this->assertSame('+15551234567', SmsService::normalize_phone('+15551234567', $opts));
+        $this->assertSame(self::NORMALIZED_PHONE, SmsService::normalize_phone(self::LOCAL_PHONE, $opts));
+        $this->assertSame(self::E164_PHONE, SmsService::normalize_phone(self::E164_PHONE, $opts));
     }
 
     public function test_email_to_sms_requires_gateway_domain(): void
     {
-        update_option(
-            SmsService::OPT,
+        $this->updateSmsOptions(
             [
                 'provider' => 'email2sms',
                 'email_gateway' => '',
-            ],
-            false
+            ]
         );
 
-        $result = SmsService::send('+15551234567', 'Test message');
+        $result = SmsService::send(self::E164_PHONE, 'Test message');
 
         $this->assertInstanceOf(\WP_Error::class, $result);
         $this->assertSame('kc_sms_email_gateway', $result->get_error_code());
@@ -82,21 +127,23 @@ final class SmsServiceSmokeTest extends TestCase
 
     public function test_email_to_sms_success_uses_wp_mail_gateway_address(): void
     {
-        update_option(
-            SmsService::OPT,
+        $this->updateSmsOptions(
             [
                 'provider' => 'email2sms',
                 'email_gateway' => 'vtext.example',
-            ],
-            false
+            ]
         );
 
         $captured = [];
 
         add_filter(
             'pre_wp_mail',
-            static function ($preempt, $atts) use (&$captured) {
+            function ($preempt, $atts) use (&$captured) {
                 $captured = $atts;
+
+                if (null !== $preempt) {
+                    return $preempt;
+                }
 
                 return true;
             },
@@ -104,7 +151,7 @@ final class SmsServiceSmokeTest extends TestCase
             2
         );
 
-        $result = SmsService::send('(201) 555-0123', '<strong>Hello</strong> SMS');
+        $result = SmsService::send(self::LOCAL_PHONE, '<strong>Hello</strong> SMS');
 
         $this->assertIsArray($result);
         $this->assertTrue($result['ok']);
@@ -115,116 +162,77 @@ final class SmsServiceSmokeTest extends TestCase
 
     public function test_webhook_post_success_sends_json_body_and_headers(): void
     {
-        update_option(
-            SmsService::OPT,
+        $this->updateSmsOptions(
             [
-                'provider' => 'webhook',
+                'provider' => self::PROVIDER_WEBHOOK,
                 'api_key' => 'test-api-key',
                 'api_secret' => '',
                 'auth_method' => 'bearer',
-                'from_number' => '+15555559999',
+                'from_number' => self::FROM_NUMBER,
                 'country_code' => '+1',
-                'gateway_url' => 'http://kerbcycle-sms-dev:4001/v1/messages',
+                'gateway_url' => self::SMS_ENDPOINT,
                 'method' => 'POST',
                 'body_template' => '{"from":"{from}","to":"{to}","body":"{message}"}',
-                'headers' => "Content-Type: application/json\nX-Test-Key: {api_key}",
-                'debug' => '0',
-            ],
-            false
+                'headers' => self::HEADER_JSON_LINE . "\nX-Test-Key: {api_key}",
+            ]
         );
 
         add_filter(
             'pre_http_request',
-            static function ($preempt, $parsed_args, $url) {
-                if ($url !== 'http://kerbcycle-sms-dev:4001/v1/messages') {
+            function ($preempt, $parsedArgs, $url) {
+                if ($url !== self::SMS_ENDPOINT) {
                     return $preempt;
                 }
 
-                $headers = $parsed_args['headers'];
-                $body = json_decode((string) $parsed_args['body'], true);
+                $headers = $parsedArgs['headers'];
+                $body = json_decode((string) $parsedArgs['body'], true);
 
-                if (($headers['Authorization'] ?? '') !== 'Bearer test-api-key') {
-                    return new \WP_Error('unexpected_auth', 'Unexpected auth header.');
-                }
+                $this->assertSame('Bearer test-api-key', $headers['Authorization'] ?? '');
+                $this->assertSame('test-api-key', $headers['X-Test-Key'] ?? '');
+                $this->assertSame(self::FROM_NUMBER, $body['from'] ?? '');
+                $this->assertSame(self::NORMALIZED_PHONE, $body['to'] ?? '');
+                $this->assertSame('Pickup reminder', $body['body'] ?? '');
 
-                if (($headers['X-Test-Key'] ?? '') !== 'test-api-key') {
-                    return new \WP_Error('unexpected_custom_header', 'Unexpected custom header.');
-                }
-
-                if (($body['from'] ?? '') !== '+15555559999') {
-                    return new \WP_Error('unexpected_from', 'Unexpected from number.');
-                }
-
-                if (($body['to'] ?? '') !== '+12015550123') {
-                    return new \WP_Error('unexpected_to', 'Unexpected normalized recipient.');
-                }
-
-                if (($body['body'] ?? '') !== 'Pickup reminder') {
-                    return new \WP_Error('unexpected_body', 'Unexpected message body.');
-                }
-
-                return [
-                    'headers' => [],
-                    'body' => '{"queued":true}',
-                    'response' => [
-                        'code' => 202,
-                        'message' => 'Accepted',
-                    ],
-                    'cookies' => [],
-                    'filename' => null,
-                ];
+                return $this->httpResponse(202, 'Accepted', '{"queued":true}');
             },
             10,
             3
         );
 
-        $result = SmsService::send('(201) 555-0123', '<em>Pickup reminder</em>');
+        $result = SmsService::send(self::LOCAL_PHONE, '<em>Pickup reminder</em>');
 
-        $this->assertIsArray($result);
-        $this->assertTrue($result['ok']);
-        $this->assertSame(202, $result['http']);
-        $this->assertSame('{"queued":true}', $result['body']);
+        $this->assertSuccessfulSmsResult($result, 202, '{"queued":true}');
     }
 
     public function test_webhook_post_http_error_returns_wp_error_with_status_data(): void
     {
-        update_option(
-            SmsService::OPT,
+        $this->updateSmsOptions(
             [
-                'provider' => 'webhook',
+                'provider' => self::PROVIDER_WEBHOOK,
                 'auth_method' => 'none',
-                'gateway_url' => 'http://sms-error.test/v1/messages',
+                'gateway_url' => self::SMS_ERROR_ENDPOINT,
                 'method' => 'POST',
                 'body_template' => '{"to":"{to}","body":"{message}"}',
-                'headers' => 'Content-Type: application/json',
-                'debug' => '0',
-            ],
-            false
+                'headers' => self::HEADER_JSON_LINE,
+            ]
         );
 
         add_filter(
             'pre_http_request',
-            static function ($preempt, $parsed_args, $url) {
-                if ($url !== 'http://sms-error.test/v1/messages') {
+            function ($preempt, $parsedArgs, $url) {
+                if ($url !== self::SMS_ERROR_ENDPOINT) {
                     return $preempt;
                 }
 
-                return [
-                    'headers' => [],
-                    'body' => 'Forbidden',
-                    'response' => [
-                        'code' => 403,
-                        'message' => 'Forbidden',
-                    ],
-                    'cookies' => [],
-                    'filename' => null,
-                ];
+                $this->assertIsArray($parsedArgs);
+
+                return $this->httpResponse(403, 'Forbidden', 'Forbidden');
             },
             10,
             3
         );
 
-        $result = SmsService::send('+15551234567', 'Blocked message');
+        $result = SmsService::send(self::E164_PHONE, 'Blocked message');
 
         $this->assertInstanceOf(\WP_Error::class, $result);
         $this->assertSame('kc_sms_http', $result->get_error_code());
@@ -234,75 +242,54 @@ final class SmsServiceSmokeTest extends TestCase
 
     public function test_webhook_get_success_appends_template_as_query_args(): void
     {
-        update_option(
-            SmsService::OPT,
+        $this->updateSmsOptions(
             [
-                'provider' => 'webhook',
+                'provider' => self::PROVIDER_WEBHOOK,
                 'auth_method' => 'key_header',
                 'api_key' => 'query-api-key',
-                'gateway_url' => 'http://sms-get.test/send',
+                'gateway_url' => self::SMS_GET_ENDPOINT,
                 'method' => 'GET',
                 'country_code' => '+1',
                 'body_template' => '{"to":"{to}","message":"{message}"}',
                 'headers' => '',
-                'debug' => '0',
-            ],
-            false
+            ]
         );
 
         add_filter(
             'pre_http_request',
-            static function ($preempt, $parsed_args, $url) {
-                if (strpos($url, 'http://sms-get.test/send') !== 0) {
+            function ($preempt, $parsedArgs, $url) {
+                if (strpos($url, self::SMS_GET_ENDPOINT) !== 0) {
                     return $preempt;
                 }
 
                 $query = [];
                 wp_parse_str((string) wp_parse_url($url, PHP_URL_QUERY), $query);
 
-                if (($parsed_args['headers']['key'] ?? '') !== 'query-api-key') {
-                    return new \WP_Error('unexpected_key_header', 'Unexpected key header.');
-                }
+                $queryToDigits = preg_replace('/\D+/', '', (string) ($query['to'] ?? ''));
 
-               $queryToDigits = preg_replace('/\D+/', '', (string) ($query['to'] ?? ''));
+                $this->assertSame('query-api-key', $parsedArgs['headers']['key'] ?? '');
+                $this->assertSame(self::NORMALIZED_PHONE_DIGITS, $queryToDigits);
+                $this->assertSame('GET message', $query['message'] ?? '');
 
-               if ($queryToDigits !== '12015550123') {
-                   return new \WP_Error('unexpected_query_to', 'Unexpected query recipient.');
-}
-
-                if (($query['message'] ?? '') !== 'GET message') {
-                    return new \WP_Error('unexpected_query_message', 'Unexpected query message.');
-                }
-
-                return [
-                    'headers' => [],
-                    'body' => 'OK',
-                    'response' => [
-                        'code' => 200,
-                        'message' => 'OK',
-                    ],
-                    'cookies' => [],
-                    'filename' => null,
-                ];
+                return $this->httpResponse(200, 'OK', 'OK');
             },
             10,
             3
         );
 
-        $result = SmsService::send('(201) 555-0123', 'GET message');
+        $result = SmsService::send(self::LOCAL_PHONE, 'GET message');
 
-        $this->assertIsArray($result);
-        $this->assertTrue($result['ok']);
-        $this->assertSame(200, $result['http']);
-        $this->assertSame('OK', $result['body']);
+        $this->assertSuccessfulSmsResult($result, 200, 'OK');
     }
 
     public function test_send_notification_returns_error_when_user_has_no_phone(): void
     {
-        $userId = self::factory()->user->create([
-            'role' => 'subscriber',
-            'display_name' => 'No Phone User',
-        ]);
+        $userId = self::factory()->user->create(
+            [
+                'role' => 'subscriber',
+                'display_name' => 'No Phone User',
+            ]
+        );
 
         $service = new SmsService();
         $result = $service->send_notification($userId, 'QR-NO-PHONE', 'assigned');
@@ -315,20 +302,17 @@ final class SmsServiceSmokeTest extends TestCase
     {
         global $wpdb;
 
-        update_option(
-            SmsService::OPT,
+        $this->updateSmsOptions(
             [
-                'provider' => 'webhook',
+                'provider' => self::PROVIDER_WEBHOOK,
                 'auth_method' => 'none',
-                'from_number' => '+15555559999',
+                'from_number' => self::FROM_NUMBER,
                 'country_code' => '+1',
-                'gateway_url' => 'http://notify-sms.test/send',
+                'gateway_url' => self::NOTIFY_SMS_ENDPOINT,
                 'method' => 'POST',
                 'body_template' => '{"to":"{to}","message":"{message}"}',
-                'headers' => 'Content-Type: application/json',
-                'debug' => '0',
-            ],
-            false
+                'headers' => self::HEADER_JSON_LINE,
+            ]
         );
 
         update_option(
@@ -344,42 +328,30 @@ final class SmsServiceSmokeTest extends TestCase
 
         add_filter(
             'pre_http_request',
-            static function ($preempt, $parsed_args, $url) {
-                if ($url !== 'http://notify-sms.test/send') {
+            function ($preempt, $parsedArgs, $url) {
+                if ($url !== self::NOTIFY_SMS_ENDPOINT) {
                     return $preempt;
                 }
 
-                $body = json_decode((string) $parsed_args['body'], true);
+                $body = json_decode((string) $parsedArgs['body'], true);
 
-                if (($body['to'] ?? '') !== '+12015550123') {
-                    return new \WP_Error('unexpected_notify_to', 'Unexpected notification recipient.');
-                }
+                $this->assertSame(self::NORMALIZED_PHONE, $body['to'] ?? '');
+                $this->assertSame('Assigned QR-NOTIFY-001 to Notify User', $body['message'] ?? '');
 
-                if (($body['message'] ?? '') !== 'Assigned QR-NOTIFY-001 to Notify User') {
-                    return new \WP_Error('unexpected_notify_body', 'Unexpected notification body.');
-                }
-
-                return [
-                    'headers' => [],
-                    'body' => '{"sent":true}',
-                    'response' => [
-                        'code' => 200,
-                        'message' => 'OK',
-                    ],
-                    'cookies' => [],
-                    'filename' => null,
-                ];
+                return $this->httpResponse(200, 'OK', '{"sent":true}');
             },
             10,
             3
         );
 
-        $userId = self::factory()->user->create([
-            'role' => 'subscriber',
-            'display_name' => 'Notify User',
-        ]);
+        $userId = self::factory()->user->create(
+            [
+                'role' => 'subscriber',
+                'display_name' => 'Notify User',
+            ]
+        );
 
-        update_user_meta($userId, 'billing_phone', '(201) 555-0123');
+        update_user_meta($userId, 'billing_phone', self::LOCAL_PHONE);
 
         $service = new SmsService();
         $result = $service->send_notification($userId, 'QR-NOTIFY-001', 'assigned');
@@ -387,15 +359,15 @@ final class SmsServiceSmokeTest extends TestCase
         $this->assertTrue($result);
 
         $log = $wpdb->get_row(
-            'SELECT * FROM ' . $this->message_log_table_name() . ' ORDER BY id DESC LIMIT 1'
+            'SELECT * FROM ' . $this->messageLogTableName() . ' ORDER BY id DESC LIMIT 1'
         );
 
         $this->assertNotNull($log);
         $this->assertSame('sms', $log->type);
-        $this->assertSame('(201) 555-0123', $log->recipient);
+        $this->assertSame(self::LOCAL_PHONE, $log->recipient);
         $this->assertSame('Assigned QR-NOTIFY-001 to Notify User', $log->body);
         $this->assertSame('sent', $log->status);
-        $this->assertSame('webhook', $log->provider);
+        $this->assertSame(self::PROVIDER_WEBHOOK, $log->provider);
         $this->assertStringContainsString('"ok":true', $log->response);
     }
 }

--- a/tests/phpunit/Smoke/SmsServiceSmokeTest.php
+++ b/tests/phpunit/Smoke/SmsServiceSmokeTest.php
@@ -264,9 +264,11 @@ final class SmsServiceSmokeTest extends TestCase
                     return new \WP_Error('unexpected_key_header', 'Unexpected key header.');
                 }
 
-                if (($query['to'] ?? '') !== '+12015550123') {
-                    return new \WP_Error('unexpected_query_to', 'Unexpected query recipient.');
-                }
+               $queryToDigits = preg_replace('/\D+/', '', (string) ($query['to'] ?? ''));
+
+               if ($queryToDigits !== '12015550123') {
+                   return new \WP_Error('unexpected_query_to', 'Unexpected query recipient.');
+}
 
                 if (($query['message'] ?? '') !== 'GET message') {
                     return new \WP_Error('unexpected_query_message', 'Unexpected query message.');


### PR DESCRIPTION
## Summary

Adds PHPUnit smoke coverage for SmsService configuration, phone normalization, gateway handling, and notification logging.

## Covered behavior

- SMS option defaults and saved-option merging
- Phone normalization with country code
- Email-to-SMS missing gateway failure
- Email-to-SMS success through wp_mail interception
- Webhook POST success with mocked HTTP response
- Webhook POST HTTP failure
- Webhook GET query handling
- send_notification missing phone failure
- send_notification success path and message log creation

## Notes

This PR is test-only and does not change production code. HTTP calls are intercepted through WordPress `pre_http_request`, and email-to-SMS calls are intercepted through `pre_wp_mail`, so no real SMS or email provider is contacted.