### PR TITLE
Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,4 +1,4 @@
-name: Scheduled - OpenSSF Scorecard
+name: OpenSSF Scorecard
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   analysis:
-    name: scheduled / scorecard
+    name: Scorecard analysis
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,7 +1,9 @@
-name: OpenSSF Scorecard
+name: Scheduled - OpenSSF Scorecard
 
 on:
   push:
+    branches:
+      - main
   schedule:
     # Weekly on Saturday at 1:30 UTC.
     - cron: '30 1 * * 6'
@@ -11,16 +13,16 @@ permissions:
 
 jobs:
   analysis:
-    name: Scorecard analysis
+    name: scheduled / scorecard
     runs-on: ubuntu-latest
 
     permissions:
+      security-events: write
+      id-token: write
       contents: read
       issues: read
       pull-requests: read
       checks: read
-      security-events: write
-      id-token: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+name: Scheduled - OpenSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly on Saturday at 1:30 UTC.
+    - cron: '30 1 * * 6'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: scheduled / scorecard
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Needed to upload SARIF results to GitHub code scanning.
+      security-events: write
+
+      # Needed when publish_results is true.
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: openssf-scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,13 +2,12 @@ name: OpenSSF Scorecard
 
 on:
   push:
-    branches:
-      - main
   schedule:
     # Weekly on Saturday at 1:30 UTC.
     - cron: '30 1 * * 6'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:
@@ -16,10 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      # Needed to upload SARIF results to GitHub code scanning.
+      contents: read
+      issues: read
+      pull-requests: read
+      checks: read
       security-events: write
-
-      # Needed when publish_results is true.
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary
Adds an OpenSSF Scorecard workflow to assess repository supply-chain security posture.

## Details
- Runs on pushes to `main`
- Runs weekly on a scheduled basis
- Uploads SARIF results to GitHub code scanning
- Publishes results for OpenSSF Scorecard badge/API support
- Uses pinned action SHAs

## Notes
This is intended as a report-only posture check initially and should not be made a required PR gate until the first results are reviewed.