### PR TITLE
Chore/add non-blocking playwright smoke tests

### DIFF
--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -19,10 +19,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: npm
@@ -48,7 +50,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: playwright-report/
@@ -56,7 +58,7 @@ jobs:
 
       - name: Upload Playwright test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-test-results
           path: test-results/

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -1,0 +1,63 @@
+name: Playwright Smoke Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 7 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  playwright-smoke:
+    name: Browser smoke tests
+    runs-on: ubuntu-latest
+
+    # Non-blocking while this new test layer is being stabilized.
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright smoke tests
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ secrets.PLAYWRIGHT_BASE_URL }}
+          BASIC_AUTH_USER: ${{ secrets.BASIC_AUTH_USER }}
+          BASIC_AUTH_PASS: ${{ secrets.BASIC_AUTH_PASS }}
+          KC_CUSTOMER_USER: ${{ secrets.KC_CUSTOMER_USER }}
+          KC_CUSTOMER_PASS: ${{ secrets.KC_CUSTOMER_PASS }}
+          KC_OPERATOR_USER: ${{ secrets.KC_OPERATOR_USER }}
+          KC_OPERATOR_PASS: ${{ secrets.KC_OPERATOR_PASS }}
+          KC_ADMIN_USER: ${{ secrets.KC_ADMIN_USER }}
+          KC_ADMIN_PASS: ${{ secrets.KC_ADMIN_PASS }}
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-test-results
+          path: test-results/
+          retention-days: 7

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -1,4 +1,4 @@
-name: Playwright Smoke Tests
+name: Advisory - Playwright Smoke Tests
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   playwright-smoke:
-    name: Browser smoke tests
+    name: advisory / playwright
     runs-on: ubuntu-latest
 
     # Non-blocking while this new test layer is being stabilized.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "devDependencies": {
         "@playwright/test": "^1.61.1",
+        "@types/node": "^26.0.1",
         "@wordpress/eslint-plugin": "^25.4.1",
         "eslint": "^9.39.4",
         "globals": "^17.6.0"
@@ -2186,6 +2187,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -7329,6 +7340,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@wordpress/eslint-plugin": "^25.4.1",
         "eslint": "^9.39.4",
         "globals": "^17.6.0"
@@ -2129,6 +2130,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4842,6 +4859,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6319,6 +6351,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
+    "@types/node": "^26.0.1",
     "@wordpress/eslint-plugin": "^25.4.1",
     "eslint": "^9.39.4",
     "globals": "^17.6.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "lint:js:fix": "eslint \"assets/js/**/*.js\" --fix"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@wordpress/eslint-plugin": "^25.4.1",
     "eslint": "^9.39.4",
     "globals": "^17.6.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
-const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'https://example.com';
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || "https://example.com";
 
 export default defineConfig({
-  testDir: './tests/playwright',
+  testDir: "./tests/playwright",
   timeout: 30_000,
   expect: {
     timeout: 10_000,
@@ -12,14 +12,14 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
 
   reporter: process.env.CI
-    ? [['html'], ['github'], ['list']]
-    : [['list'], ['html']],
+    ? [["html"], ["github"], ["list"]]
+    : [["list"], ["html"]],
 
   use: {
     baseURL,
-    trace: 'retain-on-failure',
-    screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
 
     httpCredentials:
       process.env.BASIC_AUTH_USER && process.env.BASIC_AUTH_PASS
@@ -32,9 +32,9 @@ export default defineConfig({
 
   projects: [
     {
-      name: 'chromium',
+      name: "chromium",
       use: {
-        ...devices['Desktop Chrome'],
+        ...devices["Desktop Chrome"],
       },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'https://example.com';
+
+export default defineConfig({
+  testDir: './tests/playwright',
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+
+  reporter: process.env.CI
+    ? [['html'], ['github'], ['list']]
+    : [['list'], ['html']],
+
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+
+    httpCredentials:
+      process.env.BASIC_AUTH_USER && process.env.BASIC_AUTH_PASS
+        ? {
+            username: process.env.BASIC_AUTH_USER,
+            password: process.env.BASIC_AUTH_PASS,
+          }
+        : undefined,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+});

--- a/tests/playwright/smoke.spec.ts
+++ b/tests/playwright/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from "@playwright/test";
 
 const customerUser = process.env.KC_CUSTOMER_USER;
 const customerPass = process.env.KC_CUSTOMER_PASS;
@@ -32,65 +32,67 @@ function getCredentials(
  * These URLs may need adjustment after the first CI run.
  */
 const urls = {
-  myAccount: '/my-account/',
-  scanner: '/scanner/',
-  adminQrCodes: '/wp-admin/admin.php?page=kerbcycle-qr-codes',
-  adminQrHistory: '/wp-admin/admin.php?page=kerbcycle-qr-history',
-  adminReports: '/wp-admin/admin.php?page=kerbcycle-reports',
-  adminPickupExceptions: '/wp-admin/admin.php?page=kerbcycle-pickup-exceptions',
-  adminSettings: '/wp-admin/admin.php?page=kerbcycle-settings',
+  myAccount: "/my-account/",
+  scanner: "/scanner/",
+  adminQrCodes: "/wp-admin/admin.php?page=kerbcycle-qr-codes",
+  adminQrHistory: "/wp-admin/admin.php?page=kerbcycle-qr-history",
+  adminReports: "/wp-admin/admin.php?page=kerbcycle-reports",
+  adminPickupExceptions: "/wp-admin/admin.php?page=kerbcycle-pickup-exceptions",
+  adminSettings: "/wp-admin/admin.php?page=kerbcycle-settings",
 };
 
 async function expectNoVisibleWordPressErrors(page: Page) {
-  const body = await page.locator('body').innerText();
+  const body = await page.locator("body").innerText();
 
-  expect(body).not.toContain('There has been a critical error');
-  expect(body).not.toContain('Fatal error');
-  expect(body).not.toContain('Parse error');
-  expect(body).not.toContain('Warning:');
-  expect(body).not.toContain('Notice:');
-  expect(body).not.toContain('Deprecated:');
-  expect(body).not.toContain('Uncaught Error');
+  expect(body).not.toContain("There has been a critical error");
+  expect(body).not.toContain("Fatal error");
+  expect(body).not.toContain("Parse error");
+  expect(body).not.toContain("Warning:");
+  expect(body).not.toContain("Notice:");
+  expect(body).not.toContain("Deprecated:");
+  expect(body).not.toContain("Uncaught Error");
 }
 
 async function login(page: Page, username: string, password: string) {
-  await page.goto('/wp-login.php');
+  await page.goto("/wp-login.php");
 
-  await expect(page.locator('#user_login')).toBeVisible();
-  await expect(page.locator('#user_pass')).toBeVisible();
+  await expect(page.locator("#user_login")).toBeVisible();
+  await expect(page.locator("#user_pass")).toBeVisible();
 
-  await page.fill('#user_login', username);
-  await page.fill('#user_pass', password);
-  await page.click('#wp-submit');
+  await page.fill("#user_login", username);
+  await page.fill("#user_pass", password);
+  await page.click("#wp-submit");
 
-  await page.waitForLoadState('domcontentloaded');
-  await expect(page.locator('body')).toBeVisible();
+  await page.waitForLoadState("domcontentloaded");
+  await expect(page.locator("body")).toBeVisible();
   await expectNoVisibleWordPressErrors(page);
 }
 
-test.describe('KerbCycle browser smoke tests', () => {
-  test('homepage loads without visible WordPress/PHP errors', async ({ page }) => {
-    await page.goto('/');
+test.describe("KerbCycle browser smoke tests", () => {
+  test("homepage loads without visible WordPress/PHP errors", async ({
+    page,
+  }) => {
+    await page.goto("/");
 
-    await expect(page.locator('body')).toBeVisible();
+    await expect(page.locator("body")).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
   });
 
-  test('WordPress login page loads', async ({ page }) => {
-    await page.goto('/wp-login.php');
+  test("WordPress login page loads", async ({ page }) => {
+    await page.goto("/wp-login.php");
 
-    await expect(page.locator('#user_login')).toBeVisible();
-    await expect(page.locator('#user_pass')).toBeVisible();
-    await expect(page.locator('#wp-submit')).toBeVisible();
+    await expect(page.locator("#user_login")).toBeVisible();
+    await expect(page.locator("#user_pass")).toBeVisible();
+    await expect(page.locator("#wp-submit")).toBeVisible();
 
     await expectNoVisibleWordPressErrors(page);
   });
 
-  test('customer can log in and access My Account', async ({ page }) => {
+  test("customer can log in and access My Account", async ({ page }) => {
     const credentials = getCredentials(customerUser, customerPass);
 
     if (credentials === null) {
-      test.skip(true, 'Customer credentials are not configured.');
+      test.skip(true, "Customer credentials are not configured.");
       return;
     }
 
@@ -98,19 +100,19 @@ test.describe('KerbCycle browser smoke tests', () => {
 
     await page.goto(urls.myAccount);
 
-    await expect(page.locator('body')).toBeVisible();
+    await expect(page.locator("body")).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
 
-    await expect(page.locator('body')).toContainText(
+    await expect(page.locator("body")).toContainText(
       /dashboard|account|wallet|orders|logout/i,
     );
   });
 
-  test('operator can log in and access scanner page', async ({ page }) => {
+  test("operator can log in and access scanner page", async ({ page }) => {
     const credentials = getCredentials(operatorUser, operatorPass);
 
     if (credentials === null) {
-      test.skip(true, 'Operator credentials are not configured.');
+      test.skip(true, "Operator credentials are not configured.");
       return;
     }
 
@@ -118,17 +120,19 @@ test.describe('KerbCycle browser smoke tests', () => {
 
     await page.goto(urls.scanner);
 
-    await expect(page.locator('body')).toBeVisible();
+    await expect(page.locator("body")).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
 
-    await expect(page.locator('body')).toContainText(/scan|scanner|qr/i);
+    await expect(page.locator("body")).toContainText(/scan|scanner|qr/i);
   });
 
-  test('customer cannot access protected KerbCycle admin page', async ({ page }) => {
+  test("customer cannot access protected KerbCycle admin page", async ({
+    page,
+  }) => {
     const credentials = getCredentials(customerUser, customerPass);
 
     if (credentials === null) {
-      test.skip(true, 'Customer credentials are not configured.');
+      test.skip(true, "Customer credentials are not configured.");
       return;
     }
 
@@ -136,21 +140,21 @@ test.describe('KerbCycle browser smoke tests', () => {
 
     await page.goto(urls.adminQrCodes);
 
-    await expect(page.locator('body')).toBeVisible();
+    await expect(page.locator("body")).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
 
-    const body = await page.locator('body').innerText();
+    const body = await page.locator("body").innerText();
 
-    expect(body).not.toContain('KerbCycle QR Codes');
-    expect(body).not.toContain('Add QR Code');
-    expect(body).not.toContain('Pickup Exceptions');
+    expect(body).not.toContain("KerbCycle QR Codes");
+    expect(body).not.toContain("Add QR Code");
+    expect(body).not.toContain("Pickup Exceptions");
   });
 
-  test('admin can load key KerbCycle admin pages', async ({ page }) => {
+  test("admin can load key KerbCycle admin pages", async ({ page }) => {
     const credentials = getCredentials(adminUser, adminPass);
 
     if (credentials === null) {
-      test.skip(true, 'Admin credentials are not configured.');
+      test.skip(true, "Admin credentials are not configured.");
       return;
     }
 
@@ -167,7 +171,7 @@ test.describe('KerbCycle browser smoke tests', () => {
     for (const adminPage of adminPages) {
       await page.goto(adminPage);
 
-      await expect(page.locator('body')).toBeVisible();
+      await expect(page.locator("body")).toBeVisible();
       await expectNoVisibleWordPressErrors(page);
     }
   });

--- a/tests/playwright/smoke.spec.ts
+++ b/tests/playwright/smoke.spec.ts
@@ -1,0 +1,133 @@
+import { expect, Page, test } from '@playwright/test';
+
+const customerUser = process.env.KC_CUSTOMER_USER;
+const customerPass = process.env.KC_CUSTOMER_PASS;
+
+const operatorUser = process.env.KC_OPERATOR_USER;
+const operatorPass = process.env.KC_OPERATOR_PASS;
+
+const adminUser = process.env.KC_ADMIN_USER;
+const adminPass = process.env.KC_ADMIN_PASS;
+
+/**
+ * These URLs may need adjustment after the first CI run.
+ */
+const urls = {
+  myAccount: '/my-account/',
+  scanner: '/scanner/',
+  adminQrCodes: '/wp-admin/admin.php?page=kerbcycle-qr-codes',
+  adminQrHistory: '/wp-admin/admin.php?page=kerbcycle-qr-history',
+  adminReports: '/wp-admin/admin.php?page=kerbcycle-reports',
+  adminPickupExceptions: '/wp-admin/admin.php?page=kerbcycle-pickup-exceptions',
+  adminSettings: '/wp-admin/admin.php?page=kerbcycle-settings',
+};
+
+async function expectNoVisibleWordPressErrors(page: Page) {
+  const body = await page.locator('body').innerText();
+
+  expect(body).not.toContain('There has been a critical error');
+  expect(body).not.toContain('Fatal error');
+  expect(body).not.toContain('Parse error');
+  expect(body).not.toContain('Warning:');
+  expect(body).not.toContain('Notice:');
+  expect(body).not.toContain('Deprecated:');
+  expect(body).not.toContain('Uncaught Error');
+}
+
+async function login(page: Page, username: string, password: string) {
+  await page.goto('/wp-login.php');
+
+  await expect(page.locator('#user_login')).toBeVisible();
+  await expect(page.locator('#user_pass')).toBeVisible();
+
+  await page.fill('#user_login', username);
+  await page.fill('#user_pass', password);
+  await page.click('#wp-submit');
+
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.locator('body')).toBeVisible();
+  await expectNoVisibleWordPressErrors(page);
+}
+
+test.describe('KerbCycle browser smoke tests', () => {
+  test('homepage loads without visible WordPress/PHP errors', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.locator('body')).toBeVisible();
+    await expectNoVisibleWordPressErrors(page);
+  });
+
+  test('WordPress login page loads', async ({ page }) => {
+    await page.goto('/wp-login.php');
+
+    await expect(page.locator('#user_login')).toBeVisible();
+    await expect(page.locator('#user_pass')).toBeVisible();
+    await expect(page.locator('#wp-submit')).toBeVisible();
+
+    await expectNoVisibleWordPressErrors(page);
+  });
+
+  test('customer can log in and access My Account', async ({ page }) => {
+    test.skip(!customerUser || !customerPass, 'Customer credentials are not configured.');
+
+    await login(page, customerUser!, customerPass!);
+
+    await page.goto(urls.myAccount);
+
+    await expect(page.locator('body')).toBeVisible();
+    await expectNoVisibleWordPressErrors(page);
+
+    await expect(page.locator('body')).toContainText(/dashboard|account|wallet|orders|logout/i);
+  });
+
+  test('operator can log in and access scanner page', async ({ page }) => {
+    test.skip(!operatorUser || !operatorPass, 'Operator credentials are not configured.');
+
+    await login(page, operatorUser!, operatorPass!);
+
+    await page.goto(urls.scanner);
+
+    await expect(page.locator('body')).toBeVisible();
+    await expectNoVisibleWordPressErrors(page);
+
+    await expect(page.locator('body')).toContainText(/scan|scanner|qr/i);
+  });
+
+  test('customer cannot access protected KerbCycle admin page', async ({ page }) => {
+    test.skip(!customerUser || !customerPass, 'Customer credentials are not configured.');
+
+    await login(page, customerUser!, customerPass!);
+
+    await page.goto(urls.adminQrCodes);
+
+    await expect(page.locator('body')).toBeVisible();
+    await expectNoVisibleWordPressErrors(page);
+
+    const body = await page.locator('body').innerText();
+
+    expect(body).not.toContain('KerbCycle QR Codes');
+    expect(body).not.toContain('Add QR Code');
+    expect(body).not.toContain('Pickup Exceptions');
+  });
+
+  test('admin can load key KerbCycle admin pages', async ({ page }) => {
+    test.skip(!adminUser || !adminPass, 'Admin credentials are not configured.');
+
+    await login(page, adminUser!, adminPass!);
+
+    const adminPages = [
+      urls.adminQrCodes,
+      urls.adminQrHistory,
+      urls.adminReports,
+      urls.adminPickupExceptions,
+      urls.adminSettings,
+    ];
+
+    for (const adminPage of adminPages) {
+      await page.goto(adminPage);
+
+      await expect(page.locator('body')).toBeVisible();
+      await expectNoVisibleWordPressErrors(page);
+    }
+  });
+});

--- a/tests/playwright/smoke.spec.ts
+++ b/tests/playwright/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from "@playwright/test";
 
 const customerUser = process.env.KC_CUSTOMER_USER;
 const customerPass = process.env.KC_CUSTOMER_PASS;
@@ -13,105 +13,123 @@ const adminPass = process.env.KC_ADMIN_PASS;
  * These URLs may need adjustment after the first CI run.
  */
 const urls = {
-  myAccount: '/my-account/',
-  scanner: '/scanner/',
-  adminQrCodes: '/wp-admin/admin.php?page=kerbcycle-qr-codes',
-  adminQrHistory: '/wp-admin/admin.php?page=kerbcycle-qr-history',
-  adminReports: '/wp-admin/admin.php?page=kerbcycle-reports',
-  adminPickupExceptions: '/wp-admin/admin.php?page=kerbcycle-pickup-exceptions',
-  adminSettings: '/wp-admin/admin.php?page=kerbcycle-settings',
+  myAccount: "/my-account/",
+  scanner: "/scanner/",
+  adminQrCodes: "/wp-admin/admin.php?page=kerbcycle-qr-codes",
+  adminQrHistory: "/wp-admin/admin.php?page=kerbcycle-qr-history",
+  adminReports: "/wp-admin/admin.php?page=kerbcycle-reports",
+  adminPickupExceptions: "/wp-admin/admin.php?page=kerbcycle-pickup-exceptions",
+  adminSettings: "/wp-admin/admin.php?page=kerbcycle-settings",
 };
 
 async function expectNoVisibleWordPressErrors(page: Page) {
-  const body = await page.locator('body').innerText();
+  const body = await page.locator("body").innerText();
 
-  expect(body).not.toContain('There has been a critical error');
-  expect(body).not.toContain('Fatal error');
-  expect(body).not.toContain('Parse error');
-  expect(body).not.toContain('Warning:');
-  expect(body).not.toContain('Notice:');
-  expect(body).not.toContain('Deprecated:');
-  expect(body).not.toContain('Uncaught Error');
+  expect(body).not.toContain("There has been a critical error");
+  expect(body).not.toContain("Fatal error");
+  expect(body).not.toContain("Parse error");
+  expect(body).not.toContain("Warning:");
+  expect(body).not.toContain("Notice:");
+  expect(body).not.toContain("Deprecated:");
+  expect(body).not.toContain("Uncaught Error");
 }
 
 async function login(page: Page, username: string, password: string) {
-  await page.goto('/wp-login.php');
+  await page.goto("/wp-login.php");
 
-  await expect(page.locator('#user_login')).toBeVisible();
-  await expect(page.locator('#user_pass')).toBeVisible();
+  await expect(page.locator("#user_login")).toBeVisible();
+  await expect(page.locator("#user_pass")).toBeVisible();
 
-  await page.fill('#user_login', username);
-  await page.fill('#user_pass', password);
-  await page.click('#wp-submit');
+  await page.fill("#user_login", username);
+  await page.fill("#user_pass", password);
+  await page.click("#wp-submit");
 
-  await page.waitForLoadState('domcontentloaded');
-  await expect(page.locator('body')).toBeVisible();
+  await page.waitForLoadState("domcontentloaded");
+  await expect(page.locator("body")).toBeVisible();
   await expectNoVisibleWordPressErrors(page);
 }
 
-test.describe('KerbCycle browser smoke tests', () => {
-  test('homepage loads without visible WordPress/PHP errors', async ({ page }) => {
-    await page.goto('/');
+test.describe("KerbCycle browser smoke tests", () => {
+  test("homepage loads without visible WordPress/PHP errors", async ({
+    page,
+  }) => {
+    await page.goto("/");
 
-    await expect(page.locator('body')).toBeVisible();
+    await expect(page.locator("body")).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
   });
 
-  test('WordPress login page loads', async ({ page }) => {
-    await page.goto('/wp-login.php');
+  test("WordPress login page loads", async ({ page }) => {
+    await page.goto("/wp-login.php");
 
-    await expect(page.locator('#user_login')).toBeVisible();
-    await expect(page.locator('#user_pass')).toBeVisible();
-    await expect(page.locator('#wp-submit')).toBeVisible();
+    await expect(page.locator("#user_login")).toBeVisible();
+    await expect(page.locator("#user_pass")).toBeVisible();
+    await expect(page.locator("#wp-submit")).toBeVisible();
 
     await expectNoVisibleWordPressErrors(page);
   });
 
-  test('customer can log in and access My Account', async ({ page }) => {
-    test.skip(!customerUser || !customerPass, 'Customer credentials are not configured.');
+  test("customer can log in and access My Account", async ({ page }) => {
+    test.skip(
+      !customerUser || !customerPass,
+      "Customer credentials are not configured.",
+    );
 
     await login(page, customerUser!, customerPass!);
 
     await page.goto(urls.myAccount);
 
-    await expect(page.locator('body')).toBeVisible();
+    await expect(page.locator("body")).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
 
-    await expect(page.locator('body')).toContainText(/dashboard|account|wallet|orders|logout/i);
+    await expect(page.locator("body")).toContainText(
+      /dashboard|account|wallet|orders|logout/i,
+    );
   });
 
-  test('operator can log in and access scanner page', async ({ page }) => {
-    test.skip(!operatorUser || !operatorPass, 'Operator credentials are not configured.');
+  test("operator can log in and access scanner page", async ({ page }) => {
+    test.skip(
+      !operatorUser || !operatorPass,
+      "Operator credentials are not configured.",
+    );
 
     await login(page, operatorUser!, operatorPass!);
 
     await page.goto(urls.scanner);
 
-    await expect(page.locator('body')).toBeVisible();
+    await expect(page.locator("body")).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
 
-    await expect(page.locator('body')).toContainText(/scan|scanner|qr/i);
+    await expect(page.locator("body")).toContainText(/scan|scanner|qr/i);
   });
 
-  test('customer cannot access protected KerbCycle admin page', async ({ page }) => {
-    test.skip(!customerUser || !customerPass, 'Customer credentials are not configured.');
+  test("customer cannot access protected KerbCycle admin page", async ({
+    page,
+  }) => {
+    test.skip(
+      !customerUser || !customerPass,
+      "Customer credentials are not configured.",
+    );
 
     await login(page, customerUser!, customerPass!);
 
     await page.goto(urls.adminQrCodes);
 
-    await expect(page.locator('body')).toBeVisible();
+    await expect(page.locator("body")).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
 
-    const body = await page.locator('body').innerText();
+    const body = await page.locator("body").innerText();
 
-    expect(body).not.toContain('KerbCycle QR Codes');
-    expect(body).not.toContain('Add QR Code');
-    expect(body).not.toContain('Pickup Exceptions');
+    expect(body).not.toContain("KerbCycle QR Codes");
+    expect(body).not.toContain("Add QR Code");
+    expect(body).not.toContain("Pickup Exceptions");
   });
 
-  test('admin can load key KerbCycle admin pages', async ({ page }) => {
-    test.skip(!adminUser || !adminPass, 'Admin credentials are not configured.');
+  test("admin can load key KerbCycle admin pages", async ({ page }) => {
+    test.skip(
+      !adminUser || !adminPass,
+      "Admin credentials are not configured.",
+    );
 
     await login(page, adminUser!, adminPass!);
 
@@ -126,7 +144,7 @@ test.describe('KerbCycle browser smoke tests', () => {
     for (const adminPage of adminPages) {
       await page.goto(adminPage);
 
-      await expect(page.locator('body')).toBeVisible();
+      await expect(page.locator("body")).toBeVisible();
       await expectNoVisibleWordPressErrors(page);
     }
   });

--- a/tests/playwright/smoke.spec.ts
+++ b/tests/playwright/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, Page, test } from '@playwright/test';
 
 const customerUser = process.env.KC_CUSTOMER_USER;
 const customerPass = process.env.KC_CUSTOMER_PASS;
@@ -9,129 +9,152 @@ const operatorPass = process.env.KC_OPERATOR_PASS;
 const adminUser = process.env.KC_ADMIN_USER;
 const adminPass = process.env.KC_ADMIN_PASS;
 
+type Credentials = {
+  username: string;
+  password: string;
+};
+
+function getCredentials(
+  username: string | undefined,
+  password: string | undefined,
+): Credentials | null {
+  if (!username || !password) {
+    return null;
+  }
+
+  return {
+    username,
+    password,
+  };
+}
+
 /**
  * These URLs may need adjustment after the first CI run.
  */
 const urls = {
-  myAccount: "/my-account/",
-  scanner: "/scanner/",
-  adminQrCodes: "/wp-admin/admin.php?page=kerbcycle-qr-codes",
-  adminQrHistory: "/wp-admin/admin.php?page=kerbcycle-qr-history",
-  adminReports: "/wp-admin/admin.php?page=kerbcycle-reports",
-  adminPickupExceptions: "/wp-admin/admin.php?page=kerbcycle-pickup-exceptions",
-  adminSettings: "/wp-admin/admin.php?page=kerbcycle-settings",
+  myAccount: '/my-account/',
+  scanner: '/scanner/',
+  adminQrCodes: '/wp-admin/admin.php?page=kerbcycle-qr-codes',
+  adminQrHistory: '/wp-admin/admin.php?page=kerbcycle-qr-history',
+  adminReports: '/wp-admin/admin.php?page=kerbcycle-reports',
+  adminPickupExceptions: '/wp-admin/admin.php?page=kerbcycle-pickup-exceptions',
+  adminSettings: '/wp-admin/admin.php?page=kerbcycle-settings',
 };
 
 async function expectNoVisibleWordPressErrors(page: Page) {
-  const body = await page.locator("body").innerText();
+  const body = await page.locator('body').innerText();
 
-  expect(body).not.toContain("There has been a critical error");
-  expect(body).not.toContain("Fatal error");
-  expect(body).not.toContain("Parse error");
-  expect(body).not.toContain("Warning:");
-  expect(body).not.toContain("Notice:");
-  expect(body).not.toContain("Deprecated:");
-  expect(body).not.toContain("Uncaught Error");
+  expect(body).not.toContain('There has been a critical error');
+  expect(body).not.toContain('Fatal error');
+  expect(body).not.toContain('Parse error');
+  expect(body).not.toContain('Warning:');
+  expect(body).not.toContain('Notice:');
+  expect(body).not.toContain('Deprecated:');
+  expect(body).not.toContain('Uncaught Error');
 }
 
 async function login(page: Page, username: string, password: string) {
-  await page.goto("/wp-login.php");
+  await page.goto('/wp-login.php');
 
-  await expect(page.locator("#user_login")).toBeVisible();
-  await expect(page.locator("#user_pass")).toBeVisible();
+  await expect(page.locator('#user_login')).toBeVisible();
+  await expect(page.locator('#user_pass')).toBeVisible();
 
-  await page.fill("#user_login", username);
-  await page.fill("#user_pass", password);
-  await page.click("#wp-submit");
+  await page.fill('#user_login', username);
+  await page.fill('#user_pass', password);
+  await page.click('#wp-submit');
 
-  await page.waitForLoadState("domcontentloaded");
-  await expect(page.locator("body")).toBeVisible();
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.locator('body')).toBeVisible();
   await expectNoVisibleWordPressErrors(page);
 }
 
-test.describe("KerbCycle browser smoke tests", () => {
-  test("homepage loads without visible WordPress/PHP errors", async ({
-    page,
-  }) => {
-    await page.goto("/");
+test.describe('KerbCycle browser smoke tests', () => {
+  test('homepage loads without visible WordPress/PHP errors', async ({ page }) => {
+    await page.goto('/');
 
-    await expect(page.locator("body")).toBeVisible();
+    await expect(page.locator('body')).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
   });
 
-  test("WordPress login page loads", async ({ page }) => {
-    await page.goto("/wp-login.php");
+  test('WordPress login page loads', async ({ page }) => {
+    await page.goto('/wp-login.php');
 
-    await expect(page.locator("#user_login")).toBeVisible();
-    await expect(page.locator("#user_pass")).toBeVisible();
-    await expect(page.locator("#wp-submit")).toBeVisible();
+    await expect(page.locator('#user_login')).toBeVisible();
+    await expect(page.locator('#user_pass')).toBeVisible();
+    await expect(page.locator('#wp-submit')).toBeVisible();
 
     await expectNoVisibleWordPressErrors(page);
   });
 
-  test("customer can log in and access My Account", async ({ page }) => {
-    test.skip(
-      !customerUser || !customerPass,
-      "Customer credentials are not configured.",
-    );
+  test('customer can log in and access My Account', async ({ page }) => {
+    const credentials = getCredentials(customerUser, customerPass);
 
-    await login(page, customerUser!, customerPass!);
+    if (credentials === null) {
+      test.skip(true, 'Customer credentials are not configured.');
+      return;
+    }
+
+    await login(page, credentials.username, credentials.password);
 
     await page.goto(urls.myAccount);
 
-    await expect(page.locator("body")).toBeVisible();
+    await expect(page.locator('body')).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
 
-    await expect(page.locator("body")).toContainText(
+    await expect(page.locator('body')).toContainText(
       /dashboard|account|wallet|orders|logout/i,
     );
   });
 
-  test("operator can log in and access scanner page", async ({ page }) => {
-    test.skip(
-      !operatorUser || !operatorPass,
-      "Operator credentials are not configured.",
-    );
+  test('operator can log in and access scanner page', async ({ page }) => {
+    const credentials = getCredentials(operatorUser, operatorPass);
 
-    await login(page, operatorUser!, operatorPass!);
+    if (credentials === null) {
+      test.skip(true, 'Operator credentials are not configured.');
+      return;
+    }
+
+    await login(page, credentials.username, credentials.password);
 
     await page.goto(urls.scanner);
 
-    await expect(page.locator("body")).toBeVisible();
+    await expect(page.locator('body')).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
 
-    await expect(page.locator("body")).toContainText(/scan|scanner|qr/i);
+    await expect(page.locator('body')).toContainText(/scan|scanner|qr/i);
   });
 
-  test("customer cannot access protected KerbCycle admin page", async ({
-    page,
-  }) => {
-    test.skip(
-      !customerUser || !customerPass,
-      "Customer credentials are not configured.",
-    );
+  test('customer cannot access protected KerbCycle admin page', async ({ page }) => {
+    const credentials = getCredentials(customerUser, customerPass);
 
-    await login(page, customerUser!, customerPass!);
+    if (credentials === null) {
+      test.skip(true, 'Customer credentials are not configured.');
+      return;
+    }
+
+    await login(page, credentials.username, credentials.password);
 
     await page.goto(urls.adminQrCodes);
 
-    await expect(page.locator("body")).toBeVisible();
+    await expect(page.locator('body')).toBeVisible();
     await expectNoVisibleWordPressErrors(page);
 
-    const body = await page.locator("body").innerText();
+    const body = await page.locator('body').innerText();
 
-    expect(body).not.toContain("KerbCycle QR Codes");
-    expect(body).not.toContain("Add QR Code");
-    expect(body).not.toContain("Pickup Exceptions");
+    expect(body).not.toContain('KerbCycle QR Codes');
+    expect(body).not.toContain('Add QR Code');
+    expect(body).not.toContain('Pickup Exceptions');
   });
 
-  test("admin can load key KerbCycle admin pages", async ({ page }) => {
-    test.skip(
-      !adminUser || !adminPass,
-      "Admin credentials are not configured.",
-    );
+  test('admin can load key KerbCycle admin pages', async ({ page }) => {
+    const credentials = getCredentials(adminUser, adminPass);
 
-    await login(page, adminUser!, adminPass!);
+    if (credentials === null) {
+      test.skip(true, 'Admin credentials are not configured.');
+      return;
+    }
+
+    await login(page, credentials.username, credentials.password);
 
     const adminPages = [
       urls.adminQrCodes,
@@ -144,7 +167,7 @@ test.describe("KerbCycle browser smoke tests", () => {
     for (const adminPage of adminPages) {
       await page.goto(adminPage);
 
-      await expect(page.locator("body")).toBeVisible();
+      await expect(page.locator('body')).toBeVisible();
       await expectNoVisibleWordPressErrors(page);
     }
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node", "@playwright/test"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "playwright.config.ts",
+    "tests/playwright/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an initial non-blocking Playwright browser smoke-test workflow for KerbCycle staging.

This test layer is intentionally small. It checks page-load health, login availability, basic My Account access, scanner page rendering, protected admin access boundaries, and key KerbCycle admin page loading.

## Tests added

- Homepage loads without visible WordPress/PHP errors
- WordPress login page loads
- Customer can log in and access My Account
- Operator can log in and access scanner page
- Customer cannot access protected KerbCycle admin page
- Admin can load key KerbCycle admin pages

## CI behavior

The workflow currently uses `continue-on-error: true` so Playwright findings are visible but do not block PRs while this new layer is stabilized.

## Out of scope

- Camera-based QR scanning
- Real SMS/email sending
- Payment/refund behavior
- Full scheduling submission
- OSRM route validation
- Visual snapshot testing